### PR TITLE
[Feat] QueryDsl을 이용한 Todo 조회 기능 구현

### DIFF
--- a/src/main/java/scs/planus/dto/todo/TodoDailyResponseDto.java
+++ b/src/main/java/scs/planus/dto/todo/TodoDailyResponseDto.java
@@ -28,7 +28,7 @@ public class TodoDailyResponseDto {
                 .title(todo.getTitle())
                 .startTime(todo.getStartTime())
                 .isGroupMemberTodo(todo.getGroup() != null)
-                .isPeriodTodo(todo.getStartDate() != todo.getEndDate())
+                .isPeriodTodo(todo.getEndDate().isAfter(todo.getStartDate()))
                 .hasDescription(todo.getDescription() != null)
                 .build();
     }

--- a/src/main/java/scs/planus/repository/todo/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/repository/todo/TodoQueryRepository.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import scs.planus.domain.todo.Todo;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 import static scs.planus.domain.QGroup.group;
@@ -29,6 +31,19 @@ public class TodoQueryRepository {
                 .join(todo.todoCategory, todoCategory).fetchJoin()
                 .where(todo.id.eq(todoId), memberIdEq(memberId))
                 .fetchOne());
+    }
+
+    public List<Todo> findDailyTodosByDate(Long memberId, LocalDate date) {
+        return queryFactory
+                .selectFrom(todo)
+                .join(todo.member, member)
+                .leftJoin(todo.group, group).fetchJoin()
+                .where(memberIdEq(memberId), dateBetween(date))
+                .fetch();
+    }
+
+    private BooleanExpression dateBetween(LocalDate date) {
+        return todo.startDate.loe(date).and(todo.endDate.goe(date));
     }
 
     private BooleanExpression memberIdEq(Long memberId) {

--- a/src/main/java/scs/planus/repository/todo/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/repository/todo/TodoQueryRepository.java
@@ -1,0 +1,37 @@
+package scs.planus.repository.todo;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import scs.planus.domain.todo.Todo;
+
+import java.util.Optional;
+
+import static scs.planus.domain.QGroup.group;
+import static scs.planus.domain.QMember.member;
+import static scs.planus.domain.QTodoCategory.todoCategory;
+import static scs.planus.domain.todo.QTodo.todo;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class TodoQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Optional<Todo> findOneTodoById(Long todoId, Long memberId){
+        return Optional.ofNullable(queryFactory
+                .selectFrom(todo)
+                .join(todo.member, member)
+                .leftJoin(todo.group, group).fetchJoin()
+                .join(todo.todoCategory, todoCategory).fetchJoin()
+                .where(todo.id.eq(todoId), memberIdEq(memberId))
+                .fetchOne());
+    }
+
+    private BooleanExpression memberIdEq(Long memberId) {
+        return member.id.eq(memberId);
+    }
+}

--- a/src/main/java/scs/planus/repository/todo/TodoRepository.java
+++ b/src/main/java/scs/planus/repository/todo/TodoRepository.java
@@ -1,4 +1,4 @@
-package scs.planus.repository;
+package scs.planus.repository.todo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/scs/planus/repository/todo/TodoRepository.java
+++ b/src/main/java/scs/planus/repository/todo/TodoRepository.java
@@ -7,10 +7,8 @@ import scs.planus.domain.todo.Todo;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
-    Optional<Todo> findByIdAndMemberId(Long id, Long memberId);
 
     @Query("select t from Todo t " +
             "join fetch t.member m " +

--- a/src/main/java/scs/planus/repository/todo/TodoRepository.java
+++ b/src/main/java/scs/planus/repository/todo/TodoRepository.java
@@ -1,18 +1,7 @@
 package scs.planus.repository.todo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import scs.planus.domain.todo.Todo;
 
-import java.time.LocalDate;
-import java.util.List;
-
 public interface TodoRepository extends JpaRepository<Todo, Long> {
-
-    @Query("select t from Todo t " +
-            "join fetch t.member m " +
-            "where m.id = :memberId and (t.startDate <= :date and t.endDate >= :date)")
-    List<Todo> findAllByMemberIdAndDate(@Param("memberId") Long memberId,
-                                        @Param("date") LocalDate date);
 }

--- a/src/main/java/scs/planus/service/TodoService.java
+++ b/src/main/java/scs/planus/service/TodoService.java
@@ -14,7 +14,8 @@ import scs.planus.dto.todo.TodoGetResponseDto;
 import scs.planus.dto.todo.TodoResponseDto;
 import scs.planus.repository.CategoryRepository;
 import scs.planus.repository.MemberRepository;
-import scs.planus.repository.TodoRepository;
+import scs.planus.repository.todo.TodoQueryRepository;
+import scs.planus.repository.todo.TodoRepository;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -31,6 +32,7 @@ public class TodoService {
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
     private final TodoRepository todoRepository;
+    private final TodoQueryRepository todoQueryRepository;
 
     @Transactional
     public TodoResponseDto createPrivateTodo(Long memberId, TodoCreateRequestDto requestDto) {
@@ -50,7 +52,7 @@ public class TodoService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
-        Todo todo = todoRepository.findByIdAndMemberId(todoId, member.getId())
+        Todo todo = todoQueryRepository.findOneTodoById(todoId, member.getId())
                 .orElseThrow(() -> new PlanusException(NONE_TODO));
 
         return TodoGetResponseDto.of(todo);
@@ -60,7 +62,7 @@ public class TodoService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
-        List<Todo> todos = todoRepository.findAllByMemberIdAndDate(member.getId(), date);
+        List<Todo> todos = todoQueryRepository.findDailyTodosByDate(member.getId(), date);
         List<TodoDailyResponseDto> responseDtos = todos.stream()
                 .map(TodoDailyResponseDto::of)
                 .collect(Collectors.toList());


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [X]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- QueryDsl을 이용한 Todo 조회 기능 구현
- 일별 Todo를 조회할 때, 기간 Todo가 아닌데도 true로 반영하던 점을 수정하였습니다.


### :: 특이사항
🔥 Todo 조회
- Todo 조회시, 연관관계에 있는 Group과 Category를 fetch join을 통해 한번에 끌어오도록 수정하였습니다.
- Todo에서 Member를 조회하지 않으므로 fetch join을 적용하지 않았습니다.
- 단건 Todo 조회
  - TodoCategory와 Group 정보를 사용합니다.
- 일별 Todo 조회
  - Group 정보를 사용합니다.

🔥 버그 수정
- LocalDate를 비교하기 위해, `isAfter()` 메서드를 사용하여 기간 Todo를 판별하도록 수정하였습니다.
