### PR TITLE
[Feat] Group 생성시 필요한 TagService 및 GroupTag 생성 기능 구현

### DIFF
--- a/src/main/java/scs/planus/controller/GroupController.java
+++ b/src/main/java/scs/planus/controller/GroupController.java
@@ -22,7 +22,7 @@ public class GroupController {
 
     @PostMapping("/groups")
     public BaseResponse<GroupResponseDto> createGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                         @RequestPart(value = "image", required = false) MultipartFile multipartFile,
+                                                         @RequestPart(value = "image") MultipartFile multipartFile,
                                                          @Valid @RequestPart(value = "groupCreateRequestDto") GroupCreateRequestDto requestDto ) {
         Long memberId = principalDetails.getId();
         GroupResponseDto responseDto = groupService.createGroup( memberId, requestDto, multipartFile );

--- a/src/main/java/scs/planus/controller/GroupController.java
+++ b/src/main/java/scs/planus/controller/GroupController.java
@@ -21,11 +21,11 @@ public class GroupController {
     private final GroupService groupService;
 
     @PostMapping("/groups")
-    public BaseResponse< GroupResponseDto > createGroup( @AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                            @RequestPart(value = "image", required = false) MultipartFile multipartFile,
-                                                            @Valid @RequestPart(value = "groupCreateRequestDto") GroupCreateRequestDto requestDto ) {
+    public BaseResponse<GroupResponseDto> createGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                         @RequestPart(value = "image", required = false) MultipartFile multipartFile,
+                                                         @Valid @RequestPart(value = "groupCreateRequestDto") GroupCreateRequestDto requestDto ) {
         Long memberId = principalDetails.getId();
-        GroupResponseDto responseDto = groupService.create(memberId, requestDto, multipartFile);
+        GroupResponseDto responseDto = groupService.createGroup( memberId, requestDto, multipartFile );
 
         return new BaseResponse<>(responseDto);
     }

--- a/src/main/java/scs/planus/domain/Group.java
+++ b/src/main/java/scs/planus/domain/Group.java
@@ -36,6 +36,9 @@ public class Group extends BaseTimeEntity {
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GroupMember> groupMembers = new ArrayList<>();
 
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<GroupTag> groupTags = new ArrayList<>();
+
     @Builder
     public Group(String name, String notice, String groupImageUrl, Long limitCount, GroupScope scope, Status status) {
         this.name = name;
@@ -46,14 +49,14 @@ public class Group extends BaseTimeEntity {
         this.status = status;
     }
 
-    public static Group creatGroup(String name, String notice, Long limitCount, String groupImageUrl) {
+    public static Group creatGroup( String name, String notice, Long limitCount, String groupImageUrl ) {
         return Group.builder()
-                .name(name)
-                .notice(notice)
-                .limitCount(limitCount)
-                .groupImageUrl(groupImageUrl)
-                .scope(GroupScope.PUBLIC)
-                .status(Status.ACTIVE)
+                .name( name )
+                .notice( notice )
+                .limitCount( limitCount )
+                .groupImageUrl( groupImageUrl )
+                .scope( GroupScope.PUBLIC )
+                .status( Status.ACTIVE )
                 .build();
     }
 }

--- a/src/main/java/scs/planus/domain/Group.java
+++ b/src/main/java/scs/planus/domain/Group.java
@@ -36,7 +36,7 @@ public class Group extends BaseTimeEntity {
     @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GroupMember> groupMembers = new ArrayList<>();
 
-    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<GroupTag> groupTags = new ArrayList<>();
 
     @Builder

--- a/src/main/java/scs/planus/domain/GroupTag.java
+++ b/src/main/java/scs/planus/domain/GroupTag.java
@@ -1,9 +1,6 @@
 package scs.planus.domain;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -13,6 +10,8 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -31,4 +30,20 @@ public class GroupTag extends BaseTimeEntity{
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tag_id")
     private Tag tag;
+
+    @Builder
+    public GroupTag( Group group, Tag tag ) {
+        this.group = group;
+        if (group != null) { group.getGroupTags().add(this); }
+        this.tag = tag;
+    }
+
+    public static List<GroupTag> create( Group group, List<Tag> tagList ) {
+        return tagList.stream()
+                .map( tag -> GroupTag.builder()
+                                .group( group )
+                                .tag( tag )
+                                .build() )
+                .collect( Collectors.toList() );
+    }
 }

--- a/src/main/java/scs/planus/domain/Tag.java
+++ b/src/main/java/scs/planus/domain/Tag.java
@@ -1,9 +1,6 @@
 package scs.planus.domain;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -22,4 +19,9 @@ public class Tag extends BaseTimeEntity{
     private Long id;
 
     private String name;
+
+    @Builder
+    public Tag(String name) {
+        this.name = name;
+    }
 }

--- a/src/main/java/scs/planus/dto/group/GroupCreateRequestDto.java
+++ b/src/main/java/scs/planus/dto/group/GroupCreateRequestDto.java
@@ -1,18 +1,24 @@
 package scs.planus.dto.group;
 
-import lombok.Builder;
 import lombok.Getter;
-import org.hibernate.validator.constraints.URL;
-import scs.planus.domain.Group;
+import scs.planus.dto.tag.TagCreateRequestDto;
 
+import javax.validation.Valid;
 import javax.validation.constraints.*;
+import java.util.List;
 
 @Getter
 public class GroupCreateRequestDto {
+
     @NotBlank(message = "[request] 그룹명을 입력해 주세요.")
     @Size(min = 2, max = 20, message = "[request] 그룹명은 2 - 20글자로 입력해 주세요.")
     private String name;
+
     private String notice;
+
+    @Size(max = 5, message = "[request] 테그는 5개 이하로 입력해 주세요.")
+    private List<@Valid TagCreateRequestDto> tagList;
+
     @NotNull(message = "[request] 그룹 제한 인원을 설정해 주세요.")
     @Max(value = 50, message = "[request] 그룹 제한 인원은 50명 이하로 입력해 주세요.")
     @Min(value = 2, message = "[request] 그룹 제한 인원은 2명 이상으로 입력해 주세요.")

--- a/src/main/java/scs/planus/dto/group/GroupResponseDto.java
+++ b/src/main/java/scs/planus/dto/group/GroupResponseDto.java
@@ -7,19 +7,11 @@ import scs.planus.domain.Group;
 @Getter
 @Builder
 public class GroupResponseDto {
-    private Long id;
-    private String name;
-    private String notice;
-    private String groupImageUrl;
-    private Long limitCount;
+    private Long groupId;
 
-    public static GroupResponseDto of(Group group) {
+    public static GroupResponseDto of(Group group ) {
         return GroupResponseDto.builder()
-                .id(group.getId())
-                .name(group.getName())
-                .notice(group.getNotice())
-                .limitCount(group.getLimitCount())
-                .groupImageUrl(group.getGroupImageUrl())
+                .groupId( group.getId() )
                 .build();
     }
 }

--- a/src/main/java/scs/planus/dto/tag/GroupTagResponseDto.java
+++ b/src/main/java/scs/planus/dto/tag/GroupTagResponseDto.java
@@ -1,0 +1,19 @@
+package scs.planus.dto.tag;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.GroupTag;
+
+@Getter
+@Builder
+public class GroupTagResponseDto {
+    private Long id;
+    private String name;
+
+    public static GroupTagResponseDto of( GroupTag groupTag ) {
+        return GroupTagResponseDto.builder()
+                .id( groupTag.getTag().getId() )
+                .name( groupTag.getTag().getName() )
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/dto/tag/TagCreateRequestDto.java
+++ b/src/main/java/scs/planus/dto/tag/TagCreateRequestDto.java
@@ -1,0 +1,13 @@
+package scs.planus.dto.tag;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+@Getter
+public class TagCreateRequestDto {
+    @NotBlank(message = "[request] 태그명을 입력해 주세요.")
+    @Size(max = 7, message = "[request] 태그는 7 글자 이내로 작성해 주세요.")
+    private String name;
+}

--- a/src/main/java/scs/planus/repository/TagRepository.java
+++ b/src/main/java/scs/planus/repository/TagRepository.java
@@ -1,0 +1,10 @@
+package scs.planus.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scs.planus.domain.Tag;
+
+import java.util.Optional;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    Optional<Tag> findByName(String name);
+}

--- a/src/main/java/scs/planus/service/GroupService.java
+++ b/src/main/java/scs/planus/service/GroupService.java
@@ -5,17 +5,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import reactor.netty.internal.shaded.reactor.pool.PoolAcquirePendingLimitException;
 import scs.planus.common.exception.PlanusException;
 import scs.planus.common.response.CustomResponseStatus;
-import scs.planus.domain.Group;
-import scs.planus.domain.GroupMember;
-import scs.planus.domain.Member;
+import scs.planus.domain.*;
 import scs.planus.dto.group.GroupCreateRequestDto;
 import scs.planus.dto.group.GroupResponseDto;
 import scs.planus.infra.AmazonS3Uploader;
 import scs.planus.repository.GroupRepository;
 import scs.planus.repository.MemberRepository;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -25,9 +24,10 @@ public class GroupService {
     private final AmazonS3Uploader s3Uploader;
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
+    private final TagService tagService;
 
     @Transactional
-    public GroupResponseDto create( Long memberId, GroupCreateRequestDto requestDto, MultipartFile multipartFile ) {
+    public GroupResponseDto createGroup(Long memberId, GroupCreateRequestDto requestDto, MultipartFile multipartFile ) {
         Member member = memberRepository.findById( memberId )
                 .orElseThrow(() -> {
                     throw new PlanusException( CustomResponseStatus.NONE_USER );
@@ -35,7 +35,12 @@ public class GroupService {
 
         String groupImageUrl = createGroupImage( multipartFile );
         Group group = Group.creatGroup( requestDto.getName(), requestDto.getNotice(), requestDto.getLimitCount(), groupImageUrl );
-        GroupMember.creatGroupMemberLeader(member, group);
+
+        List<Tag> tagList = tagService.transformToTag( requestDto.getTagList() );
+        GroupTag.create( group, tagList );
+
+        GroupMember.creatGroupMemberLeader( member, group );
+
         Group saveGroup = groupRepository.save( group );
 
         return GroupResponseDto.of( saveGroup );

--- a/src/main/java/scs/planus/service/TagService.java
+++ b/src/main/java/scs/planus/service/TagService.java
@@ -1,0 +1,37 @@
+package scs.planus.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import scs.planus.domain.Tag;
+import scs.planus.dto.tag.TagCreateRequestDto;
+import scs.planus.repository.TagRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class TagService {
+    private final TagRepository tagRepository;
+
+    @Transactional
+    public Tag create( TagCreateRequestDto tagDto ) {
+        Tag tag = Tag.builder()
+                .name( tagDto.getName() )
+                .build();
+
+        return tagRepository.save( tag );
+    }
+
+    public List<Tag> transformToTag( List<TagCreateRequestDto> tagDtos ) {
+
+        return tagDtos.stream()
+                .map( tag -> tagRepository.findByName( tag.getName() )
+                        .orElseGet( () -> this.create( tag ) ) )
+                .collect( Collectors.toList() );
+    }
+}


### PR DESCRIPTION
### :: PR 타입
- [x] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- `Group` 생성시 `TagCreateRequestDto` 에 담겨온 `Tag` 들로 `GroupTag` 를 생성하는 기능을 구현하였습니다.
- `TagService` 에 존재하는 `Tag`들은 `id`를 반환하고, 존재하지 않는 `Tag`들은 새로 생성하여 `id`를 반환하는 기능을 구현하였습니다.
- `GroupTag`엔티티 내에 생성 메소드를 구현하였습니다. 여기서 Group 과 연관관계 편의를 추가하였습니다.

### :: 특이사항
- `GroupCreateRequestDto` 에서 `List<Tag>`의 `Tag` 하나하나를 `Validation` 할수가 없어, `TagCreateRequestDto`를 추가로 구현하여 이 `Dto`내에서 `Validation`처리하였습니다.
- 테그는 한번에 최대 5개까지 포함할 수 있도록 List<TagCreateRquestDto>를 `@Size(max = 5)` 로 제한하였습니다.
- 각각의 테그는 7글자 이내로 작성할 수 있도록 하기 위해 `@Size(max = 7)` 로 제한하였습니다.
