### PR TITLE
[Feat] MemberTodo 생성 기능 구현

### DIFF
--- a/src/main/java/scs/planus/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/scs/planus/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package scs.planus.common.exception;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -20,6 +21,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Object> handleValidException() {
+        ResponseStatus status = CommonResponseStatus.INVALID_PARAMETER;
+        return ResponseEntity.status(status.getHttpStatus())
+                .body(new BaseResponse<>(status));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Object> handleJsonException() {
         ResponseStatus status = CommonResponseStatus.INVALID_PARAMETER;
         return ResponseEntity.status(status.getHttpStatus())
                 .body(new BaseResponse<>(status));

--- a/src/main/java/scs/planus/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/scs/planus/common/exception/GlobalExceptionHandler.java
@@ -1,30 +1,24 @@
 package scs.planus.common.exception;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindException;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import scs.planus.common.response.BaseResponse;
 import scs.planus.common.response.CommonResponseStatus;
 import scs.planus.common.response.ResponseStatus;
 
-import org.springframework.validation.BindingResult;
-
-import java.util.List;
-
 @RestControllerAdvice
-public class ExceptionHandler {
+public class GlobalExceptionHandler {
 
-    @org.springframework.web.bind.annotation.ExceptionHandler(PlanusException.class)
+    @ExceptionHandler(PlanusException.class)
     public ResponseEntity<Object> handlePlanusException(PlanusException e) {
         ResponseStatus status = e.getStatus();
         return ResponseEntity.status(status.getHttpStatus())
                 .body(new BaseResponse<>(status));
     }
 
-    @org.springframework.web.bind.annotation.ExceptionHandler(MethodArgumentNotValidException.class)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Object> handleValidException() {
         ResponseStatus status = CommonResponseStatus.INVALID_PARAMETER;
         return ResponseEntity.status(status.getHttpStatus())

--- a/src/main/java/scs/planus/common/response/CustomResponseStatus.java
+++ b/src/main/java/scs/planus/common/response/CustomResponseStatus.java
@@ -23,6 +23,9 @@ public enum CustomResponseStatus implements ResponseStatus {
     // category exception
     NOT_EXIST_CATEGORY(BAD_REQUEST, 2400, "존재하지 않는 카테고리 입니다."),
 
+    // to_do exception
+    INVALID_DATE(BAD_REQUEST, 2500, "시작 날짜가 끝 날짜보다 늦을 수 없습니다."),
+
     // s3 exception
     INVALID_FILE(BAD_REQUEST, 5000, "잘못되거나 존재하지 않는 파일입니다."),
     INVALID_FILE_EXTENSION(BAD_REQUEST, 5001, "잘못된 확장자입니다. jpeg / jpg / png / heic 파일을 선택해주세요.")

--- a/src/main/java/scs/planus/controller/TodoController.java
+++ b/src/main/java/scs/planus/controller/TodoController.java
@@ -1,0 +1,34 @@
+package scs.planus.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import scs.planus.auth.PrincipalDetails;
+import scs.planus.common.response.BaseResponse;
+import scs.planus.dto.todo.TodoCreateRequestDto;
+import scs.planus.dto.todo.TodoResponseDto;
+import scs.planus.service.TodoService;
+
+@RestController
+@RequestMapping("/app")
+@RequiredArgsConstructor
+@Slf4j
+public class TodoController {
+
+    private final TodoService todoService;
+
+    @PostMapping("/todos")
+    public BaseResponse<TodoResponseDto> createTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                    @RequestBody TodoCreateRequestDto requestDto) {
+        Long memberId = principalDetails.getId();
+        if (requestDto.getGroupId() == null) {
+            TodoResponseDto responseDto = todoService.createPrivateTodo(memberId, requestDto);
+            return new BaseResponse<>(responseDto);
+        }
+        return null; // 그룹개인투두 미구현
+    }
+}

--- a/src/main/java/scs/planus/domain/todo/MemberTodo.java
+++ b/src/main/java/scs/planus/domain/todo/MemberTodo.java
@@ -2,11 +2,19 @@ package scs.planus.domain.todo;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import scs.planus.domain.Member;
+import scs.planus.domain.TodoCategory;
 
-import javax.persistence.*;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Entity
 @DiscriminatorValue("MT")
@@ -20,4 +28,12 @@ public class MemberTodo extends Todo{
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Builder
+    public MemberTodo(Long id, String title, String description, LocalTime startTime,
+                      LocalDate startDate, LocalDate endDate, boolean showDDay, TodoCategory todoCategory, boolean completion, Member member) {
+        super(id, title, description, startTime, startDate, endDate, showDDay, todoCategory);
+        this.completion = completion;
+        this.member = member;
+    }
 }

--- a/src/main/java/scs/planus/dto/todo/TodoCreateRequestDto.java
+++ b/src/main/java/scs/planus/dto/todo/TodoCreateRequestDto.java
@@ -1,0 +1,33 @@
+package scs.planus.dto.todo;
+
+import lombok.Getter;
+import scs.planus.domain.Member;
+import scs.planus.domain.TodoCategory;
+import scs.planus.domain.todo.MemberTodo;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+public class TodoCreateRequestDto {
+
+    private String title;
+    private Long categoryId;
+    private Long groupId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private LocalTime startTime;
+    private String description;
+
+    public MemberTodo toMemberTodoEntity(Member member, TodoCategory todoCategory) {
+        return MemberTodo.builder()
+                .title(title)
+                .todoCategory(todoCategory)
+                .startDate(startDate)
+                .endDate(endDate)
+                .startTime(startTime)
+                .description(description)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/dto/todo/TodoCreateRequestDto.java
+++ b/src/main/java/scs/planus/dto/todo/TodoCreateRequestDto.java
@@ -1,22 +1,33 @@
 package scs.planus.dto.todo;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import scs.planus.domain.Member;
 import scs.planus.domain.TodoCategory;
 import scs.planus.domain.todo.MemberTodo;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Getter
 public class TodoCreateRequestDto {
 
+    @NotBlank(message = "투두 제목을 입력해주세요.")
+    @Size(max = 20, message = "투두 제목은 최대 20글자입니다.")
     private String title;
     private Long categoryId;
     private Long groupId;
+
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
     private LocalDate startDate;
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
     private LocalDate endDate;
+    @JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING)
     private LocalTime startTime;
+
+    @Size(max = 70, message = "투두 메모는 최대 70글자입니다.")
     private String description;
 
     public MemberTodo toMemberTodoEntity(Member member, TodoCategory todoCategory) {

--- a/src/main/java/scs/planus/dto/todo/TodoResponseDto.java
+++ b/src/main/java/scs/planus/dto/todo/TodoResponseDto.java
@@ -1,0 +1,18 @@
+package scs.planus.dto.todo;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.todo.Todo;
+
+@Getter
+@Builder
+public class TodoResponseDto {
+
+    private Long todoId;
+
+    public static TodoResponseDto of(Todo todo) {
+        return TodoResponseDto.builder()
+                .todoId(todo.getId())
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/repository/TodoRepository.java
+++ b/src/main/java/scs/planus/repository/TodoRepository.java
@@ -1,0 +1,7 @@
+package scs.planus.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scs.planus.domain.todo.Todo;
+
+public interface TodoRepository extends JpaRepository<Todo, Long> {
+}

--- a/src/main/java/scs/planus/service/TodoService.java
+++ b/src/main/java/scs/planus/service/TodoService.java
@@ -1,0 +1,42 @@
+package scs.planus.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import scs.planus.common.exception.PlanusException;
+import scs.planus.domain.Member;
+import scs.planus.domain.TodoCategory;
+import scs.planus.domain.todo.MemberTodo;
+import scs.planus.dto.todo.TodoCreateRequestDto;
+import scs.planus.dto.todo.TodoResponseDto;
+import scs.planus.repository.CategoryRepository;
+import scs.planus.repository.MemberRepository;
+import scs.planus.repository.TodoRepository;
+
+import static scs.planus.common.response.CustomResponseStatus.NONE_USER;
+import static scs.planus.common.response.CustomResponseStatus.NOT_EXIST_CATEGORY;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class TodoService {
+
+    private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
+    private final TodoRepository todoRepository;
+
+    @Transactional
+    public TodoResponseDto createPrivateTodo(Long memberId, TodoCreateRequestDto requestDto) {
+        Member member = memberRepository.findById(memberId)
+                        .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        TodoCategory todoCategory = categoryRepository.findById(requestDto.getCategoryId())
+                .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
+
+        MemberTodo memberTodo = requestDto.toMemberTodoEntity(member, todoCategory);
+        todoRepository.save(memberTodo);
+        return TodoResponseDto.of(memberTodo);
+    }
+}

--- a/src/main/java/scs/planus/service/TodoService.java
+++ b/src/main/java/scs/planus/service/TodoService.java
@@ -14,8 +14,9 @@ import scs.planus.repository.CategoryRepository;
 import scs.planus.repository.MemberRepository;
 import scs.planus.repository.TodoRepository;
 
-import static scs.planus.common.response.CustomResponseStatus.NONE_USER;
-import static scs.planus.common.response.CustomResponseStatus.NOT_EXIST_CATEGORY;
+import java.time.LocalDate;
+
+import static scs.planus.common.response.CustomResponseStatus.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -35,8 +36,17 @@ public class TodoService {
         TodoCategory todoCategory = categoryRepository.findById(requestDto.getCategoryId())
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
 
+        validateDate(requestDto.getStartDate(), requestDto.getEndDate());
         MemberTodo memberTodo = requestDto.toMemberTodoEntity(member, todoCategory);
         todoRepository.save(memberTodo);
         return TodoResponseDto.of(memberTodo);
+    }
+
+    private void validateDate(LocalDate startDate, LocalDate endDate) {
+        if (endDate != null) {
+            if (startDate.isAfter(endDate)) {
+                throw new PlanusException(INVALID_DATE);
+            }
+        }
     }
 }


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- MemberTodo 생성 기능 구현

### :: 특이사항
- TodoCreateRequestDto에서 그룹을 지정하지 않는 경우, MemberTodo를 작성하는 API를 구현하였습니다.
- Todo 생성 Validation을 추가하였습니다.
  - 단, startDate가 endDate보다 늦어지는 경우에 대한 검증은, Service 단의 `validateDate( )` 메서드에서 이루어집니다.
    - 이 후, 수정 API에서도 이를 재활용하기 위해서 dto단이 아닌, Service 단에 메서드로 구현하였습니다.
- Group 참가 API 구현 이후에 GroupMemberTodo를 구현하고자 합니다 !
