### PR TITLE
[Feat] 단건 Todo 및 일별 Todos 조회 기능 구현

### DIFF
--- a/src/main/java/scs/planus/common/response/CustomResponseStatus.java
+++ b/src/main/java/scs/planus/common/response/CustomResponseStatus.java
@@ -25,6 +25,7 @@ public enum CustomResponseStatus implements ResponseStatus {
 
     // to_do exception
     INVALID_DATE(BAD_REQUEST, 2500, "시작 날짜가 끝 날짜보다 늦을 수 없습니다."),
+    NONE_TODO(BAD_REQUEST, 2501, "존재하지 않는 투두입니다."),
 
     // s3 exception
     INVALID_FILE(BAD_REQUEST, 5000, "잘못되거나 존재하지 않는 파일입니다."),

--- a/src/main/java/scs/planus/controller/TodoController.java
+++ b/src/main/java/scs/planus/controller/TodoController.java
@@ -3,6 +3,8 @@ package scs.planus.controller;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import scs.planus.auth.PrincipalDetails;
 import scs.planus.common.response.BaseResponse;
 import scs.planus.dto.todo.TodoCreateRequestDto;
+import scs.planus.dto.todo.TodoGetResponseDto;
 import scs.planus.dto.todo.TodoResponseDto;
 import scs.planus.service.TodoService;
 
@@ -29,6 +32,14 @@ public class TodoController {
             TodoResponseDto responseDto = todoService.createPrivateTodo(memberId, requestDto);
             return new BaseResponse<>(responseDto);
         }
-        return null; // 그룹개인투두 미구현
+        return null;
+    }
+
+    @GetMapping("/todos/{todoId}")
+    public BaseResponse<TodoGetResponseDto> getTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                       @PathVariable Long todoId) {
+        Long memberId = principalDetails.getId();
+        TodoGetResponseDto responseDto = todoService.getOneTodo(memberId, todoId);
+        return new BaseResponse<>(responseDto);
     }
 }

--- a/src/main/java/scs/planus/controller/TodoController.java
+++ b/src/main/java/scs/planus/controller/TodoController.java
@@ -2,12 +2,14 @@ package scs.planus.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import scs.planus.auth.PrincipalDetails;
 import scs.planus.common.response.BaseResponse;
@@ -15,6 +17,9 @@ import scs.planus.dto.todo.TodoCreateRequestDto;
 import scs.planus.dto.todo.TodoGetResponseDto;
 import scs.planus.dto.todo.TodoResponseDto;
 import scs.planus.service.TodoService;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequestMapping("/app")
@@ -41,5 +46,13 @@ public class TodoController {
         Long memberId = principalDetails.getId();
         TodoGetResponseDto responseDto = todoService.getOneTodo(memberId, todoId);
         return new BaseResponse<>(responseDto);
+    }
+
+    @GetMapping("/todos")
+    public BaseResponse<List<TodoGetResponseDto>> getDailyTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+        Long memberId = principalDetails.getId();
+        List<TodoGetResponseDto> responseDtos = todoService.getDailyTodos(memberId, date);
+        return new BaseResponse<>(responseDtos);
     }
 }

--- a/src/main/java/scs/planus/controller/TodoController.java
+++ b/src/main/java/scs/planus/controller/TodoController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import scs.planus.auth.PrincipalDetails;
 import scs.planus.common.response.BaseResponse;
 import scs.planus.dto.todo.TodoCreateRequestDto;
+import scs.planus.dto.todo.TodoDailyResponseDto;
 import scs.planus.dto.todo.TodoGetResponseDto;
 import scs.planus.dto.todo.TodoResponseDto;
 import scs.planus.service.TodoService;
@@ -42,17 +43,17 @@ public class TodoController {
 
     @GetMapping("/todos/{todoId}")
     public BaseResponse<TodoGetResponseDto> getTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                       @PathVariable Long todoId) {
+                                                          @PathVariable Long todoId) {
         Long memberId = principalDetails.getId();
         TodoGetResponseDto responseDto = todoService.getOneTodo(memberId, todoId);
         return new BaseResponse<>(responseDto);
     }
 
     @GetMapping("/todos")
-    public BaseResponse<List<TodoGetResponseDto>> getDailyTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+    public BaseResponse<List<TodoDailyResponseDto>> getDailyTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                  @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         Long memberId = principalDetails.getId();
-        List<TodoGetResponseDto> responseDtos = todoService.getDailyTodos(memberId, date);
+        List<TodoDailyResponseDto> responseDtos = todoService.getDailyTodos(memberId, date);
         return new BaseResponse<>(responseDtos);
     }
 }

--- a/src/main/java/scs/planus/domain/todo/Todo.java
+++ b/src/main/java/scs/planus/domain/todo/Todo.java
@@ -63,6 +63,9 @@ public class Todo extends BaseTimeEntity {
         this.startTime = startTime;
         this.startDate = startDate;
         this.endDate = endDate;
+        if (endDate == null) {
+            this.endDate = startDate;
+        }
         this.showDDay = showDDay;
         this.todoCategory = todoCategory;
         this.member = member;

--- a/src/main/java/scs/planus/dto/todo/TodoCreateRequestDto.java
+++ b/src/main/java/scs/planus/dto/todo/TodoCreateRequestDto.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import scs.planus.domain.Member;
 import scs.planus.domain.TodoCategory;
-import scs.planus.domain.todo.MemberTodo;
+import scs.planus.domain.todo.Todo;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
@@ -30,8 +30,8 @@ public class TodoCreateRequestDto {
     @Size(max = 70, message = "투두 메모는 최대 70글자입니다.")
     private String description;
 
-    public MemberTodo toMemberTodoEntity(Member member, TodoCategory todoCategory) {
-        return MemberTodo.builder()
+    public Todo toMemberTodoEntity(Member member, TodoCategory todoCategory) {
+        return Todo.builder()
                 .title(title)
                 .todoCategory(todoCategory)
                 .startDate(startDate)

--- a/src/main/java/scs/planus/dto/todo/TodoDailyResponseDto.java
+++ b/src/main/java/scs/planus/dto/todo/TodoDailyResponseDto.java
@@ -1,0 +1,35 @@
+package scs.planus.dto.todo;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import scs.planus.domain.todo.Todo;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@ToString
+public class TodoDailyResponseDto {
+
+    private Long todoId;
+    private String title;
+    @JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING)
+    private LocalTime startTime;
+
+    private Boolean isGroupMemberTodo;
+    private Boolean isPeriodTodo;
+    private Boolean hasDescription;
+
+    public static TodoDailyResponseDto of(Todo todo) {
+        return TodoDailyResponseDto.builder()
+                .todoId(todo.getId())
+                .title(todo.getTitle())
+                .startTime(todo.getStartTime())
+                .isGroupMemberTodo(todo.getGroup() != null)
+                .isPeriodTodo(todo.getStartDate() != todo.getEndDate())
+                .hasDescription(todo.getDescription() != null)
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/dto/todo/TodoGetResponseDto.java
+++ b/src/main/java/scs/planus/dto/todo/TodoGetResponseDto.java
@@ -1,0 +1,28 @@
+package scs.planus.dto.todo;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import scs.planus.domain.todo.Todo;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@ToString
+public class TodoGetResponseDto {
+
+    private Long todoId;
+    private String title;
+    @JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING)
+    private LocalTime startTime;
+
+    public static TodoGetResponseDto of(Todo todo) {
+        return TodoGetResponseDto.builder()
+                .todoId(todo.getId())
+                .title(todo.getTitle())
+                .startTime(todo.getStartTime())
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/dto/todo/TodoGetResponseDto.java
+++ b/src/main/java/scs/planus/dto/todo/TodoGetResponseDto.java
@@ -3,26 +3,36 @@ package scs.planus.dto.todo;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
 import scs.planus.domain.todo.Todo;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Getter
 @Builder
-@ToString
 public class TodoGetResponseDto {
 
-    private Long todoId;
     private String title;
+    private String categoryName;
+    private String groupName;
+
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
+    private LocalDate startDate;
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
+    private LocalDate endDate;
     @JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING)
     private LocalTime startTime;
+    private String description;
 
     public static TodoGetResponseDto of(Todo todo) {
         return TodoGetResponseDto.builder()
-                .todoId(todo.getId())
                 .title(todo.getTitle())
+                .categoryName(todo.getTodoCategory().getName())
+                .groupName(todo.getGroup() == null ? null : todo.getGroup().getName())
+                .startDate(todo.getStartDate())
+                .endDate(todo.getEndDate())
                 .startTime(todo.getStartTime())
+                .description(todo.getDescription())
                 .build();
     }
 }

--- a/src/main/java/scs/planus/repository/CategoryRepository.java
+++ b/src/main/java/scs/planus/repository/CategoryRepository.java
@@ -3,9 +3,7 @@ package scs.planus.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 import scs.planus.domain.Member;
-import scs.planus.domain.Status;
 import scs.planus.domain.TodoCategory;
 
 import java.util.List;

--- a/src/main/java/scs/planus/repository/TodoRepository.java
+++ b/src/main/java/scs/planus/repository/TodoRepository.java
@@ -3,5 +3,9 @@ package scs.planus.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import scs.planus.domain.todo.Todo;
 
+import java.util.Optional;
+
 public interface TodoRepository extends JpaRepository<Todo, Long> {
+
+    Optional<Todo> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/scs/planus/repository/TodoRepository.java
+++ b/src/main/java/scs/planus/repository/TodoRepository.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
-
     Optional<Todo> findByIdAndMemberId(Long id, Long memberId);
 
     @Query("select t from Todo t " +

--- a/src/main/java/scs/planus/repository/TodoRepository.java
+++ b/src/main/java/scs/planus/repository/TodoRepository.java
@@ -1,11 +1,21 @@
 package scs.planus.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import scs.planus.domain.todo.Todo;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     Optional<Todo> findByIdAndMemberId(Long id, Long memberId);
+
+    @Query("select t from Todo t " +
+            "join fetch t.member m " +
+            "where m.id = :memberId and (t.startDate <= :date and t.endDate >= :date)")
+    List<Todo> findAllByMemberIdAndDate(@Param("memberId") Long memberId,
+                                        @Param("date") LocalDate date);
 }

--- a/src/main/java/scs/planus/service/TodoService.java
+++ b/src/main/java/scs/planus/service/TodoService.java
@@ -9,6 +9,7 @@ import scs.planus.domain.Member;
 import scs.planus.domain.TodoCategory;
 import scs.planus.domain.todo.Todo;
 import scs.planus.dto.todo.TodoCreateRequestDto;
+import scs.planus.dto.todo.TodoDailyResponseDto;
 import scs.planus.dto.todo.TodoGetResponseDto;
 import scs.planus.dto.todo.TodoResponseDto;
 import scs.planus.repository.CategoryRepository;
@@ -55,14 +56,16 @@ public class TodoService {
         return TodoGetResponseDto.of(todo);
     }
 
-    public List<TodoGetResponseDto> getDailyTodos(Long memberId, LocalDate date) {
+    public List<TodoDailyResponseDto> getDailyTodos(Long memberId, LocalDate date) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
         List<Todo> todos = todoRepository.findAllByMemberIdAndDate(member.getId(), date);
-        return todos.stream()
-                .map(TodoGetResponseDto::of)
+        List<TodoDailyResponseDto> responseDtos = todos.stream()
+                .map(TodoDailyResponseDto::of)
                 .collect(Collectors.toList());
+
+        return responseDtos;
     }
 
     private void validateDate(LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/scs/planus/service/TodoService.java
+++ b/src/main/java/scs/planus/service/TodoService.java
@@ -7,8 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 import scs.planus.common.exception.PlanusException;
 import scs.planus.domain.Member;
 import scs.planus.domain.TodoCategory;
-import scs.planus.domain.todo.MemberTodo;
+import scs.planus.domain.todo.Todo;
 import scs.planus.dto.todo.TodoCreateRequestDto;
+import scs.planus.dto.todo.TodoGetResponseDto;
 import scs.planus.dto.todo.TodoResponseDto;
 import scs.planus.repository.CategoryRepository;
 import scs.planus.repository.MemberRepository;
@@ -37,9 +38,19 @@ public class TodoService {
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
 
         validateDate(requestDto.getStartDate(), requestDto.getEndDate());
-        MemberTodo memberTodo = requestDto.toMemberTodoEntity(member, todoCategory);
+        Todo memberTodo = requestDto.toMemberTodoEntity(member, todoCategory);
         todoRepository.save(memberTodo);
         return TodoResponseDto.of(memberTodo);
+    }
+
+    public TodoGetResponseDto getOneTodo(Long memberId, Long todoId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        Todo todo = todoRepository.findByIdAndMemberId(todoId, member.getId())
+                .orElseThrow(() -> new PlanusException(NONE_TODO));
+
+        return TodoGetResponseDto.of(todo);
     }
 
     private void validateDate(LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/scs/planus/service/TodoService.java
+++ b/src/main/java/scs/planus/service/TodoService.java
@@ -16,6 +16,8 @@ import scs.planus.repository.MemberRepository;
 import scs.planus.repository.TodoRepository;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static scs.planus.common.response.CustomResponseStatus.*;
 
@@ -51,6 +53,16 @@ public class TodoService {
                 .orElseThrow(() -> new PlanusException(NONE_TODO));
 
         return TodoGetResponseDto.of(todo);
+    }
+
+    public List<TodoGetResponseDto> getDailyTodos(Long memberId, LocalDate date) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        List<Todo> todos = todoRepository.findAllByMemberIdAndDate(member.getId(), date);
+        return todos.stream()
+                .map(TodoGetResponseDto::of)
+                .collect(Collectors.toList());
     }
 
     private void validateDate(LocalDate startDate, LocalDate endDate) {


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 단건 Todo 조회 기능 구현
- 일별 Todos 조회 기능 구현

### :: 특이사항
- PathVariable을 통해 단건 Todo 조회 기능을 구현하였습니다.
- RequestParam을 이용하여 날짜 요청시, 일별 Todo 리스트를 조회하는 기능을 구현하였습니다.
- 이 후, fetch join 등의 최적화를 진행할 예정입니다.
