### PR TITLE
[Feat] Redis를 활용한 JWT 재발급 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2',
 			'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/scs/planus/auth/controller/AuthController.java
+++ b/src/main/java/scs/planus/auth/controller/AuthController.java
@@ -1,0 +1,27 @@
+package scs.planus.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import scs.planus.auth.dto.TokenReissueRequestDto;
+import scs.planus.auth.dto.TokenReissueResponseDto;
+import scs.planus.auth.service.AuthService;
+import scs.planus.common.response.BaseResponse;
+
+@RestController
+@RequestMapping("/app")
+@RequiredArgsConstructor
+@Slf4j
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/auth/token-reissue")
+    public BaseResponse<TokenReissueResponseDto> tokenReissue(@RequestBody TokenReissueRequestDto requestDto) {
+        TokenReissueResponseDto responseDto = authService.reissue(requestDto);
+        return new BaseResponse<>(responseDto);
+    }
+}

--- a/src/main/java/scs/planus/auth/dto/TokenReissueRequestDto.java
+++ b/src/main/java/scs/planus/auth/dto/TokenReissueRequestDto.java
@@ -1,0 +1,10 @@
+package scs.planus.auth.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TokenReissueRequestDto {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/scs/planus/auth/dto/TokenReissueResponseDto.java
+++ b/src/main/java/scs/planus/auth/dto/TokenReissueResponseDto.java
@@ -1,0 +1,16 @@
+package scs.planus.auth.dto;
+
+import lombok.Getter;
+import scs.planus.auth.jwt.Token;
+
+@Getter
+public class TokenReissueResponseDto {
+
+    private final String accessToken;
+    private final String refreshToken;
+
+    public TokenReissueResponseDto(Token token) {
+        this.accessToken = token.getAccessToken();
+        this.refreshToken = token.getRefreshToken();
+    }
+}

--- a/src/main/java/scs/planus/auth/jwt/JwtProvider.java
+++ b/src/main/java/scs/planus/auth/jwt/JwtProvider.java
@@ -50,6 +50,7 @@ public class JwtProvider {
         return Token.builder()
                 .accessToken(generateAccessToken(payload))
                 .refreshToken(generateRefreshToken())
+                .refreshTokenExpiredIn(refreshTokenExpiredIn)
                 .build();
     }
 

--- a/src/main/java/scs/planus/auth/jwt/Token.java
+++ b/src/main/java/scs/planus/auth/jwt/Token.java
@@ -9,4 +9,5 @@ public class Token {
 
     private String accessToken;
     private String refreshToken;
+    private long refreshTokenExpiredIn;
 }

--- a/src/main/java/scs/planus/auth/jwt/redis/RedisService.java
+++ b/src/main/java/scs/planus/auth/jwt/redis/RedisService.java
@@ -1,0 +1,34 @@
+package scs.planus.auth.jwt.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+import scs.planus.auth.jwt.Token;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void saveValue(String email, Token token) {
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        String refreshToken = token.getRefreshToken();
+        Duration expired = Duration.ofMillis(token.getRefreshTokenExpiredIn());
+        valueOperations.set(email, refreshToken, expired);
+    }
+
+    public String getValue(String email){
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        return valueOperations.get(email);
+    }
+
+    public void delete(String email) {
+        redisTemplate.delete(email);
+    }
+}

--- a/src/main/java/scs/planus/auth/service/AuthService.java
+++ b/src/main/java/scs/planus/auth/service/AuthService.java
@@ -1,0 +1,47 @@
+package scs.planus.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import scs.planus.auth.dto.TokenReissueRequestDto;
+import scs.planus.auth.dto.TokenReissueResponseDto;
+import scs.planus.auth.jwt.JwtProvider;
+import scs.planus.auth.jwt.Token;
+import scs.planus.auth.jwt.redis.RedisService;
+import scs.planus.common.exception.PlanusException;
+
+import static scs.planus.common.response.CustomResponseStatus.EXPIRED_REFRESH_TOKEN;
+import static scs.planus.common.response.CustomResponseStatus.INVALID_REFRESH_TOKEN;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AuthService {
+
+    private final RedisService redisService;
+    private final JwtProvider jwtProvider;
+
+    @Transactional
+    public TokenReissueResponseDto reissue(TokenReissueRequestDto requestDto) {
+        String oldAccessToken = requestDto.getAccessToken();
+        String oldRefreshToken = requestDto.getRefreshToken();
+        String email = jwtProvider.getPayload(oldAccessToken);
+        validateRefreshToken(email, oldRefreshToken);
+
+        Token token = jwtProvider.generateToken(email);
+        redisService.saveValue(email, token);
+
+        return new TokenReissueResponseDto(token);
+    }
+
+    private void validateRefreshToken(String email, String refreshToken) {
+        if (redisService.getValue(email) == null) {
+            throw new PlanusException(EXPIRED_REFRESH_TOKEN);
+        }
+
+        if (!redisService.getValue(email).equals(refreshToken)) {
+            throw new PlanusException(INVALID_REFRESH_TOKEN);
+        }
+    }
+}

--- a/src/main/java/scs/planus/auth/service/OAuthService.java
+++ b/src/main/java/scs/planus/auth/service/OAuthService.java
@@ -14,6 +14,7 @@ import scs.planus.auth.dto.OAuth2TokenResponseDto;
 import scs.planus.auth.dto.OAuthLoginResponseDto;
 import scs.planus.auth.jwt.JwtProvider;
 import scs.planus.auth.jwt.Token;
+import scs.planus.auth.jwt.redis.RedisService;
 import scs.planus.auth.userinfo.attribute.MemberProfile;
 import scs.planus.auth.userinfo.attribute.OAuthAttributes;
 import scs.planus.domain.Member;
@@ -31,6 +32,7 @@ public class OAuthService {
     private final InMemoryClientRegistrationRepository clientRegistrations;
     private final MemberRepository memberRepository;
     private final JwtProvider jwtProvider;
+    private final RedisService redisService;
 
     public OAuthLoginResponseDto login(String providerName, String code) {
         ClientRegistration client = clientRegistrations.findByRegistrationId(providerName);
@@ -39,6 +41,7 @@ public class OAuthService {
 
         Member member = saveMember(profile);
         Token token = jwtProvider.generateToken(member.getEmail());
+        redisService.saveValue(member.getEmail(), token);
 
         return OAuthLoginResponseDto.builder()
                 .memberId(member.getId())

--- a/src/main/java/scs/planus/common/response/CustomResponseStatus.java
+++ b/src/main/java/scs/planus/common/response/CustomResponseStatus.java
@@ -17,6 +17,8 @@ public enum CustomResponseStatus implements ResponseStatus {
     // jwt exception
     UNAUTHORIZED_ACCESS_TOKEN(UNAUTHORIZED, 2300, "인증되지 않거나 만료된 토큰입니다."),
     FORBIDDEN_ACCESS_TOKEN(FORBIDDEN, 2301, "권한이 없는 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(BAD_REQUEST, 2302, "Refresh Token 이 만료되어 재로그인이 필요합니다."),
+    INVALID_REFRESH_TOKEN(BAD_REQUEST, 2303, "잘못된 Refresh Token 입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/scs/planus/config/RedisConfig.java
+++ b/src/main/java/scs/planus/config/RedisConfig.java
@@ -1,0 +1,31 @@
+package scs.planus.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/scs/planus/config/SecurityConfig.java
+++ b/src/main/java/scs/planus/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/app/oauth/**").permitAll()
+                .antMatchers("/app/oauth/**", "/app/auth/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- Redis를 활용한 JWT 재발급 기능 구현

### :: 특이사항
- Redis를 활용하므로 yml 파일에 변화가 존재합니다.
- AccessToken / RefreshToken 모두 요청을 합니다.
  - AccessToken을 통해 제대로 된 사용자인지 확인을 합니다.
  - RefreshToken을 통해 Redis에 존재하는지 확인합니다.
     - 존재한다면,
       - RefreshToken을 이용하여 AccessToken을 재발급합니다.
       - 이때, RefreshToken 또한 재발급하게 됩니다.
     - 존재하지 않는다면,
       - 새로운 로그인을 요청합니다.
