### PR TITLE
[Feat] 프로필 정보 변경 기능 구현

### DIFF
--- a/src/main/java/scs/planus/controller/MemberController.java
+++ b/src/main/java/scs/planus/controller/MemberController.java
@@ -4,12 +4,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import scs.planus.auth.PrincipalDetails;
 import scs.planus.common.response.BaseResponse;
 import scs.planus.dto.member.MemberResponseDto;
+import scs.planus.dto.member.MemberUpdateRequestDto;
 import scs.planus.service.MemberService;
+
+import javax.validation.Valid;
 
 @RestController
 @RequestMapping("/app")
@@ -23,6 +29,15 @@ public class MemberController {
     public BaseResponse<MemberResponseDto> showDetail(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         Long memberId = principalDetails.getId();
         MemberResponseDto responseDto = memberService.getDetail(memberId);
+        return new BaseResponse<>(responseDto);
+    }
+
+    @PatchMapping("/members")
+    public BaseResponse<MemberResponseDto> updateProfile(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                         @RequestPart(value = "image", required = false) MultipartFile multipartFile,
+                                                         @Valid @RequestPart(value = "updateRequestDto") MemberUpdateRequestDto memberUpdateRequestDto) {
+        Long memberId = principalDetails.getId();
+        MemberResponseDto responseDto = memberService.update(memberId, multipartFile, memberUpdateRequestDto);
         return new BaseResponse<>(responseDto);
     }
 }

--- a/src/main/java/scs/planus/dto/member/MemberUpdateRequestDto.java
+++ b/src/main/java/scs/planus/dto/member/MemberUpdateRequestDto.java
@@ -1,0 +1,17 @@
+package scs.planus.dto.member;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+public class MemberUpdateRequestDto {
+
+    @NotBlank(message = "닉네임을 입력해주세요.")
+    @Size(min = 2, max = 10, message = "닉네임은 2-10 글자로 입력해주세요.")
+    private String nickname;
+
+    @Size(max = 50, message = "자기 소개는 최대 50자까지 작성할 수 있습니다.")
+    private String description;
+}

--- a/src/main/java/scs/planus/infra/AmazonS3Uploader.java
+++ b/src/main/java/scs/planus/infra/AmazonS3Uploader.java
@@ -53,7 +53,7 @@ public class AmazonS3Uploader {
 
     // S3로 파일 업로드하기
     private String upload(File uploadFile, String dirName) {
-        String fileName = dirName + "/" + UUID.randomUUID() + uploadFile.getName();
+        String fileName = dirName + "/" + UUID.randomUUID() + uploadFile.getName().replaceAll(" ", "");
         String uploadImageUrl = putS3(uploadFile, fileName);
         removeNewFile(uploadFile);
         return uploadImageUrl;

--- a/src/main/java/scs/planus/infra/AmazonS3Uploader.java
+++ b/src/main/java/scs/planus/infra/AmazonS3Uploader.java
@@ -1,8 +1,10 @@
 package scs.planus.infra;
 
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3URI;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +39,15 @@ public class AmazonS3Uploader {
             return upload(uploadFile, dirName);
         } catch (IOException e) {
             throw new PlanusException(CommonResponseStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // 사진 업데이트시, 기존 파일 삭제
+    public void deleteImage(String fileName) {
+        if (fileName != null) {
+            AmazonS3URI amazonS3URI = new AmazonS3URI(fileName);
+            String s3URIKey = amazonS3URI.getKey();
+            amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, s3URIKey));
         }
     }
 

--- a/src/main/java/scs/planus/service/MemberService.java
+++ b/src/main/java/scs/planus/service/MemberService.java
@@ -4,9 +4,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import scs.planus.common.exception.PlanusException;
 import scs.planus.domain.Member;
 import scs.planus.dto.member.MemberResponseDto;
+import scs.planus.dto.member.MemberUpdateRequestDto;
+import scs.planus.infra.AmazonS3Uploader;
 import scs.planus.repository.MemberRepository;
 
 import static scs.planus.common.response.CustomResponseStatus.NONE_USER;
@@ -17,11 +20,26 @@ import static scs.planus.common.response.CustomResponseStatus.NONE_USER;
 @Slf4j
 public class MemberService {
 
+    private final AmazonS3Uploader s3Uploader;
     private final MemberRepository memberRepository;
 
     public MemberResponseDto getDetail(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
+        return MemberResponseDto.of(member);
+    }
+
+    @Transactional
+    public MemberResponseDto update(Long memberId, MultipartFile multipartFile, MemberUpdateRequestDto requestDto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        String profileImageUrl = member.getProfileImageUrl();
+        if (multipartFile != null) {
+            profileImageUrl = s3Uploader.upload(multipartFile, "profile");
+        }
+
+        member.updateProfile(requestDto.getNickname(), requestDto.getDescription(), profileImageUrl);
         return MemberResponseDto.of(member);
     }
 }

--- a/src/main/java/scs/planus/service/MemberService.java
+++ b/src/main/java/scs/planus/service/MemberService.java
@@ -35,11 +35,16 @@ public class MemberService {
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
         String profileImageUrl = member.getProfileImageUrl();
-        if (multipartFile != null) {
-            profileImageUrl = s3Uploader.upload(multipartFile, "profile");
-        }
+        profileImageUrl = updateProfileImage(multipartFile, profileImageUrl);
 
         member.updateProfile(requestDto.getNickname(), requestDto.getDescription(), profileImageUrl);
         return MemberResponseDto.of(member);
+    }
+
+    private String updateProfileImage(MultipartFile multipartFile, String profileImageUrl) {
+        if (multipartFile != null) {
+            profileImageUrl = s3Uploader.upload(multipartFile, "profile");
+        }
+        return profileImageUrl;
     }
 }

--- a/src/main/java/scs/planus/service/MemberService.java
+++ b/src/main/java/scs/planus/service/MemberService.java
@@ -43,6 +43,7 @@ public class MemberService {
 
     private String updateProfileImage(MultipartFile multipartFile, String profileImageUrl) {
         if (multipartFile != null) {
+            s3Uploader.deleteImage(profileImageUrl); // 기존 프로필 s3에서 제거
             profileImageUrl = s3Uploader.upload(multipartFile, "profile");
         }
         return profileImageUrl;


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 프로필 정보 변경 기능 구현 (닉네임 / 자기소개 / 프로필 이미지)

### :: 특이사항

- @RequestPart를 이용하여 이미지를 처리합니다.
  - 닉네임과 자기소개는 DTO로 받아 이를 validation 처리하였습니다.
  - `form-data` / `key : updateRequestDto` / `content-type : application/json`
  - Validation
    - nickname : 아무 입력 받지 않은 경우, 2-10글자
      - 🔥 특수문자처리와 관련하여 의논이 필요합니다 !
    - description : 최대 50글자
      - 🔥 자기소개가 없는 경우도 있을 것 같아 위와 같이 결정했지만 이또한 의논 필요합니다 !

- S3 로직 변경
  - 이미지 변경 시, 이전의 이미지를 S3에서 제거하여 불필요한 공간 낭비를 제거하였습니다.
  - `AmazonS3Uploader.deleteImage(String fileName)` 를 참고해주세요!
    - 이미지 제거를 위해서는 fileName을 key로 변환하는 로직이 필요하여 이를 구현하였습니다.
      - `fileName : S3 객체 URL`
      - `AmazonS3Client.deleteObject(new DeleteObjectRequest(bucket, key)) : S3 객체 키`
    - 이미지에 공백이 있는 경우, 제대로 위 로직을 처리하지 못하여 S3에 이미지 업로드 시, 공백을 제거하는 로직이 추가되었습니다.
      - AmazonS3Uploader.upload()
      - String fileName = dirName + "/" + UUID.randomUUID() + `uploadFile.getName().replaceAll(" ", "");`
