### PR TITLE
[Feat] Todo 삭제 기능 구현

### DIFF
--- a/src/main/java/scs/planus/controller/TodoController.java
+++ b/src/main/java/scs/planus/controller/TodoController.java
@@ -6,6 +6,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -56,6 +57,15 @@ public class TodoController {
         Long memberId = principalDetails.getId();
         List<TodoDailyResponseDto> responseDtos = todoService.getDailyTodos(memberId, date);
         return new BaseResponse<>(responseDtos);
+    }
+
+    @PatchMapping("/todos/{todoId}")
+    public BaseResponse<TodoGetResponseDto> updateTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                             @PathVariable Long todoId,
+                                                             @RequestBody TodoCreateRequestDto requestDto) {
+        Long memberId = principalDetails.getId();
+        TodoGetResponseDto responseDto = todoService.updateTodo(memberId, todoId, requestDto);
+        return new BaseResponse<>(responseDto);
     }
 
     @DeleteMapping("/todos/{todoId}")

--- a/src/main/java/scs/planus/controller/TodoController.java
+++ b/src/main/java/scs/planus/controller/TodoController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,5 +56,13 @@ public class TodoController {
         Long memberId = principalDetails.getId();
         List<TodoDailyResponseDto> responseDtos = todoService.getDailyTodos(memberId, date);
         return new BaseResponse<>(responseDtos);
+    }
+
+    @DeleteMapping("/todos/{todoId}")
+    public BaseResponse<TodoResponseDto> deleteTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                    @PathVariable Long todoId) {
+        Long memberId = principalDetails.getId();
+        TodoResponseDto responseDto = todoService.deleteTodo(memberId, todoId);
+        return new BaseResponse<>(responseDto);
     }
 }

--- a/src/main/java/scs/planus/domain/todo/Todo.java
+++ b/src/main/java/scs/planus/domain/todo/Todo.java
@@ -71,4 +71,18 @@ public class Todo extends BaseTimeEntity {
         this.member = member;
         this.group = group;
     }
+
+    public void update(String title, String description, LocalTime startTime, LocalDate startDate, LocalDate endDate,
+                       TodoCategory todoCategory, Group group) {
+        this.title = title;
+        this.description = description;
+        this.startTime = startTime;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        if (endDate == null) {
+            this.endDate = startDate;
+        }
+        this.todoCategory = todoCategory;
+        this.group = group;
+    }
 }

--- a/src/main/java/scs/planus/service/TodoService.java
+++ b/src/main/java/scs/planus/service/TodoService.java
@@ -70,6 +70,18 @@ public class TodoService {
         return responseDtos;
     }
 
+    @Transactional
+    public TodoResponseDto deleteTodo(Long memberId, Long todoId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        Todo todo = todoQueryRepository.findOneTodoById(todoId, member.getId())
+                .orElseThrow(() -> new PlanusException(NONE_TODO));
+
+        todoRepository.delete(todo);
+        return TodoResponseDto.of(todo);
+    }
+
     private void validateDate(LocalDate startDate, LocalDate endDate) {
         if (endDate != null) {
             if (startDate.isAfter(endDate)) {

--- a/src/main/java/scs/planus/service/TodoService.java
+++ b/src/main/java/scs/planus/service/TodoService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import scs.planus.common.exception.PlanusException;
+import scs.planus.domain.Group;
 import scs.planus.domain.Member;
 import scs.planus.domain.TodoCategory;
 import scs.planus.domain.todo.Todo;
@@ -13,6 +14,7 @@ import scs.planus.dto.todo.TodoDailyResponseDto;
 import scs.planus.dto.todo.TodoGetResponseDto;
 import scs.planus.dto.todo.TodoResponseDto;
 import scs.planus.repository.CategoryRepository;
+import scs.planus.repository.GroupRepository;
 import scs.planus.repository.MemberRepository;
 import scs.planus.repository.todo.TodoQueryRepository;
 import scs.planus.repository.todo.TodoRepository;
@@ -31,6 +33,7 @@ public class TodoService {
 
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
+    private final GroupRepository groupRepository;
     private final TodoRepository todoRepository;
     private final TodoQueryRepository todoQueryRepository;
 
@@ -71,6 +74,26 @@ public class TodoService {
     }
 
     @Transactional
+    public TodoGetResponseDto updateTodo(Long memberId, Long todoId, TodoCreateRequestDto requestDto) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        Todo todo = todoQueryRepository.findOneTodoById(todoId, member.getId())
+                .orElseThrow(() -> new PlanusException(NONE_TODO));
+
+        TodoCategory todoCategory = categoryRepository.findById(requestDto.getCategoryId())
+                .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
+
+        Group group = getGroup(requestDto.getGroupId());
+
+        validateDate(requestDto.getStartDate(), requestDto.getEndDate());
+        todo.update(requestDto.getTitle(), requestDto.getDescription(), requestDto.getStartTime(),
+                requestDto.getStartDate(), requestDto.getEndDate(), todoCategory, group);
+
+        return TodoGetResponseDto.of(todo);
+    }
+
+    @Transactional
     public TodoResponseDto deleteTodo(Long memberId, Long todoId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
@@ -88,5 +111,14 @@ public class TodoService {
                 throw new PlanusException(INVALID_DATE);
             }
         }
+    }
+
+    private Group getGroup(Long groupId) {
+        if (groupId == null) {
+            return null;
+        }
+        // TODO : 그룹 가입 이후, 현재 멤버가 해당 그룹에 가입했는지를 체크해야함. 아래 방식은 가입하지 않더라도 그룹 지정 가능한 방식
+        return groupRepository.findById(groupId)
+                    .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
     }
 }


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- Todo 삭제 기능 구현
- Todo 변경 기능 구현

### :: 특이사항

**Todo 삭제**
- Todo를 find 할때, `todoQueryRepository.findOneTodoById()`가 호출됩니다.
  - Todo를 단순 삭제 시, 연관관계를 모두 가져오는게 맞는 방법인가 싶습니다.
  - 🔥 TodoRepository에 단순 memberId와 todoId를 토대로 find하여 받아오도록 구현한다면 조금의 성능이라도 최적화할 수 있을 것 같습니다. (논의 필요!)
