### PR TITLE
[Refactor] todo-calender 분리 및 그룹 개인 투두 생성 메서드 통합

### DIFF
--- a/src/main/java/scs/planus/domain/todo/controller/TodoCalenderController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoCalenderController.java
@@ -1,0 +1,54 @@
+package scs.planus.domain.todo.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import scs.planus.domain.todo.dto.TodoDailyResponseDto;
+import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
+import scs.planus.domain.todo.dto.TodoPeriodResponseDto;
+import scs.planus.domain.todo.service.TodoCalenderService;
+import scs.planus.global.auth.entity.PrincipalDetails;
+import scs.planus.global.common.response.BaseResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/app")
+@RequiredArgsConstructor
+@Slf4j
+public class TodoCalenderController {
+
+    private final TodoCalenderService todoCalenderService;
+
+    @GetMapping("/todos")
+    public BaseResponse<List<TodoDetailsResponseDto>> getTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                               @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
+                                                               @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to){
+        Long memberId = principalDetails.getId();
+        List<TodoDetailsResponseDto> responseDtos = todoCalenderService.getPeriodDetailTodos(memberId, from, to);
+        return new BaseResponse<>(responseDtos);
+    }
+
+    @GetMapping("/todos/period")
+    public BaseResponse<List<TodoPeriodResponseDto>> getPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                    @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
+                                                                    @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
+        Long memberId = principalDetails.getId();
+        List<TodoPeriodResponseDto> responseDtos = todoCalenderService.getPeriodTodos(memberId, from, to);
+        return new BaseResponse<>(responseDtos);
+    }
+
+    @GetMapping("/todos/daily")
+    public BaseResponse<TodoDailyResponseDto> getDailyTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+        Long memberId = principalDetails.getId();
+        TodoDailyResponseDto responseDtos = todoCalenderService.getDailyTodos(memberId, date);
+        return new BaseResponse<>(responseDtos);
+    }
+}

--- a/src/main/java/scs/planus/domain/todo/controller/TodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoController.java
@@ -30,11 +30,8 @@ public class TodoController {
     public BaseResponse<TodoResponseDto> createTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                     @RequestBody TodoRequestDto requestDto) {
         Long memberId = principalDetails.getId();
-        if (requestDto.getGroupId() == null) {
-            TodoResponseDto responseDto = todoService.createPrivateTodo(memberId, requestDto);
-            return new BaseResponse<>(responseDto);
-        }
-        return null;
+        TodoResponseDto responseDto = todoService.createPrivateTodo(memberId, requestDto);
+        return new BaseResponse<>(responseDto);
     }
 
     @GetMapping("/todos/{todoId}")

--- a/src/main/java/scs/planus/domain/todo/controller/TodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoController.java
@@ -2,7 +2,6 @@ package scs.planus.domain.todo.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,19 +10,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import scs.planus.domain.todo.dto.TodoRequestDto;
-import scs.planus.domain.todo.dto.TodoDailyResponseDto;
 import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
-import scs.planus.domain.todo.dto.TodoPeriodResponseDto;
+import scs.planus.domain.todo.dto.TodoRequestDto;
 import scs.planus.domain.todo.dto.TodoResponseDto;
 import scs.planus.domain.todo.service.TodoService;
 import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.common.response.BaseResponse;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @RestController
 @RequestMapping("/app")
@@ -52,32 +45,6 @@ public class TodoController {
         return new BaseResponse<>(responseDto);
     }
 
-    @GetMapping("/todos/period")
-    public BaseResponse<List<TodoPeriodResponseDto>> getPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                    @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
-                                                                    @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
-        Long memberId = principalDetails.getId();
-        List<TodoPeriodResponseDto> responseDtos = todoService.getPeriodTodos(memberId, from, to);
-        return new BaseResponse<>(responseDtos);
-    }
-
-    @GetMapping("/todos/daily")
-    public BaseResponse<TodoDailyResponseDto> getDailyTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                            @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
-        Long memberId = principalDetails.getId();
-        TodoDailyResponseDto responseDtos = todoService.getDailyTodos(memberId, date);
-        return new BaseResponse<>(responseDtos);
-    }
-
-    @GetMapping("/todos")
-    public BaseResponse<List<TodoDetailsResponseDto>> getTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                               @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
-                                                               @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to){
-        Long memberId = principalDetails.getId();
-        List<TodoDetailsResponseDto> responseDtos = todoService.getPeriodDetailTodos(memberId, from, to);
-        return new BaseResponse<>(responseDtos);
-    }
-
     @PatchMapping("/todos/{todoId}")
     public BaseResponse<TodoDetailsResponseDto> updateTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                  @PathVariable Long todoId,
@@ -87,19 +54,19 @@ public class TodoController {
         return new BaseResponse<>(responseDto);
     }
 
-    @DeleteMapping("/todos/{todoId}")
-    public BaseResponse<TodoResponseDto> deleteTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                    @PathVariable Long todoId) {
-        Long memberId = principalDetails.getId();
-        TodoResponseDto responseDto = todoService.deleteTodo(memberId, todoId);
-        return new BaseResponse<>(responseDto);
-    }
-
     @PatchMapping("/todos/{todoId}/completion")
     public BaseResponse<TodoResponseDto> completeTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                       @PathVariable Long todoId) {
         Long memberId = principalDetails.getId();
         TodoResponseDto responseDto = todoService.checkCompletion(memberId, todoId);
+        return new BaseResponse<>(responseDto);
+    }
+
+    @DeleteMapping("/todos/{todoId}")
+    public BaseResponse<TodoResponseDto> deleteTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                    @PathVariable Long todoId) {
+        Long memberId = principalDetails.getId();
+        TodoResponseDto responseDto = todoService.deleteTodo(memberId, todoId);
         return new BaseResponse<>(responseDto);
     }
 }

--- a/src/main/java/scs/planus/domain/todo/dto/TodoRequestDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoRequestDto.java
@@ -2,8 +2,9 @@ package scs.planus.domain.todo.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
-import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.category.entity.TodoCategory;
+import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.todo.entity.Todo;
 
 import javax.validation.constraints.NotBlank;
@@ -30,7 +31,7 @@ public class TodoRequestDto {
     @Size(max = 70, message = "투두 메모는 최대 70글자입니다.")
     private String description;
 
-    public Todo toMemberTodoEntity(Member member, TodoCategory todoCategory) {
+    public Todo toEntity(Member member, TodoCategory todoCategory, Group group) {
         return Todo.builder()
                 .title(title)
                 .todoCategory(todoCategory)
@@ -39,6 +40,7 @@ public class TodoRequestDto {
                 .startTime(startTime)
                 .description(description)
                 .member(member)
+                .group(group)
                 .build();
     }
 }

--- a/src/main/java/scs/planus/domain/todo/service/TodoCalenderService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoCalenderService.java
@@ -14,12 +14,12 @@ import scs.planus.domain.todo.dto.TodoPeriodResponseDto;
 import scs.planus.domain.todo.entity.Todo;
 import scs.planus.domain.todo.repository.TodoQueryRepository;
 import scs.planus.global.exception.PlanusException;
+import scs.planus.global.util.validator.Validator;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static scs.planus.global.exception.CustomExceptionStatus.INVALID_DATE;
 import static scs.planus.global.exception.CustomExceptionStatus.NONE_USER;
 
 @Service
@@ -35,7 +35,7 @@ public class TodoCalenderService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
-        validateDate(from, to);
+        Validator.validateStartDateBeforeEndDate(from, to);
         List<Todo> todos = todoQueryRepository.findPeriodTodosDetailByDate(member.getId(), from, to);
         List<TodoDetailsResponseDto> responseDtos = todos.stream()
                 .map(TodoDetailsResponseDto::of)
@@ -48,7 +48,7 @@ public class TodoCalenderService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
-        validateDate(from, to);
+        Validator.validateStartDateBeforeEndDate(from, to);
         List<Todo> todos = todoQueryRepository.findPeriodTodosByDate(member.getId(), from, to);
         List<TodoPeriodResponseDto> responseDtos = todos.stream()
                 .map(TodoPeriodResponseDto::of)
@@ -65,14 +65,6 @@ public class TodoCalenderService {
         List<TodoDailyDto> todoDailyDtos = getDailyTodos(todos);
 
         return TodoDailyResponseDto.of(todoDailyScheduleDtos, todoDailyDtos);
-    }
-
-    private void validateDate(LocalDate startDate, LocalDate endDate) {
-        if (endDate != null) {
-            if (startDate.isAfter(endDate)) {
-                throw new PlanusException(INVALID_DATE);
-            }
-        }
     }
 
     private List<TodoDailyScheduleDto> getDailySchedules(List<Todo> todos) {

--- a/src/main/java/scs/planus/domain/todo/service/TodoCalenderService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoCalenderService.java
@@ -1,0 +1,91 @@
+package scs.planus.domain.todo.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import scs.planus.domain.member.entity.Member;
+import scs.planus.domain.member.repository.MemberRepository;
+import scs.planus.domain.todo.dto.TodoDailyDto;
+import scs.planus.domain.todo.dto.TodoDailyResponseDto;
+import scs.planus.domain.todo.dto.TodoDailyScheduleDto;
+import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
+import scs.planus.domain.todo.dto.TodoPeriodResponseDto;
+import scs.planus.domain.todo.entity.Todo;
+import scs.planus.domain.todo.repository.TodoQueryRepository;
+import scs.planus.global.exception.PlanusException;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static scs.planus.global.exception.CustomExceptionStatus.INVALID_DATE;
+import static scs.planus.global.exception.CustomExceptionStatus.NONE_USER;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class TodoCalenderService {
+
+    private final MemberRepository memberRepository;
+    private final TodoQueryRepository todoQueryRepository;
+
+    public List<TodoDetailsResponseDto> getPeriodDetailTodos(Long memberId, LocalDate from, LocalDate to) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        validateDate(from, to);
+        List<Todo> todos = todoQueryRepository.findPeriodTodosDetailByDate(member.getId(), from, to);
+        List<TodoDetailsResponseDto> responseDtos = todos.stream()
+                .map(TodoDetailsResponseDto::of)
+                .collect(Collectors.toList());
+
+        return responseDtos;
+    }
+
+    public List<TodoPeriodResponseDto> getPeriodTodos(Long memberId, LocalDate from, LocalDate to) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        validateDate(from, to);
+        List<Todo> todos = todoQueryRepository.findPeriodTodosByDate(member.getId(), from, to);
+        List<TodoPeriodResponseDto> responseDtos = todos.stream()
+                .map(TodoPeriodResponseDto::of)
+                .collect(Collectors.toList());
+        return responseDtos;
+    }
+
+    public TodoDailyResponseDto getDailyTodos(Long memberId, LocalDate date) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        List<Todo> todos = todoQueryRepository.findDailyTodosByDate(member.getId(), date);
+        List<TodoDailyScheduleDto> todoDailyScheduleDtos = getDailySchedules(todos);
+        List<TodoDailyDto> todoDailyDtos = getDailyTodos(todos);
+
+        return TodoDailyResponseDto.of(todoDailyScheduleDtos, todoDailyDtos);
+    }
+
+    private void validateDate(LocalDate startDate, LocalDate endDate) {
+        if (endDate != null) {
+            if (startDate.isAfter(endDate)) {
+                throw new PlanusException(INVALID_DATE);
+            }
+        }
+    }
+
+    private List<TodoDailyScheduleDto> getDailySchedules(List<Todo> todos) {
+        return todos.stream()
+                .filter(todo -> todo.getStartTime() != null)
+                .map(TodoDailyScheduleDto::of)
+                .collect(Collectors.toList());
+    }
+
+    private List<TodoDailyDto> getDailyTodos(List<Todo> todos) {
+        return todos.stream()
+                .filter(todo -> todo.getStartTime() == null)
+                .map(TodoDailyDto::of)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -17,8 +17,7 @@ import scs.planus.domain.todo.entity.Todo;
 import scs.planus.domain.todo.repository.TodoQueryRepository;
 import scs.planus.domain.todo.repository.TodoRepository;
 import scs.planus.global.exception.PlanusException;
-
-import java.time.LocalDate;
+import scs.planus.global.util.validator.Validator;
 
 import static scs.planus.global.exception.CustomExceptionStatus.*;
 
@@ -42,7 +41,7 @@ public class TodoService {
         TodoCategory todoCategory = categoryRepository.findById(requestDto.getCategoryId())
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
 
-        validateDate(requestDto.getStartDate(), requestDto.getEndDate());
+        Validator.validateStartDateBeforeEndDate(requestDto.getStartDate(), requestDto.getEndDate());
         Todo memberTodo = requestDto.toMemberTodoEntity(member, todoCategory, null);
         todoRepository.save(memberTodo);
         return TodoResponseDto.of(memberTodo);
@@ -59,7 +58,7 @@ public class TodoService {
         Group group = groupRepository.findById(requestDto.getGroupId())
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
 
-        validateDate(requestDto.getStartDate(), requestDto.getEndDate());
+        Validator.validateStartDateBeforeEndDate(requestDto.getStartDate(), requestDto.getEndDate());
         Todo memberTodo = requestDto.toMemberTodoEntity(member, todoCategory, group);
         todoRepository.save(memberTodo);
         return TodoResponseDto.of(memberTodo);
@@ -88,7 +87,7 @@ public class TodoService {
 
         Group group = getGroup(requestDto.getGroupId());
 
-        validateDate(requestDto.getStartDate(), requestDto.getEndDate());
+        Validator.validateStartDateBeforeEndDate(requestDto.getStartDate(), requestDto.getEndDate());
         todo.update(requestDto.getTitle(), requestDto.getDescription(), requestDto.getStartTime(),
                 requestDto.getStartDate(), requestDto.getEndDate(), todoCategory, group);
 
@@ -117,14 +116,6 @@ public class TodoService {
 
         todoRepository.delete(todo);
         return TodoResponseDto.of(todo);
-    }
-
-    private void validateDate(LocalDate startDate, LocalDate endDate) {
-        if (endDate != null) {
-            if (startDate.isAfter(endDate)) {
-                throw new PlanusException(INVALID_DATE);
-            }
-        }
     }
 
     private Group getGroup(Long groupId) {

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -41,8 +41,9 @@ public class TodoService {
         TodoCategory todoCategory = categoryRepository.findById(requestDto.getCategoryId())
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
 
+        Group group = getGroup(requestDto.getGroupId());
         Validator.validateStartDateBeforeEndDate(requestDto.getStartDate(), requestDto.getEndDate());
-        Todo memberTodo = requestDto.toEntity(member, todoCategory, null);
+        Todo memberTodo = requestDto.toEntity(member, todoCategory, group);
         todoRepository.save(memberTodo);
         return TodoResponseDto.of(memberTodo);
     }

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -42,7 +42,7 @@ public class TodoService {
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
 
         Validator.validateStartDateBeforeEndDate(requestDto.getStartDate(), requestDto.getEndDate());
-        Todo memberTodo = requestDto.toMemberTodoEntity(member, todoCategory, null);
+        Todo memberTodo = requestDto.toEntity(member, todoCategory, null);
         todoRepository.save(memberTodo);
         return TodoResponseDto.of(memberTodo);
     }
@@ -59,7 +59,7 @@ public class TodoService {
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
 
         Validator.validateStartDateBeforeEndDate(requestDto.getStartDate(), requestDto.getEndDate());
-        Todo memberTodo = requestDto.toMemberTodoEntity(member, todoCategory, group);
+        Todo memberTodo = requestDto.toEntity(member, todoCategory, group);
         todoRepository.save(memberTodo);
         return TodoResponseDto.of(memberTodo);
     }

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -48,23 +48,6 @@ public class TodoService {
         return TodoResponseDto.of(memberTodo);
     }
 
-    @Transactional
-    public TodoResponseDto createGroupPrivateTodo(Long memberId, TodoRequestDto requestDto) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new PlanusException(NONE_USER));
-
-        TodoCategory todoCategory = categoryRepository.findById(requestDto.getCategoryId())
-                .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
-
-        Group group = groupRepository.findById(requestDto.getGroupId())
-                .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
-
-        Validator.validateStartDateBeforeEndDate(requestDto.getStartDate(), requestDto.getEndDate());
-        Todo memberTodo = requestDto.toEntity(member, todoCategory, group);
-        todoRepository.save(memberTodo);
-        return TodoResponseDto.of(memberTodo);
-    }
-
     public TodoDetailsResponseDto getOneTodo(Long memberId, Long todoId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));

--- a/src/main/java/scs/planus/global/util/validator/Validator.java
+++ b/src/main/java/scs/planus/global/util/validator/Validator.java
@@ -1,0 +1,18 @@
+package scs.planus.global.util.validator;
+
+import scs.planus.global.exception.PlanusException;
+
+import java.time.LocalDate;
+
+import static scs.planus.global.exception.CustomExceptionStatus.INVALID_DATE;
+
+public class Validator {
+
+    public static void validateStartDateBeforeEndDate(LocalDate startDate, LocalDate endDate) {
+        if (endDate != null) {
+            if (startDate.isAfter(endDate)) {
+                throw new PlanusException(INVALID_DATE);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- todo-calender 분리
- 그룹 개인 투두 생성 메서드 통합

### :: 특이사항
### 🔥 todo-calender 분리
- TodoController와 TodoService는 투두 생성 / 단일조회 / 변경 / 삭제를 담당하도록 역할을 나눴습니다.
- TodoCalenderController와 TodoCalenderService는 캘린더탭 기능을 담당합니다.
- 메서드를 분리하면서, 동일한 기능의 validateDate를 제거하고, Validator 클래스가 검증을 담당하도록 구현하였습니다

### 🔥 그룹 개인 투두 생성 메서드 통합
- 기존에 Controller에서 requestDto의 groupId 값에 대해 null 체크를 하여 개인 투두인지, 그룹 개인 투두인지 나눴던 것을 하나로 통합하였습니다. 이전, Todo를 update할 때 사용되는 getGroup을 재활용하였습니다.

