### PR TITLE
[Refactor] Group 조회 API 코드리뷰 반영

### DIFF
--- a/src/main/java/scs/planus/domain/group/entity/Group.java
+++ b/src/main/java/scs/planus/domain/group/entity/Group.java
@@ -3,10 +3,13 @@ package scs.planus.domain.group.entity;
 import lombok.*;
 import scs.planus.domain.BaseTimeEntity;
 import scs.planus.domain.Status;
+import scs.planus.global.exception.PlanusException;
 
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+
+import static scs.planus.global.exception.CustomExceptionStatus.NOT_EXIST_LEADER;
 
 @Entity
 @Getter
@@ -60,5 +63,13 @@ public class Group extends BaseTimeEntity {
                 .scope( GroupScope.PUBLIC )
                 .status( Status.ACTIVE )
                 .build();
+    }
+
+    public String getLeaderName() {
+        return this.getGroupMembers().stream()
+                .filter( GroupMember::isLeader )
+                .findFirst()
+                .orElseThrow(() -> new PlanusException(NOT_EXIST_LEADER))
+                .getMember().getNickname();
     }
 }

--- a/src/main/java/scs/planus/domain/group/entity/GroupMember.java
+++ b/src/main/java/scs/planus/domain/group/entity/GroupMember.java
@@ -45,7 +45,7 @@ public class GroupMember extends BaseTimeEntity {
         if (group != null) { group.getGroupMembers().add(this); }
     }
 
-    public static GroupMember creatGroupMemberLeader(Member member, Group group ) {
+    public static GroupMember creatGroupLeader(Member member, Group group ) {
         return GroupMember.builder()
                 .leader(true)
                 .todoAuthority(true)

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -1,17 +1,7 @@
 package scs.planus.domain.group.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
 
-import java.util.Optional;
-
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
-    @Query("select gm " +
-            "from GroupMember gm " +
-            "join fetch gm.member m " +
-            "where gm.group= :group " +
-            "and gm.leader= true ")
-    Optional<GroupMember> findLeaderByGroup(Group group);
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
@@ -9,5 +9,5 @@ import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
     @Query("select g from Group g join fetch g.groupMembers gm where g.id= :groupId")
-    Optional<Group> findWithGroupMemberById(@Param("groupId") Long aLong);
+    Optional<Group> findWithGroupMemberById(@Param("groupId") Long groupId);
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
@@ -8,6 +8,9 @@ import scs.planus.domain.group.entity.Group;
 import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
-    @Query("select g from Group g join fetch g.groupMembers gm where g.id= :groupId")
+    @Query("select distinct g " +
+            "from Group g " +
+            "join fetch g.groupMembers gm " +
+            "where g.id= :groupId")
     Optional<Group> findWithGroupMemberById(@Param("groupId") Long groupId);
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
@@ -1,7 +1,13 @@
 package scs.planus.domain.group.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import scs.planus.domain.group.entity.Group;
 
+import java.util.Optional;
+
 public interface GroupRepository extends JpaRepository<Group, Long> {
+    @Query("select g from Group g join fetch g.groupMembers gm where g.id= :groupId")
+    Optional<Group> findWithGroupMemberById(@Param("groupId") Long aLong);
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupTagRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupTagRepository.java
@@ -13,5 +13,5 @@ public interface GroupTagRepository extends JpaRepository<GroupTag, Long> {
             "from GroupTag gt " +
             "join fetch gt.tag t " +
             "where gt.group= :group ")
-    List<GroupTag> findAllByGroupId(@Param("group") Group group);
+    List<GroupTag> findAllByGroup(@Param("group") Group group);
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupTagRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupTagRepository.java
@@ -2,6 +2,7 @@ package scs.planus.domain.group.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupTag;
 
@@ -12,5 +13,5 @@ public interface GroupTagRepository extends JpaRepository<GroupTag, Long> {
             "from GroupTag gt " +
             "join fetch gt.tag t " +
             "where gt.group= :group ")
-    List<GroupTag> findAllByGroupId(Group group);
+    List<GroupTag> findAllByGroupId(@Param("group") Group group);
 }

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -67,7 +67,7 @@ public class GroupService {
         String leaderName = group.getLeaderName();
 
         // 그룹 테그 조회 후 List<dto>로 변경
-        List<GroupTag> groupTags = groupTagRepository.findAllByGroupId( group );
+        List<GroupTag> groupTags = groupTagRepository.findAllByGroup( group );
         List<GroupTagResponseDto> groupTagResponseDtos =
                 groupTags.stream()
                         .map( GroupTagResponseDto::of )

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -51,7 +51,7 @@ public class GroupService {
         List<Tag> tagList = tagService.transformToTag( requestDto.getTagList() );
         GroupTag.create( group, tagList );
 
-        GroupMember.creatGroupMemberLeader( member, group );
+        GroupMember.creatGroupLeader( member, group );
 
         Group saveGroup = groupRepository.save( group );
 


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 최초로 `group`을 조회할 때,`findWithGroupMemberById()` 로 조회합니다.
- `findWithGroupMemberById()` 는 `GroupMember` 를 `fetch join` 하여 함께 가져옵니다.
- `Group` 내에 내장함수 `getLeaderName()` 를 구현하였습니다.

### :: 특이사항
- `GroupMember` 조회를 `fetch join` 으로 최적화 하여 `N + 1` 문제를 해결하고자 했습니다.
- `getGroup` 메소드의 총 쿼리 수를 `3` 으로 최소화 하였습니다.

1. `group` 조회 쿼리 (`groupMember` 와 함께)
2. `LeaderMember` 의 `Nickname`` 조회 쿼리
3. `tag` 와 `groupTag` 조회 쿼리
