### PR TITLE
[Feat] 달별 Todo 조회 기능 구현, Todo 완료 체크 기능 구현

### DIFF
--- a/src/main/java/scs/planus/domain/todo/controller/TodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoController.java
@@ -63,7 +63,7 @@ public class TodoController {
 
     @GetMapping("/todos")
     public BaseResponse<TodoDailyResponseDto> getDailyTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                  @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+                                                            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         Long memberId = principalDetails.getId();
         TodoDailyResponseDto responseDtos = todoService.getDailyTodos(memberId, date);
         return new BaseResponse<>(responseDtos);

--- a/src/main/java/scs/planus/domain/todo/controller/TodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import scs.planus.domain.todo.dto.TodoRequestDto;
 import scs.planus.domain.todo.dto.TodoDailyResponseDto;
-import scs.planus.domain.todo.dto.TodoGetResponseDto;
+import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
 import scs.planus.domain.todo.dto.TodoPeriodResponseDto;
 import scs.planus.domain.todo.dto.TodoResponseDto;
 import scs.planus.domain.todo.service.TodoService;
@@ -45,10 +45,10 @@ public class TodoController {
     }
 
     @GetMapping("/todos/{todoId}")
-    public BaseResponse<TodoGetResponseDto> getTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                          @PathVariable Long todoId) {
+    public BaseResponse<TodoDetailsResponseDto> getTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                              @PathVariable Long todoId) {
         Long memberId = principalDetails.getId();
-        TodoGetResponseDto responseDto = todoService.getOneTodo(memberId, todoId);
+        TodoDetailsResponseDto responseDto = todoService.getOneTodo(memberId, todoId);
         return new BaseResponse<>(responseDto);
     }
 
@@ -70,20 +70,20 @@ public class TodoController {
     }
 
     @GetMapping("/todos")
-    public BaseResponse<List<TodoGetResponseDto>> getTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                           @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
-                                                           @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to){
+    public BaseResponse<List<TodoDetailsResponseDto>> getTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                               @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
+                                                               @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to){
         Long memberId = principalDetails.getId();
-        List<TodoGetResponseDto> responseDtos = todoService.getPeriodDetailTodos(memberId, from, to);
+        List<TodoDetailsResponseDto> responseDtos = todoService.getPeriodDetailTodos(memberId, from, to);
         return new BaseResponse<>(responseDtos);
     }
 
     @PatchMapping("/todos/{todoId}")
-    public BaseResponse<TodoGetResponseDto> updateTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                             @PathVariable Long todoId,
-                                                             @RequestBody TodoRequestDto requestDto) {
+    public BaseResponse<TodoDetailsResponseDto> updateTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                 @PathVariable Long todoId,
+                                                                 @RequestBody TodoRequestDto requestDto) {
         Long memberId = principalDetails.getId();
-        TodoGetResponseDto responseDto = todoService.updateTodo(memberId, todoId, requestDto);
+        TodoDetailsResponseDto responseDto = todoService.updateTodo(memberId, todoId, requestDto);
         return new BaseResponse<>(responseDto);
     }
 

--- a/src/main/java/scs/planus/domain/todo/controller/TodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoController.java
@@ -69,6 +69,15 @@ public class TodoController {
         return new BaseResponse<>(responseDtos);
     }
 
+    @GetMapping("/todos")
+    public BaseResponse<List<TodoGetResponseDto>> getTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                           @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
+                                                           @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to){
+        Long memberId = principalDetails.getId();
+        List<TodoGetResponseDto> responseDtos = todoService.getPeriodDetailTodos(memberId, from, to);
+        return new BaseResponse<>(responseDtos);
+    }
+
     @PatchMapping("/todos/{todoId}")
     public BaseResponse<TodoGetResponseDto> updateTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                              @PathVariable Long todoId,

--- a/src/main/java/scs/planus/domain/todo/controller/TodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoController.java
@@ -86,7 +86,7 @@ public class TodoController {
         return new BaseResponse<>(responseDto);
     }
 
-    @PatchMapping("/todos/{todoId}/completion")
+    @PostMapping("/todos/{todoId}/completion")
     public BaseResponse<TodoResponseDto> completeTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                       @PathVariable Long todoId) {
         Long memberId = principalDetails.getId();

--- a/src/main/java/scs/planus/domain/todo/controller/TodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import scs.planus.domain.todo.dto.TodoCreateRequestDto;
+import scs.planus.domain.todo.dto.TodoRequestDto;
 import scs.planus.domain.todo.dto.TodoDailyResponseDto;
 import scs.planus.domain.todo.dto.TodoGetResponseDto;
 import scs.planus.domain.todo.dto.TodoPeriodResponseDto;
@@ -35,7 +35,7 @@ public class TodoController {
 
     @PostMapping("/todos")
     public BaseResponse<TodoResponseDto> createTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                    @RequestBody TodoCreateRequestDto requestDto) {
+                                                    @RequestBody TodoRequestDto requestDto) {
         Long memberId = principalDetails.getId();
         if (requestDto.getGroupId() == null) {
             TodoResponseDto responseDto = todoService.createPrivateTodo(memberId, requestDto);
@@ -72,7 +72,7 @@ public class TodoController {
     @PatchMapping("/todos/{todoId}")
     public BaseResponse<TodoGetResponseDto> updateTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                              @PathVariable Long todoId,
-                                                             @RequestBody TodoCreateRequestDto requestDto) {
+                                                             @RequestBody TodoRequestDto requestDto) {
         Long memberId = principalDetails.getId();
         TodoGetResponseDto responseDto = todoService.updateTodo(memberId, todoId, requestDto);
         return new BaseResponse<>(responseDto);

--- a/src/main/java/scs/planus/domain/todo/controller/TodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoController.java
@@ -56,7 +56,6 @@ public class TodoController {
     public BaseResponse<List<TodoPeriodResponseDto>> getPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                     @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
                                                                     @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
-        log.info("from~to={}~{}", from, to);
         Long memberId = principalDetails.getId();
         List<TodoPeriodResponseDto> responseDtos = todoService.getPeriodTodos(memberId, from, to);
         return new BaseResponse<>(responseDtos);

--- a/src/main/java/scs/planus/domain/todo/controller/TodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoController.java
@@ -62,10 +62,10 @@ public class TodoController {
     }
 
     @GetMapping("/todos")
-    public BaseResponse<List<TodoDailyResponseDto>> getDailyTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+    public BaseResponse<TodoDailyResponseDto> getDailyTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                   @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         Long memberId = principalDetails.getId();
-        List<TodoDailyResponseDto> responseDtos = todoService.getDailyTodos(memberId, date);
+        TodoDailyResponseDto responseDtos = todoService.getDailyTodos(memberId, date);
         return new BaseResponse<>(responseDtos);
     }
 

--- a/src/main/java/scs/planus/domain/todo/controller/TodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoController.java
@@ -85,4 +85,12 @@ public class TodoController {
         TodoResponseDto responseDto = todoService.deleteTodo(memberId, todoId);
         return new BaseResponse<>(responseDto);
     }
+
+    @PatchMapping("/todos/{todoId}/completion")
+    public BaseResponse<TodoResponseDto> completeTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                      @PathVariable Long todoId) {
+        Long memberId = principalDetails.getId();
+        TodoResponseDto responseDto = todoService.checkCompletion(memberId, todoId);
+        return new BaseResponse<>(responseDto);
+    }
 }

--- a/src/main/java/scs/planus/domain/todo/controller/TodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoController.java
@@ -13,13 +13,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import scs.planus.global.auth.entity.PrincipalDetails;
-import scs.planus.global.common.response.BaseResponse;
 import scs.planus.domain.todo.dto.TodoCreateRequestDto;
 import scs.planus.domain.todo.dto.TodoDailyResponseDto;
 import scs.planus.domain.todo.dto.TodoGetResponseDto;
+import scs.planus.domain.todo.dto.TodoPeriodResponseDto;
 import scs.planus.domain.todo.dto.TodoResponseDto;
 import scs.planus.domain.todo.service.TodoService;
+import scs.planus.global.auth.entity.PrincipalDetails;
+import scs.planus.global.common.response.BaseResponse;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -49,6 +50,16 @@ public class TodoController {
         Long memberId = principalDetails.getId();
         TodoGetResponseDto responseDto = todoService.getOneTodo(memberId, todoId);
         return new BaseResponse<>(responseDto);
+    }
+
+    @GetMapping("/todos/period")
+    public BaseResponse<List<TodoPeriodResponseDto>> getPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                    @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
+                                                                    @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
+        log.info("from~to={}~{}", from, to);
+        Long memberId = principalDetails.getId();
+        List<TodoPeriodResponseDto> responseDtos = todoService.getPeriodTodos(memberId, from, to);
+        return new BaseResponse<>(responseDtos);
     }
 
     @GetMapping("/todos")

--- a/src/main/java/scs/planus/domain/todo/controller/TodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoController.java
@@ -86,7 +86,7 @@ public class TodoController {
         return new BaseResponse<>(responseDto);
     }
 
-    @PostMapping("/todos/{todoId}/completion")
+    @PatchMapping("/todos/{todoId}/completion")
     public BaseResponse<TodoResponseDto> completeTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                       @PathVariable Long todoId) {
         Long memberId = principalDetails.getId();

--- a/src/main/java/scs/planus/domain/todo/controller/TodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoController.java
@@ -61,7 +61,7 @@ public class TodoController {
         return new BaseResponse<>(responseDtos);
     }
 
-    @GetMapping("/todos")
+    @GetMapping("/todos/daily")
     public BaseResponse<TodoDailyResponseDto> getDailyTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         Long memberId = principalDetails.getId();

--- a/src/main/java/scs/planus/domain/todo/dto/TodoDailyDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoDailyDto.java
@@ -9,6 +9,7 @@ import scs.planus.domain.todo.entity.Todo;
 public class TodoDailyDto {
 
     private Long todoId;
+    private Long categoryId;
     private String title;
 
     private Boolean isGroupMemberTodo;
@@ -19,6 +20,7 @@ public class TodoDailyDto {
     public static TodoDailyDto of(Todo todo) {
         return TodoDailyDto.builder()
                 .todoId(todo.getId())
+                .categoryId(todo.getTodoCategory().getId())
                 .title(todo.getTitle())
                 .isGroupMemberTodo(todo.getGroup() != null)
                 .isPeriodTodo(todo.getEndDate().isAfter(todo.getStartDate()))

--- a/src/main/java/scs/planus/domain/todo/dto/TodoDailyDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoDailyDto.java
@@ -1,0 +1,29 @@
+package scs.planus.domain.todo.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.todo.entity.Todo;
+
+@Getter
+@Builder
+public class TodoDailyDto {
+
+    private Long todoId;
+    private String title;
+
+    private Boolean isGroupMemberTodo;
+    private Boolean isPeriodTodo;
+    private Boolean hasDescription;
+    private Boolean isCompleted;
+
+    public static TodoDailyDto of(Todo todo) {
+        return TodoDailyDto.builder()
+                .todoId(todo.getId())
+                .title(todo.getTitle())
+                .isGroupMemberTodo(todo.getGroup() != null)
+                .isPeriodTodo(todo.getEndDate().isAfter(todo.getStartDate()))
+                .hasDescription(todo.getDescription() != null)
+                .isCompleted(todo.isCompletion())
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/todo/dto/TodoDailyResponseDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoDailyResponseDto.java
@@ -1,35 +1,22 @@
 package scs.planus.domain.todo.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.ToString;
-import scs.planus.domain.todo.entity.Todo;
 
-import java.time.LocalTime;
+import java.util.List;
 
 @Getter
 @Builder
-@ToString
 public class TodoDailyResponseDto {
 
-    private Long todoId;
-    private String title;
-    @JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING)
-    private LocalTime startTime;
+    private List<TodoDailyScheduleDto> dailySchedules;
+    private List<TodoDailyDto> dailyTodos;
 
-    private Boolean isGroupMemberTodo;
-    private Boolean isPeriodTodo;
-    private Boolean hasDescription;
-
-    public static TodoDailyResponseDto of(Todo todo) {
+    public static TodoDailyResponseDto of(List<TodoDailyScheduleDto> todoDailyScheduleDtos,
+                                          List<TodoDailyDto> todoDailyDtos) {
         return TodoDailyResponseDto.builder()
-                .todoId(todo.getId())
-                .title(todo.getTitle())
-                .startTime(todo.getStartTime())
-                .isGroupMemberTodo(todo.getGroup() != null)
-                .isPeriodTodo(todo.getEndDate().isAfter(todo.getStartDate()))
-                .hasDescription(todo.getDescription() != null)
+                .dailySchedules(todoDailyScheduleDtos)
+                .dailyTodos(todoDailyDtos)
                 .build();
     }
 }

--- a/src/main/java/scs/planus/domain/todo/dto/TodoDailyScheduleDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoDailyScheduleDto.java
@@ -12,6 +12,7 @@ import java.time.LocalTime;
 public class TodoDailyScheduleDto {
 
     private Long todoId;
+    private Long categoryId;
     private String title;
     @JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING)
     private LocalTime startTime;
@@ -24,6 +25,7 @@ public class TodoDailyScheduleDto {
     public static TodoDailyScheduleDto of(Todo todo) {
         return TodoDailyScheduleDto.builder()
                 .todoId(todo.getId())
+                .categoryId(todo.getTodoCategory().getId())
                 .title(todo.getTitle())
                 .startTime(todo.getStartTime())
                 .isGroupMemberTodo(todo.getGroup() != null)

--- a/src/main/java/scs/planus/domain/todo/dto/TodoDailyScheduleDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoDailyScheduleDto.java
@@ -1,0 +1,35 @@
+package scs.planus.domain.todo.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.todo.entity.Todo;
+
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class TodoDailyScheduleDto {
+
+    private Long todoId;
+    private String title;
+    @JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING)
+    private LocalTime startTime;
+
+    private Boolean isGroupMemberTodo;
+    private Boolean isPeriodTodo;
+    private Boolean hasDescription;
+    private Boolean isCompleted;
+
+    public static TodoDailyScheduleDto of(Todo todo) {
+        return TodoDailyScheduleDto.builder()
+                .todoId(todo.getId())
+                .title(todo.getTitle())
+                .startTime(todo.getStartTime())
+                .isGroupMemberTodo(todo.getGroup() != null)
+                .isPeriodTodo(todo.getEndDate().isAfter(todo.getStartDate()))
+                .hasDescription(todo.getDescription() != null)
+                .isCompleted(todo.isCompletion())
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/todo/dto/TodoDetailsResponseDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoDetailsResponseDto.java
@@ -10,7 +10,7 @@ import java.time.LocalTime;
 
 @Getter
 @Builder
-public class TodoGetResponseDto {
+public class TodoDetailsResponseDto {
 
     private Long todoId;
     private String title;
@@ -25,8 +25,8 @@ public class TodoGetResponseDto {
     private LocalTime startTime;
     private String description;
 
-    public static TodoGetResponseDto of(Todo todo) {
-        return TodoGetResponseDto.builder()
+    public static TodoDetailsResponseDto of(Todo todo) {
+        return TodoDetailsResponseDto.builder()
                 .todoId(todo.getId())
                 .title(todo.getTitle())
                 .categoryId(todo.getTodoCategory().getId())

--- a/src/main/java/scs/planus/domain/todo/dto/TodoGetResponseDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoGetResponseDto.java
@@ -14,8 +14,8 @@ public class TodoGetResponseDto {
 
     private Long todoId;
     private String title;
-    private String categoryName;
-    private String groupName;
+    private Long categoryId;
+    private Long groupId;
 
     @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
     private LocalDate startDate;
@@ -29,8 +29,8 @@ public class TodoGetResponseDto {
         return TodoGetResponseDto.builder()
                 .todoId(todo.getId())
                 .title(todo.getTitle())
-                .categoryName(todo.getTodoCategory().getName())
-                .groupName(todo.getGroup() == null ? null : todo.getGroup().getName())
+                .categoryId(todo.getTodoCategory().getId())
+                .groupId(todo.getGroup() == null ? null : todo.getGroup().getId())
                 .startDate(todo.getStartDate())
                 .endDate(todo.getEndDate())
                 .startTime(todo.getStartTime())

--- a/src/main/java/scs/planus/domain/todo/dto/TodoGetResponseDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoGetResponseDto.java
@@ -12,6 +12,7 @@ import java.time.LocalTime;
 @Builder
 public class TodoGetResponseDto {
 
+    private Long id;
     private String title;
     private String categoryName;
     private String groupName;
@@ -26,6 +27,7 @@ public class TodoGetResponseDto {
 
     public static TodoGetResponseDto of(Todo todo) {
         return TodoGetResponseDto.builder()
+                .id(todo.getId())
                 .title(todo.getTitle())
                 .categoryName(todo.getTodoCategory().getName())
                 .groupName(todo.getGroup() == null ? null : todo.getGroup().getName())

--- a/src/main/java/scs/planus/domain/todo/dto/TodoGetResponseDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoGetResponseDto.java
@@ -12,7 +12,7 @@ import java.time.LocalTime;
 @Builder
 public class TodoGetResponseDto {
 
-    private Long id;
+    private Long todoId;
     private String title;
     private String categoryName;
     private String groupName;
@@ -27,7 +27,7 @@ public class TodoGetResponseDto {
 
     public static TodoGetResponseDto of(Todo todo) {
         return TodoGetResponseDto.builder()
-                .id(todo.getId())
+                .todoId(todo.getId())
                 .title(todo.getTitle())
                 .categoryName(todo.getTodoCategory().getName())
                 .groupName(todo.getGroup() == null ? null : todo.getGroup().getName())

--- a/src/main/java/scs/planus/domain/todo/dto/TodoPeriodResponseDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoPeriodResponseDto.java
@@ -1,0 +1,29 @@
+package scs.planus.domain.todo.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.todo.entity.Todo;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+public class TodoPeriodResponseDto {
+
+    private Long id;
+    private String title;
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
+    private LocalDate startDate;
+    @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
+    private LocalDate endDate;
+
+    public static TodoPeriodResponseDto of(Todo todo) {
+        return TodoPeriodResponseDto.builder()
+                .id(todo.getId())
+                .title(todo.getTitle())
+                .startDate(todo.getStartDate())
+                .endDate(todo.getEndDate())
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/todo/dto/TodoPeriodResponseDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoPeriodResponseDto.java
@@ -11,7 +11,8 @@ import java.time.LocalDate;
 @Builder
 public class TodoPeriodResponseDto {
 
-    private Long id;
+    private Long todoId;
+    private Long categoryId;
     private String title;
     @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
     private LocalDate startDate;
@@ -20,7 +21,8 @@ public class TodoPeriodResponseDto {
 
     public static TodoPeriodResponseDto of(Todo todo) {
         return TodoPeriodResponseDto.builder()
-                .id(todo.getId())
+                .todoId(todo.getId())
+                .categoryId(todo.getTodoCategory().getId())
                 .title(todo.getTitle())
                 .startDate(todo.getStartDate())
                 .endDate(todo.getEndDate())

--- a/src/main/java/scs/planus/domain/todo/dto/TodoRequestDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoRequestDto.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Getter
-public class TodoCreateRequestDto {
+public class TodoRequestDto {
 
     @NotBlank(message = "투두 제목을 입력해주세요.")
     @Size(max = 20, message = "투두 제목은 최대 20글자입니다.")

--- a/src/main/java/scs/planus/domain/todo/entity/Todo.java
+++ b/src/main/java/scs/planus/domain/todo/entity/Todo.java
@@ -88,7 +88,7 @@ public class Todo extends BaseTimeEntity {
         this.group = group;
     }
 
-    public void complete() {
+    public void changeCompletion() {
         this.completion = !this.completion;
     }
 }

--- a/src/main/java/scs/planus/domain/todo/entity/Todo.java
+++ b/src/main/java/scs/planus/domain/todo/entity/Todo.java
@@ -43,6 +43,8 @@ public class Todo extends BaseTimeEntity {
 
     private boolean showDDay;
 
+    private boolean completion;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "todo_category_id")
     private TodoCategory todoCategory;

--- a/src/main/java/scs/planus/domain/todo/entity/Todo.java
+++ b/src/main/java/scs/planus/domain/todo/entity/Todo.java
@@ -87,4 +87,8 @@ public class Todo extends BaseTimeEntity {
         this.todoCategory = todoCategory;
         this.group = group;
     }
+
+    public void complete() {
+        this.completion = !this.completion;
+    }
 }

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -48,6 +48,7 @@ public class TodoQueryRepository {
                 .join(todo.member, member)
                 .leftJoin(todo.group, group).fetchJoin()
                 .where(memberIdEq(memberId), dateBetween(date))
+                .orderBy(todo.startTime.asc())
                 .fetch();
     }
 

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -11,10 +11,10 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import static scs.planus.domain.QGroup.group;
-import static scs.planus.domain.QMember.member;
-import static scs.planus.domain.QTodoCategory.todoCategory;
-import static scs.planus.domain.todo.QTodo.todo;
+import static scs.planus.domain.category.entity.QTodoCategory.todoCategory;
+import static scs.planus.domain.group.entity.QGroup.group;
+import static scs.planus.domain.member.entity.QMember.member;
+import static scs.planus.domain.todo.entity.QTodo.todo;
 
 @Repository
 @RequiredArgsConstructor

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -54,6 +54,17 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
+    public List<Todo> findPeriodDetailTodosByDate(Long memberId, LocalDate from, LocalDate to) {
+        return queryFactory
+                .selectFrom(todo)
+                .join(todo.member, member)
+                .leftJoin(todo.group, group).fetchJoin()
+                .join(todo.todoCategory, todoCategory).fetchJoin()
+                .where(memberIdEq(memberId), periodBetween(from, to))
+                .orderBy(todo.startDate.asc())
+                .fetch();
+    }
+
     private BooleanExpression periodBetween(LocalDate from, LocalDate to) {
         return todo.startDate.between(from, to).or(todo.endDate.between(from, to));
     }

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -23,7 +23,7 @@ public class TodoQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public Optional<Todo> findOneTodoById(Long todoId, Long memberId){
+    public Optional<Todo> findOneTodoById(Long todoId, Long memberId) {
         return Optional.ofNullable(queryFactory
                 .selectFrom(todo)
                 .join(todo.member, member)
@@ -33,6 +33,15 @@ public class TodoQueryRepository {
                 .fetchOne());
     }
 
+    public List<Todo> findPeriodTodosByDate(Long memberId, LocalDate from, LocalDate to) {
+        return queryFactory
+                .selectFrom(todo)
+                .join(todo.member, member).fetchJoin()
+                .where(memberIdEq(memberId), periodBetween(from, to))
+                .orderBy(todo.startDate.asc())
+                .fetch();
+    }
+
     public List<Todo> findDailyTodosByDate(Long memberId, LocalDate date) {
         return queryFactory
                 .selectFrom(todo)
@@ -40,6 +49,10 @@ public class TodoQueryRepository {
                 .leftJoin(todo.group, group).fetchJoin()
                 .where(memberIdEq(memberId), dateBetween(date))
                 .fetch();
+    }
+
+    private BooleanExpression periodBetween(LocalDate from, LocalDate to) {
+        return todo.startDate.between(from, to).or(todo.endDate.between(from, to));
     }
 
     private BooleanExpression dateBetween(LocalDate date) {

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -37,6 +37,7 @@ public class TodoQueryRepository {
         return queryFactory
                 .selectFrom(todo)
                 .join(todo.member, member).fetchJoin()
+                .join(todo.todoCategory, todoCategory).fetchJoin()
                 .where(memberIdEq(memberId), periodBetween(from, to))
                 .orderBy(todo.startDate.asc())
                 .fetch();
@@ -47,6 +48,7 @@ public class TodoQueryRepository {
                 .selectFrom(todo)
                 .join(todo.member, member)
                 .leftJoin(todo.group, group).fetchJoin()
+                .join(todo.todoCategory, todoCategory).fetchJoin()
                 .where(memberIdEq(memberId), dateBetween(date))
                 .orderBy(todo.startTime.asc())
                 .fetch();

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -54,7 +54,7 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
-    public List<Todo> findPeriodDetailTodosByDate(Long memberId, LocalDate from, LocalDate to) {
+    public List<Todo> findPeriodTodosDetailByDate(Long memberId, LocalDate from, LocalDate to) {
         return queryFactory
                 .selectFrom(todo)
                 .join(todo.member, member)

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -14,7 +14,7 @@ import scs.planus.domain.todo.dto.TodoRequestDto;
 import scs.planus.domain.todo.dto.TodoDailyDto;
 import scs.planus.domain.todo.dto.TodoDailyResponseDto;
 import scs.planus.domain.todo.dto.TodoDailyScheduleDto;
-import scs.planus.domain.todo.dto.TodoGetResponseDto;
+import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
 import scs.planus.domain.todo.dto.TodoPeriodResponseDto;
 import scs.planus.domain.todo.dto.TodoResponseDto;
 import scs.planus.domain.todo.entity.Todo;
@@ -54,14 +54,14 @@ public class TodoService {
         return TodoResponseDto.of(memberTodo);
     }
 
-    public TodoGetResponseDto getOneTodo(Long memberId, Long todoId) {
+    public TodoDetailsResponseDto getOneTodo(Long memberId, Long todoId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
         Todo todo = todoQueryRepository.findOneTodoById(todoId, member.getId())
                 .orElseThrow(() -> new PlanusException(NONE_TODO));
 
-        return TodoGetResponseDto.of(todo);
+        return TodoDetailsResponseDto.of(todo);
     }
 
     public List<TodoPeriodResponseDto> getPeriodTodos(Long memberId, LocalDate from, LocalDate to) {
@@ -87,21 +87,21 @@ public class TodoService {
         return TodoDailyResponseDto.of(todoDailyScheduleDtos, todoDailyDtos);
     }
 
-    public List<TodoGetResponseDto> getPeriodDetailTodos(Long memberId, LocalDate from, LocalDate to) {
+    public List<TodoDetailsResponseDto> getPeriodDetailTodos(Long memberId, LocalDate from, LocalDate to) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
         validateDate(from, to);
         List<Todo> todos = todoQueryRepository.findPeriodDetailTodosByDate(member.getId(), from, to);
-        List<TodoGetResponseDto> responseDtos = todos.stream()
-                .map(TodoGetResponseDto::of)
+        List<TodoDetailsResponseDto> responseDtos = todos.stream()
+                .map(TodoDetailsResponseDto::of)
                 .collect(Collectors.toList());
 
         return responseDtos;
     }
 
     @Transactional
-    public TodoGetResponseDto updateTodo(Long memberId, Long todoId, TodoRequestDto requestDto) {
+    public TodoDetailsResponseDto updateTodo(Long memberId, Long todoId, TodoRequestDto requestDto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
@@ -117,7 +117,7 @@ public class TodoService {
         todo.update(requestDto.getTitle(), requestDto.getDescription(), requestDto.getStartTime(),
                 requestDto.getStartDate(), requestDto.getEndDate(), todoCategory, group);
 
-        return TodoGetResponseDto.of(todo);
+        return TodoDetailsResponseDto.of(todo);
     }
 
     @Transactional

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -87,6 +87,19 @@ public class TodoService {
         return TodoDailyResponseDto.of(todoDailyScheduleDtos, todoDailyDtos);
     }
 
+    public List<TodoGetResponseDto> getPeriodDetailTodos(Long memberId, LocalDate from, LocalDate to) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        validateDate(from, to);
+        List<Todo> todos = todoQueryRepository.findPeriodDetailTodosByDate(member.getId(), from, to);
+        List<TodoGetResponseDto> responseDtos = todos.stream()
+                .map(TodoGetResponseDto::of)
+                .collect(Collectors.toList());
+
+        return responseDtos;
+    }
+
     @Transactional
     public TodoGetResponseDto updateTodo(Long memberId, Long todoId, TodoRequestDto requestDto) {
         Member member = memberRepository.findById(memberId)

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -10,7 +10,7 @@ import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.repository.GroupRepository;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
-import scs.planus.domain.todo.dto.TodoCreateRequestDto;
+import scs.planus.domain.todo.dto.TodoRequestDto;
 import scs.planus.domain.todo.dto.TodoDailyDto;
 import scs.planus.domain.todo.dto.TodoDailyResponseDto;
 import scs.planus.domain.todo.dto.TodoDailyScheduleDto;
@@ -41,7 +41,7 @@ public class TodoService {
     private final TodoQueryRepository todoQueryRepository;
 
     @Transactional
-    public TodoResponseDto createPrivateTodo(Long memberId, TodoCreateRequestDto requestDto) {
+    public TodoResponseDto createPrivateTodo(Long memberId, TodoRequestDto requestDto) {
         Member member = memberRepository.findById(memberId)
                         .orElseThrow(() -> new PlanusException(NONE_USER));
 
@@ -88,7 +88,7 @@ public class TodoService {
     }
 
     @Transactional
-    public TodoGetResponseDto updateTodo(Long memberId, Long todoId, TodoCreateRequestDto requestDto) {
+    public TodoGetResponseDto updateTodo(Long memberId, Long todoId, TodoRequestDto requestDto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -119,6 +119,18 @@ public class TodoService {
         return TodoResponseDto.of(todo);
     }
 
+    @Transactional
+    public TodoResponseDto checkCompletion(Long memberId, Long todoId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        Todo todo = todoQueryRepository.findOneTodoById(todoId, member.getId())
+                .orElseThrow(() -> new PlanusException(NONE_TODO));
+
+        todo.complete();
+        return TodoResponseDto.of(todo);
+    }
+
     private void validateDate(LocalDate startDate, LocalDate endDate) {
         if (endDate != null) {
             if (startDate.isAfter(endDate)) {

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -92,7 +92,7 @@ public class TodoService {
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
         validateDate(from, to);
-        List<Todo> todos = todoQueryRepository.findPeriodDetailTodosByDate(member.getId(), from, to);
+        List<Todo> todos = todoQueryRepository.findPeriodTodosDetailByDate(member.getId(), from, to);
         List<TodoDetailsResponseDto> responseDtos = todos.stream()
                 .map(TodoDetailsResponseDto::of)
                 .collect(Collectors.toList());

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -119,6 +119,6 @@ public class TodoService {
         }
         // TODO : 그룹 가입 이후, 현재 멤버가 해당 그룹에 가입했는지를 체크해야함. 아래 방식은 가입하지 않더라도 그룹 지정 가능한 방식
         return groupRepository.findById(groupId)
-                    .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
+                    .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
     }
 }

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -4,20 +4,21 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import scs.planus.global.exception.PlanusException;
-import scs.planus.domain.group.entity.Group;
-import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.category.entity.TodoCategory;
-import scs.planus.domain.todo.entity.Todo;
+import scs.planus.domain.category.repository.CategoryRepository;
+import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.group.repository.GroupRepository;
+import scs.planus.domain.member.entity.Member;
+import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.domain.todo.dto.TodoCreateRequestDto;
 import scs.planus.domain.todo.dto.TodoDailyResponseDto;
 import scs.planus.domain.todo.dto.TodoGetResponseDto;
+import scs.planus.domain.todo.dto.TodoPeriodResponseDto;
 import scs.planus.domain.todo.dto.TodoResponseDto;
-import scs.planus.domain.category.repository.CategoryRepository;
-import scs.planus.domain.group.repository.GroupRepository;
-import scs.planus.domain.member.repository.MemberRepository;
+import scs.planus.domain.todo.entity.Todo;
 import scs.planus.domain.todo.repository.TodoQueryRepository;
 import scs.planus.domain.todo.repository.TodoRepository;
+import scs.planus.global.exception.PlanusException;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -59,6 +60,18 @@ public class TodoService {
                 .orElseThrow(() -> new PlanusException(NONE_TODO));
 
         return TodoGetResponseDto.of(todo);
+    }
+
+    public List<TodoPeriodResponseDto> getPeriodTodos(Long memberId, LocalDate from, LocalDate to) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        validateDate(from, to);
+        List<Todo> todos = todoQueryRepository.findPeriodTodosByDate(member.getId(), from, to);
+        List<TodoPeriodResponseDto> responseDtos = todos.stream()
+                .map(TodoPeriodResponseDto::of)
+                .collect(Collectors.toList());
+        return responseDtos;
     }
 
     public List<TodoDailyResponseDto> getDailyTodos(Long memberId, LocalDate date) {

--- a/src/main/java/scs/planus/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/scs/planus/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import scs.planus.global.common.response.BaseResponse;
 import scs.planus.global.common.response.ResponseStatus;
 
@@ -29,6 +30,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<Object> handleJsonException() {
+        ResponseStatus status = INVALID_PARAMETER;
+        return ResponseEntity.status(status.getHttpStatus())
+                .body(new BaseResponse<>(status));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<Object> handleInvalidQueryStringException() {
         ResponseStatus status = INVALID_PARAMETER;
         return ResponseEntity.status(status.getHttpStatus())
                 .body(new BaseResponse<>(status));


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 달별 Todo 조회 기능 구현
- 일별 Todo 조회 리팩토링
- Todo 완료 체크 기능 구현

### :: 특이사항

###  🔥 달별 Todo 조회 기능 구현 
- 캘린더 화면, 즉 달별 Todo 조회를 구현하였습니다.
- 프론트의 요구사항을 반영하여 매월 1일 ~ 끝일 까지의 Todo가 아닌, 화면에 맞도록 from ~ to 까지의 Todo를 조회합니다.

<p align="center"><img width="150" alt="스크린샷 2023-04-24 오후 6 56 05" src="https://user-images.githubusercontent.com/97597051/233963808-8fdbb6fc-82a4-4d06-829d-bbd4d0e045e0.png"></p>

- 위와 같은 경우일 때, 2023년 3월 캘린더를 보기 위하여 `from=2023-02-27, to=2023-04-03`과 같이 요청합니다.
- Todo를 생성한 순이 아닌, 기간이 이른 것부터 출력되도록 정렬되도록 `startDate`를 기준으로 오름차순 정렬하였습니다.

###  🔥 일별 Todo 조회 리팩토링
- 기존에 일별 Todo 전체를 구분없이 응답하던 것을 구분하여 응답하였습니다.
  - `DailySchedule` : 일별 Todo 중, `startTime`이 존재하는 일정
  - `DailyTodo` : 일별 Todo 중, `startTime`이 존재하지 않는 일반적인 투두
- 일정을 시간 순으로 응답하기 위해, `startTime`을 오름차순으로 정렬하였습니다. 

###  🔥 Todo 완료 체크 기능 구현
- `todos/{id}/completion`
- 투두 완료 체크 기능을 Patch method로 구현하였습니다.
