### PR TITLE
[Feat] 그룹 생성 API 구현

### DIFF
--- a/src/main/java/scs/planus/controller/GroupController.java
+++ b/src/main/java/scs/planus/controller/GroupController.java
@@ -1,0 +1,32 @@
+package scs.planus.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import scs.planus.auth.PrincipalDetails;
+import scs.planus.common.response.BaseResponse;
+import scs.planus.dto.group.GroupCreateRequestDto;
+import scs.planus.dto.group.GroupResponseDto;
+import scs.planus.service.GroupService;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/app")
+@RequiredArgsConstructor
+@Slf4j
+public class GroupController {
+    private final GroupService groupService;
+
+    @PostMapping("/groups")
+    public BaseResponse< GroupResponseDto > createCategory( @AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                            @RequestPart(value = "image", required = false) MultipartFile multipartFile,
+                                                            @Valid @RequestPart(value = "groupCreateRequestDto") GroupCreateRequestDto requestDto ) {
+        Long memberId = principalDetails.getId();
+        GroupResponseDto responseDto = groupService.create(memberId, requestDto, multipartFile);
+
+        return new BaseResponse<>(responseDto);
+    }
+}

--- a/src/main/java/scs/planus/controller/GroupController.java
+++ b/src/main/java/scs/planus/controller/GroupController.java
@@ -21,7 +21,7 @@ public class GroupController {
     private final GroupService groupService;
 
     @PostMapping("/groups")
-    public BaseResponse< GroupResponseDto > createCategory( @AuthenticationPrincipal PrincipalDetails principalDetails,
+    public BaseResponse< GroupResponseDto > createGroup( @AuthenticationPrincipal PrincipalDetails principalDetails,
                                                             @RequestPart(value = "image", required = false) MultipartFile multipartFile,
                                                             @Valid @RequestPart(value = "groupCreateRequestDto") GroupCreateRequestDto requestDto ) {
         Long memberId = principalDetails.getId();

--- a/src/main/java/scs/planus/domain/Group.java
+++ b/src/main/java/scs/planus/domain/Group.java
@@ -33,7 +33,7 @@ public class Group extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Status status;
 
-    @OneToMany(mappedBy = "group", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GroupMember> groupMembers = new ArrayList<>();
 
     @Builder

--- a/src/main/java/scs/planus/domain/Group.java
+++ b/src/main/java/scs/planus/domain/Group.java
@@ -1,18 +1,10 @@
 package scs.planus.domain;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -40,4 +32,28 @@ public class Group extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private Status status;
+
+    @OneToMany(mappedBy = "group", cascade = CascadeType.PERSIST)
+    private List<GroupMember> groupMembers = new ArrayList<>();
+
+    @Builder
+    public Group(String name, String notice, String groupImageUrl, Long limitCount, GroupScope scope, Status status) {
+        this.name = name;
+        this.notice = notice;
+        this.groupImageUrl = groupImageUrl;
+        this.limitCount = limitCount;
+        this.scope = scope;
+        this.status = status;
+    }
+
+    public static Group creatGroup(String name, String notice, Long limitCount, String groupImageUrl) {
+        return Group.builder()
+                .name(name)
+                .notice(notice)
+                .limitCount(limitCount)
+                .groupImageUrl(groupImageUrl)
+                .scope(GroupScope.PUBLIC)
+                .status(Status.ACTIVE)
+                .build();
+    }
 }

--- a/src/main/java/scs/planus/domain/GroupMember.java
+++ b/src/main/java/scs/planus/domain/GroupMember.java
@@ -1,18 +1,8 @@
 package scs.planus.domain;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+import javax.persistence.*;
 
 @Entity
 @Getter
@@ -30,6 +20,7 @@ public class GroupMember extends BaseTimeEntity{
 
     private boolean todoAuthority;
 
+    @Enumerated(EnumType.STRING)
     private Status status;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -39,4 +30,24 @@ public class GroupMember extends BaseTimeEntity{
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
     private Group group;
+
+    @Builder
+    public GroupMember(boolean leader, boolean todoAuthority, Member member, Group group) {
+        this.onlineStatus = false;
+        this.leader = leader;
+        this.todoAuthority = todoAuthority;
+        this.status = Status.ACTIVE;
+        this.member = member;
+        this.group = group;
+        if (group != null) { group.getGroupMembers().add(this); }
+    }
+
+    public static GroupMember creatGroupMemberLeader(Member member, Group group ) {
+        return GroupMember.builder()
+                .leader(true)
+                .todoAuthority(true)
+                .member(member)
+                .group(group)
+                .build();
+    }
 }

--- a/src/main/java/scs/planus/dto/group/GroupCreateRequestDto.java
+++ b/src/main/java/scs/planus/dto/group/GroupCreateRequestDto.java
@@ -1,0 +1,20 @@
+package scs.planus.dto.group;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.hibernate.validator.constraints.URL;
+import scs.planus.domain.Group;
+
+import javax.validation.constraints.*;
+
+@Getter
+public class GroupCreateRequestDto {
+    @NotBlank(message = "[request] 그룹명을 입력해 주세요.")
+    @Size(min = 2, max = 20, message = "[request] 그룹명은 2 - 20글자로 입력해 주세요.")
+    private String name;
+    private String notice;
+    @NotNull(message = "[request] 그룹 제한 인원을 설정해 주세요.")
+    @Max(value = 50, message = "[request] 그룹 제한 인원은 50명 이하로 입력해 주세요.")
+    @Min(value = 2, message = "[request] 그룹 제한 인원은 2명 이상으로 입력해 주세요.")
+    private Long limitCount;
+}

--- a/src/main/java/scs/planus/dto/group/GroupResponseDto.java
+++ b/src/main/java/scs/planus/dto/group/GroupResponseDto.java
@@ -1,0 +1,25 @@
+package scs.planus.dto.group;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.Group;
+
+@Getter
+@Builder
+public class GroupResponseDto {
+    private Long id;
+    private String name;
+    private String notice;
+    private String groupImageUrl;
+    private Long limitCount;
+
+    public static GroupResponseDto of(Group group) {
+        return GroupResponseDto.builder()
+                .id(group.getId())
+                .name(group.getName())
+                .notice(group.getNotice())
+                .limitCount(group.getLimitCount())
+                .groupImageUrl(group.getGroupImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/repository/GroupRepository.java
+++ b/src/main/java/scs/planus/repository/GroupRepository.java
@@ -1,0 +1,7 @@
+package scs.planus.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scs.planus.domain.Group;
+
+public interface GroupRepository extends JpaRepository<Group, Long> {
+}

--- a/src/main/java/scs/planus/service/GroupService.java
+++ b/src/main/java/scs/planus/service/GroupService.java
@@ -1,0 +1,50 @@
+package scs.planus.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import reactor.netty.internal.shaded.reactor.pool.PoolAcquirePendingLimitException;
+import scs.planus.common.exception.PlanusException;
+import scs.planus.common.response.CustomResponseStatus;
+import scs.planus.domain.Group;
+import scs.planus.domain.GroupMember;
+import scs.planus.domain.Member;
+import scs.planus.dto.group.GroupCreateRequestDto;
+import scs.planus.dto.group.GroupResponseDto;
+import scs.planus.infra.AmazonS3Uploader;
+import scs.planus.repository.GroupRepository;
+import scs.planus.repository.MemberRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class GroupService {
+    private final AmazonS3Uploader s3Uploader;
+    private final MemberRepository memberRepository;
+    private final GroupRepository groupRepository;
+
+    @Transactional
+    public GroupResponseDto create( Long memberId, GroupCreateRequestDto requestDto, MultipartFile multipartFile ) {
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> {
+                    throw new PlanusException( CustomResponseStatus.NONE_USER );
+                });
+
+        String groupImageUrl = createGroupImage( multipartFile );
+        Group group = Group.creatGroup( requestDto.getName(), requestDto.getNotice(), requestDto.getLimitCount(), groupImageUrl );
+        GroupMember.creatGroupMemberLeader(member, group);
+        Group saveGroup = groupRepository.save( group );
+
+        return GroupResponseDto.of( saveGroup );
+    }
+
+    private String createGroupImage(MultipartFile multipartFile) {
+        if (multipartFile != null) {
+            return s3Uploader.upload(multipartFile, "groups");
+        }
+        throw new PlanusException(CustomResponseStatus.INVALID_FILE);
+    }
+}


### PR DESCRIPTION
### :: PR 타입
- [x] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- `Group` 도메인 내에 빌더 타입과 생성 메소드 구현했습니다.
- 양방향 매핑을 위해 `Group` 에 `List<GroupMember>` 를 추가하였습니다.
- `GroupMember` 내에 빌더 태입과 리더용 생성 메소드를 구현하였습니다.
- 그룹 생성 요청을 위한 `GroupCreateRequestDto` 를 구현하였습니다.
- 그룹 생성 응답을 위한 `GroupResponseDto` 를 구현하였습니다. (우선 Group 정보 모두 반환)
- `JpaRepository` 를 상속받은 `GroupRepository` 를 구현하였습니다.
- 그룹을 생성하는 `create` 서비스 기능을 구현하였습니다.
- 그룹 생성을 위한 `createGroup` 기능을 구현하였습니다.

### :: 특이사항
- `Group` 이 생성될 시, `GroupScope = PUBLIC`, `Status = ACTIVE` 를 기본값으로 설정하였습니다.
- `Group` 생성시 `GroupMember` 에게로 영속화 전이를 위해 `Cascade.PERSIST` 로 설정하였습니다.
- `GroupMember` 객체를 생성할 때, 빌더 내에서 `Group` 과의 연관관계가 이루어지도록 구현하였습니다.
- `GroupService` 의 `createGroupImage` 함수에서 이미지를 첨부하지 않았으때 `S3`에 업로드 되기 전에 예외 처리를 하였습니다.
