### PR TITLE
[Feat] Group 개별 조회 API 구현

### DIFF
--- a/src/main/java/scs/planus/common/response/CustomResponseStatus.java
+++ b/src/main/java/scs/planus/common/response/CustomResponseStatus.java
@@ -26,6 +26,10 @@ public enum CustomResponseStatus implements ResponseStatus {
     // to_do exception
     INVALID_DATE(BAD_REQUEST, 2500, "시작 날짜가 끝 날짜보다 늦을 수 없습니다."),
 
+    // group exception
+    NOT_EXIST_GROUP(BAD_REQUEST, 2600, "존재하지 않는 그룹 입니다."),
+    NOT_EXIST_LEADER(BAD_REQUEST, 2601, "해당 그룹에 그룹장이 존재하지 않습니다."),
+
     // s3 exception
     INVALID_FILE(BAD_REQUEST, 5000, "잘못되거나 존재하지 않는 파일입니다."),
     INVALID_FILE_EXTENSION(BAD_REQUEST, 5001, "잘못된 확장자입니다. jpeg / jpg / png / heic 파일을 선택해주세요.")

--- a/src/main/java/scs/planus/controller/GroupController.java
+++ b/src/main/java/scs/planus/controller/GroupController.java
@@ -32,9 +32,10 @@ public class GroupController {
     }
 
     @GetMapping("/groups/{groupId}")
-    public BaseResponse<GroupGetResponseDto> getGroup( @PathVariable("groupId") Long groupId ) {
+    public BaseResponse<GroupGetResponseDto> getGroup( @AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                       @PathVariable("groupId") Long groupId ) {
 
-        GroupGetResponseDto responseDto = groupService.findById( groupId );
+        GroupGetResponseDto responseDto = groupService.getGroup( groupId );
 
         return new BaseResponse<>( responseDto );
     }

--- a/src/main/java/scs/planus/controller/GroupController.java
+++ b/src/main/java/scs/planus/controller/GroupController.java
@@ -8,6 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 import scs.planus.auth.PrincipalDetails;
 import scs.planus.common.response.BaseResponse;
 import scs.planus.dto.group.GroupCreateRequestDto;
+import scs.planus.dto.group.GroupGetResponseDto;
 import scs.planus.dto.group.GroupResponseDto;
 import scs.planus.service.GroupService;
 
@@ -28,5 +29,13 @@ public class GroupController {
         GroupResponseDto responseDto = groupService.createGroup( memberId, requestDto, multipartFile );
 
         return new BaseResponse<>(responseDto);
+    }
+
+    @GetMapping("/groups/{groupId}")
+    public BaseResponse<GroupGetResponseDto> getGroup( @PathVariable("groupId") Long groupId ) {
+
+        GroupGetResponseDto responseDto = groupService.findById( groupId );
+
+        return new BaseResponse<>( responseDto );
     }
 }

--- a/src/main/java/scs/planus/dto/group/GroupGetResponseDto.java
+++ b/src/main/java/scs/planus/dto/group/GroupGetResponseDto.java
@@ -1,0 +1,55 @@
+package scs.planus.dto.group;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.common.exception.PlanusException;
+import scs.planus.common.response.CustomResponseStatus;
+import scs.planus.domain.Group;
+import scs.planus.domain.GroupMember;
+import scs.planus.dto.tag.GroupTagResponseDto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class GroupGetResponseDto {
+    private Long id;
+    private String name;
+    private String notice;
+    private String groupImageUrl;
+    private Integer memberCount;
+    private Long limitCount;
+    private String leaderName;
+    private List<GroupTagResponseDto> groupTags;
+
+    public static GroupGetResponseDto of(Group group ) {
+
+        List<GroupTagResponseDto> groupTagNameList = group.getGroupTags().stream()
+                                                        .map( GroupTagResponseDto::of )
+                                                        .collect( Collectors.toList() );
+
+        String leaderName = findLeader(group);
+
+        return GroupGetResponseDto.builder()
+                .id( group.getId() )
+                .name( group.getName() )
+                .notice( group.getNotice() )
+                .groupImageUrl( group.getGroupImageUrl() )
+                .memberCount( group.getGroupMembers().size() )
+                .limitCount( group.getLimitCount() )
+                .leaderName( leaderName )
+                .groupTags( groupTagNameList )
+                .build();
+    }
+
+    private static String findLeader( Group group ) {
+        return group.getGroupMembers().stream()
+                .filter( GroupMember::isLeader )
+                .findFirst()
+                .map( gm -> gm.getMember().getNickname() )
+                .orElseThrow( () ->
+                        new PlanusException(CustomResponseStatus.NOT_EXIST_LEADER)
+                );
+    }
+}

--- a/src/main/java/scs/planus/service/GroupService.java
+++ b/src/main/java/scs/planus/service/GroupService.java
@@ -9,6 +9,7 @@ import scs.planus.common.exception.PlanusException;
 import scs.planus.common.response.CustomResponseStatus;
 import scs.planus.domain.*;
 import scs.planus.dto.group.GroupCreateRequestDto;
+import scs.planus.dto.group.GroupGetResponseDto;
 import scs.planus.dto.group.GroupResponseDto;
 import scs.planus.infra.AmazonS3Uploader;
 import scs.planus.repository.GroupRepository;
@@ -46,10 +47,18 @@ public class GroupService {
         return GroupResponseDto.of( saveGroup );
     }
 
-    private String createGroupImage(MultipartFile multipartFile) {
-        if (multipartFile != null) {
-            return s3Uploader.upload(multipartFile, "groups");
+    public GroupGetResponseDto findById( Long groupId ) {
+        Group group = groupRepository.findById( groupId )
+                .orElseThrow( () -> {
+                    throw new PlanusException( CustomResponseStatus.NOT_EXIST_GROUP );
+                });
+
+        return GroupGetResponseDto.of( group );
+    }
+    private String createGroupImage( MultipartFile multipartFile ) {
+        if ( multipartFile != null ) {
+            return s3Uploader.upload( multipartFile, "groups" );
         }
-        throw new PlanusException(CustomResponseStatus.INVALID_FILE);
+        throw new PlanusException( CustomResponseStatus.INVALID_FILE );
     }
 }

--- a/src/main/java/scs/planus/service/GroupService.java
+++ b/src/main/java/scs/planus/service/GroupService.java
@@ -47,7 +47,7 @@ public class GroupService {
         return GroupResponseDto.of( saveGroup );
     }
 
-    public GroupGetResponseDto findById( Long groupId ) {
+    public GroupGetResponseDto getGroup(Long groupId ) {
         Group group = groupRepository.findById( groupId )
                 .orElseThrow( () -> {
                     throw new PlanusException( CustomResponseStatus.NOT_EXIST_GROUP );


### PR DESCRIPTION
### :: PR 타입
- [x] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 가입되지 않은 Group을 조회할 때, groupId 로 Group 정보를 반환하는 개별 조회 API를 구현하였습니다.
- GroupGetResponseDto 를 구현하였습니다.

### :: 특이사항
- `Group` 관련 `Exception`을 `code 2600` 번 대로 추가하였습니다.
- `GroupGetResponseDto` 내에 `Tag`들을 `GroupTagResponseDto` 로 변환하는 기능을 구현하였습니다.
- `GroupGetResponseDto` 내에 `Group`의 `LeaderName` 을 찾는 기능을 구현하였습니다.
