### PR TITLE
[Feat]  그룹 상세정보 수정, 공지 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -33,7 +33,7 @@ public class GroupController {
     public BaseResponse<GroupGetResponseDto> getGroup( @AuthenticationPrincipal PrincipalDetails principalDetails,
                                                        @PathVariable("groupId") Long groupId ) {
 
-        GroupGetResponseDto responseDto = groupService.getGroup( groupId );
+        GroupGetResponseDto responseDto = groupService.getGroupForNonMember( groupId );
 
         return new BaseResponse<>( responseDto );
     }

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -5,12 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import scs.planus.domain.group.dto.*;
+import scs.planus.domain.group.service.GroupService;
 import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.common.response.BaseResponse;
-import scs.planus.domain.group.dto.GroupCreateRequestDto;
-import scs.planus.domain.group.dto.GroupGetResponseDto;
-import scs.planus.domain.group.dto.GroupResponseDto;
-import scs.planus.domain.group.service.GroupService;
 
 import javax.validation.Valid;
 
@@ -36,6 +34,17 @@ public class GroupController {
                                                        @PathVariable("groupId") Long groupId ) {
 
         GroupGetResponseDto responseDto = groupService.getGroup( groupId );
+
+        return new BaseResponse<>( responseDto );
+    }
+
+    @PatchMapping("/groups/{groupId}")
+    public BaseResponse<GroupResponseDto> updateGroupDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                            @PathVariable("groupId") Long groupId,
+                                                            @RequestPart(value = "image", required = false) MultipartFile multipartFile,
+                                                            @Valid @RequestPart(value = "groupUpdateRequestDto", required = false) GroupDetailUpdateRequestDto requestDto  ) {
+        Long memberId = principalDetails.getId();
+        GroupResponseDto responseDto = groupService.updateGroupDetail( memberId, groupId, requestDto, multipartFile );
 
         return new BaseResponse<>( responseDto );
     }

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -60,6 +60,16 @@ public class GroupController {
         return new BaseResponse<>( responseDto );
     }
 
+    @DeleteMapping("/groups/{groupId}")
+    public BaseResponse<GroupResponseDto> softDeleteGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                          @PathVariable("groupId") Long groupId ){
+
+        Long memberId = principalDetails.getId();
+        GroupResponseDto responseDto = groupService.softDeleteGroup( memberId, groupId );
+
+        return new BaseResponse<>( responseDto );
+    }
+
     @PostMapping("/groups/{groupId}")
     public BaseResponse<GroupResponseDto> joinGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                     @PathVariable("groupId") Long groupId ) {

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -49,6 +49,17 @@ public class GroupController {
         return new BaseResponse<>( responseDto );
     }
 
+    @PatchMapping("/groups/{groupId}/notice")
+    public BaseResponse<GroupResponseDto> updateGroupNotice(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                            @PathVariable("groupId") Long groupId,
+                                                            @Valid @RequestBody GroupNoticeUpdateRequestDto requestDto ) {
+
+        Long memberId = principalDetails.getId();
+        GroupResponseDto responseDto = groupService.updateGroupNotice( memberId, groupId, requestDto );
+
+        return new BaseResponse<>( responseDto );
+    }
+
     @PostMapping("/groups/{groupId}")
     public BaseResponse<GroupResponseDto> joinGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                     @PathVariable("groupId") Long groupId ) {

--- a/src/main/java/scs/planus/domain/group/dto/GroupDetailUpdateRequestDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupDetailUpdateRequestDto.java
@@ -1,0 +1,19 @@
+package scs.planus.domain.group.dto;
+
+import lombok.Getter;
+import scs.planus.domain.tag.dto.TagCreateRequestDto;
+
+import javax.validation.Valid;
+import javax.validation.constraints.*;
+import java.util.List;
+
+@Getter
+public class GroupDetailUpdateRequestDto {
+
+    @Size(max = 5, message = "[request] 테그는 5개 이하로 입력해 주세요.")
+    private List<@Valid TagCreateRequestDto> tagList;
+
+    @Max(value = 50, message = "[request] 그룹 제한 인원은 50명 이하로 입력해 주세요.")
+    @Min(value = 2, message = "[request] 그룹 제한 인원은 2명 이상으로 입력해 주세요.")
+    private Long limitCount;
+}

--- a/src/main/java/scs/planus/domain/group/dto/GroupNoticeUpdateRequestDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupNoticeUpdateRequestDto.java
@@ -1,0 +1,8 @@
+package scs.planus.domain.group.dto;
+
+import lombok.Getter;
+
+@Getter
+public class GroupNoticeUpdateRequestDto {
+    private String notice;
+}

--- a/src/main/java/scs/planus/domain/group/entity/Group.java
+++ b/src/main/java/scs/planus/domain/group/entity/Group.java
@@ -73,19 +73,16 @@ public class Group extends BaseTimeEntity {
                 .getMember().getNickname();
     }
 
-    public Group updateDetail(Long limitCount, String groupImageUrl ) {
+    public void updateDetail(Long limitCount, String groupImageUrl ) {
         this.limitCount = limitCount;
         this.groupImageUrl = groupImageUrl;
-        return this;
     }
 
-    public Group updateNotice( String notice ) {
+    public void updateNotice( String notice ) {
         this.notice = notice;
-        return this;
     }
 
-    public Group changeStatusToInactive() {
+    public void changeStatusToInactive() {
         this.status = Status.INACTIVE;
-        return this;
     }
 }

--- a/src/main/java/scs/planus/domain/group/entity/Group.java
+++ b/src/main/java/scs/planus/domain/group/entity/Group.java
@@ -83,4 +83,9 @@ public class Group extends BaseTimeEntity {
         this.notice = notice;
         return this;
     }
+
+    public Group changeStatusToInactive() {
+        this.status = Status.INACTIVE;
+        return this;
+    }
 }

--- a/src/main/java/scs/planus/domain/group/entity/Group.java
+++ b/src/main/java/scs/planus/domain/group/entity/Group.java
@@ -78,4 +78,9 @@ public class Group extends BaseTimeEntity {
         this.groupImageUrl = groupImageUrl;
         return this;
     }
+
+    public Group updateNotice( String notice ) {
+        this.notice = notice;
+        return this;
+    }
 }

--- a/src/main/java/scs/planus/domain/group/entity/Group.java
+++ b/src/main/java/scs/planus/domain/group/entity/Group.java
@@ -72,4 +72,10 @@ public class Group extends BaseTimeEntity {
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_LEADER))
                 .getMember().getNickname();
     }
+
+    public Group updateDetail(Long limitCount, String groupImageUrl ) {
+        this.limitCount = limitCount;
+        this.groupImageUrl = groupImageUrl;
+        return this;
+    }
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -1,7 +1,19 @@
 package scs.planus.domain.group.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
 
+import java.util.Optional;
+
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+    @Query("select gm " +
+            "from GroupMember gm " +
+            "join fetch gm.group " +
+            "join fetch gm.member " +
+            "where gm.group= :group " +
+            "and gm.leader= true")
+    Optional<GroupMember> findWithGroupAndLeaderByGroup(@Param("group") Group group );
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
@@ -11,7 +11,8 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
     @Query("select distinct g " +
             "from Group g " +
             "join fetch g.groupMembers gm " +
-            "where g.id= :groupId")
+            "where g.id= :groupId " +
+            "and g.status= 'ACTIVE'")
     Optional<Group> findWithGroupMemberById(@Param("groupId") Long groupId);
 
     @Query("select g " +

--- a/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
@@ -13,4 +13,10 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             "join fetch g.groupMembers gm " +
             "where g.id= :groupId")
     Optional<Group> findWithGroupMemberById(@Param("groupId") Long groupId);
+
+    @Query("select g " +
+            "from Group g " +
+            "where g.id= :groupId " +
+            "and g.status= 'ACTIVE'")
+    Optional<Group> findByIdAndStatus(@Param("groupId") Long groupId);
 }

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -98,6 +98,19 @@ public class GroupService {
         return GroupResponseDto.of( updateGroup );
     }
 
+    @Transactional
+    public GroupResponseDto updateGroupNotice( Long memberId, Long groupId, GroupNoticeUpdateRequestDto requestDto ) {
+        Group group = groupRepository.findByIdAndStatus( groupId )
+                .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_GROUP ); });
+
+        // 리더가 아니면 수정 불가능
+        validateLeaderPermission( memberId, group );
+
+        Group updateGroup = group.updateNotice( requestDto.getNotice() );
+
+        return GroupResponseDto.of( updateGroup );
+    }
+
     private String createGroupImage( MultipartFile multipartFile ) {
         if ( multipartFile != null ) {
             return s3Uploader.upload( multipartFile, "groups" );

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -58,7 +58,7 @@ public class GroupService {
         return GroupResponseDto.of( saveGroup );
     }
 
-    public GroupGetResponseDto getGroup( Long groupId ) {
+    public GroupGetResponseDto getGroupForNonMember(Long groupId ) {
         Group group = groupRepository.findWithGroupMemberById( groupId )
                 .orElseThrow(() ->  new PlanusException(NOT_EXIST_GROUP));
 

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -80,8 +80,11 @@ public class GroupService {
         Group group = groupRepository.findByIdAndStatus( groupId )
                 .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_GROUP ); });
 
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+
         // 리더가 아니면 수정 불가능
-        validateLeaderPermission( memberId, group );
+        validateLeaderPermission( member, group );
 
         // 그룹 이미지 변경
         String groupImageUrl = group.getGroupImageUrl();
@@ -103,8 +106,11 @@ public class GroupService {
         Group group = groupRepository.findByIdAndStatus( groupId )
                 .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_GROUP ); });
 
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+
         // 리더가 아니면 수정 불가능
-        validateLeaderPermission( memberId, group );
+        validateLeaderPermission( member, group );
 
         Group updateGroup = group.updateNotice( requestDto.getNotice() );
 
@@ -116,8 +122,11 @@ public class GroupService {
         Group group = groupRepository.findByIdAndStatus( groupId )
                 .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_GROUP ); });
 
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+
         // 리더가 아니면 수정 불가능
-        validateLeaderPermission( memberId, group );
+        validateLeaderPermission( member, group );
 
         Group inactiveGroup = group.changeStatusToInactive();
 
@@ -157,12 +166,9 @@ public class GroupService {
         return GroupResponseDto.of( group );
     }
 
-    private void validateLeaderPermission( Long memberId, Group group ) {
+    private void validateLeaderPermission( Member member, Group group ) {
         GroupMember groupLeader = groupMemberRepository.findWithGroupAndLeaderByGroup( group )
                 .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_LEADER ); });
-
-        Member member = memberRepository.findById( memberId )
-                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
 
         if ( !member.equals( groupLeader.getMember() ) )
             throw new PlanusException( NOT_GROUP_LEADER_PERMISSION );

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -87,8 +87,8 @@ public class GroupService {
         validateLeaderPermission( member, group );
 
         // 그룹 이미지 변경
-        String groupImageUrl = group.getGroupImageUrl();
-        groupImageUrl = updateGroupImage( multipartFile, groupImageUrl );
+        String oldGroupImageUrl = group.getGroupImageUrl();
+        String newGroupImageUrl = updateGroupImage(multipartFile, oldGroupImageUrl);
 
         // 그룹 테그 수정.
         List<TagCreateRequestDto> addTagDtos = groupTagService.update( group, requestDto.getTagList() );
@@ -96,7 +96,7 @@ public class GroupService {
         GroupTag.create( group, addTags );
 
         // 그 외 세부사항 수정
-        Group updateGroup = group.updateDetail( requestDto.getLimitCount(), groupImageUrl );
+        Group updateGroup = group.updateDetail( requestDto.getLimitCount(), newGroupImageUrl );
 
         return GroupResponseDto.of( updateGroup );
     }

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -111,6 +111,19 @@ public class GroupService {
         return GroupResponseDto.of( updateGroup );
     }
 
+    @Transactional
+    public GroupResponseDto softDeleteGroup( Long memberId, Long groupId ) {
+        Group group = groupRepository.findByIdAndStatus( groupId )
+                .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_GROUP ); });
+
+        // 리더가 아니면 수정 불가능
+        validateLeaderPermission( memberId, group );
+
+        Group inactiveGroup = group.changeStatusToInactive();
+
+        return GroupResponseDto.of( inactiveGroup );
+    }
+
     private String createGroupImage( MultipartFile multipartFile ) {
         if ( multipartFile != null ) {
             return s3Uploader.upload( multipartFile, "groups" );

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -96,9 +96,9 @@ public class GroupService {
         GroupTag.create( group, addTags );
 
         // 그 외 세부사항 수정
-        Group updateGroup = group.updateDetail( requestDto.getLimitCount(), newGroupImageUrl );
+        group.updateDetail( requestDto.getLimitCount(), newGroupImageUrl );
 
-        return GroupResponseDto.of( updateGroup );
+        return GroupResponseDto.of( group );
     }
 
     @Transactional
@@ -112,9 +112,9 @@ public class GroupService {
         // 리더가 아니면 수정 불가능
         validateLeaderPermission( member, group );
 
-        Group updateGroup = group.updateNotice( requestDto.getNotice() );
+        group.updateNotice( requestDto.getNotice() );
 
-        return GroupResponseDto.of( updateGroup );
+        return GroupResponseDto.of( group );
     }
 
     @Transactional
@@ -128,9 +128,9 @@ public class GroupService {
         // 리더가 아니면 수정 불가능
         validateLeaderPermission( member, group );
 
-        Group inactiveGroup = group.changeStatusToInactive();
+        group.changeStatusToInactive();
 
-        return GroupResponseDto.of( inactiveGroup );
+        return GroupResponseDto.of( group );
     }
 
     private String createGroupImage( MultipartFile multipartFile ) {

--- a/src/main/java/scs/planus/domain/group/service/GroupTagService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupTagService.java
@@ -1,0 +1,49 @@
+package scs.planus.domain.group.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.group.entity.GroupTag;
+import scs.planus.domain.group.repository.GroupTagRepository;
+import scs.planus.domain.tag.dto.TagCreateRequestDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class GroupTagService {
+    private final GroupTagRepository groupTagRepository;
+
+    // TODO : 리펙토링 필요할 듯
+    @Transactional
+    public List<TagCreateRequestDto> update(Group group, List<TagCreateRequestDto> updateTags ) {
+        List<GroupTag> groupTags = groupTagRepository.findAllByGroup( group );
+
+        List<GroupTag> removeGroupTag = new ArrayList<>();
+        List<TagCreateRequestDto> removeUpdateTag = new ArrayList<>();
+
+        for (GroupTag gt : groupTags) {
+            boolean removeFlag = true;
+            for ( TagCreateRequestDto t : updateTags ) {
+                if (gt.getTag().getName().equals(t.getName())) {
+                    removeUpdateTag.add(t);
+                    removeFlag = false;
+                    break;
+                }
+            }
+            if (removeFlag) removeGroupTag.add(gt);
+        }
+
+        groupTagRepository.deleteAll(removeGroupTag);
+
+        // 존재하는 태그 제외하고, 추가해야할 태그만 리턴
+        updateTags.removeAll(removeUpdateTag);
+
+        return updateTags;
+    }
+}

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -37,6 +37,7 @@ public enum CustomExceptionStatus implements ResponseStatus {
     // group exception
     NOT_EXIST_GROUP(BAD_REQUEST, 2600, "존재하지 않는 그룹 입니다."),
     NOT_EXIST_LEADER(BAD_REQUEST, 2601, "해당 그룹에 그룹장이 존재하지 않습니다."),
+    NOT_GROUP_LEADER_PERMISSION(BAD_REQUEST, 2602, "그룹을 수정할 권한이 없습니다."),
 
     // s3 exception
     INVALID_FILE(BAD_REQUEST, 5000, "잘못되거나 존재하지 않는 파일입니다."),


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 그룹 상세 정보 수정 기능을 구현하였습니다.
- 그룹 공지 수정 기능을 구현하였습니다.
- 그룹 상태만 변경하는 Soft 삭제 기능을 구현하였습니다.
- 수정 및 삭제는 그룹 리더의 권한이기 때문에, 요청을 한 사용자가 그룹 리더인지를 검증하는 `validateLeaderPermission` 메소드를 구현하였습니다.

### :: 특이사항
- 세 기능 모두 사용자가 그룹 리더인지를 검증하는 단계에서, `member`를 조회하고, `group`으로 부터 `groupLeader`를 조회하는 코드가 중복적으로 발생하여 `memberId`와 `group`을 파라미터로 받아 검증가지 하도록 `validateLeaderPermission`를 구현하였습니다.
- `TagService` 에 존재하는 `tags` 와 수정 요청으로 들어온 `updateTags` 를 비교하여, 삭제 및 추가하는 코드는 추후에 리펙토링이 필요합니다!
- `groupId` 로 그룹을 조회하는 쿼리문에서 삭제된(`status = Status.Inactive`) 그룹은 조회되면 안됨으로, 조건문을 추가하였습니다.
