### PR TITLE
[Feat] 그룹 멤버 목록 조회 기능 구현

### DIFF
--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -34,7 +34,8 @@ public class GroupController {
     public BaseResponse<GroupGetResponseDto> getGroupDetailForNonMember( @AuthenticationPrincipal PrincipalDetails principalDetails,
                                                        @PathVariable("groupId") Long groupId ) {
 
-        GroupGetResponseDto responseDto = groupService.getGroupDetailForNonMember( groupId );
+        Long memberId = principalDetails.getId();
+        GroupGetResponseDto responseDto = groupService.getGroupDetailForNonMember( memberId, groupId );
 
         return new BaseResponse<>( responseDto );
     }

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -30,7 +30,7 @@ public class GroupController {
     }
 
     @GetMapping("/groups/{groupId}")
-    public BaseResponse<GroupGetResponseDto> getGroup( @AuthenticationPrincipal PrincipalDetails principalDetails,
+    public BaseResponse<GroupGetResponseDto> getGroupForNonMember( @AuthenticationPrincipal PrincipalDetails principalDetails,
                                                        @PathVariable("groupId") Long groupId ) {
 
         GroupGetResponseDto responseDto = groupService.getGroupForNonMember( groupId );

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -30,10 +30,10 @@ public class GroupController {
     }
 
     @GetMapping("/groups/{groupId}")
-    public BaseResponse<GroupGetResponseDto> getGroupForNonMember( @AuthenticationPrincipal PrincipalDetails principalDetails,
+    public BaseResponse<GroupGetResponseDto> getGroupDetailForNonMember( @AuthenticationPrincipal PrincipalDetails principalDetails,
                                                        @PathVariable("groupId") Long groupId ) {
 
-        GroupGetResponseDto responseDto = groupService.getGroupForNonMember( groupId );
+        GroupGetResponseDto responseDto = groupService.getGroupDetailForNonMember( groupId );
 
         return new BaseResponse<>( responseDto );
     }

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -11,6 +11,7 @@ import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.common.response.BaseResponse;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequestMapping("/app")
@@ -34,6 +35,15 @@ public class GroupController {
                                                        @PathVariable("groupId") Long groupId ) {
 
         GroupGetResponseDto responseDto = groupService.getGroupDetailForNonMember( groupId );
+
+        return new BaseResponse<>( responseDto );
+    }
+
+    @GetMapping("/groups/{groupId}/members")
+    public BaseResponse<List<GroupGetMemberResponseDto>> getGroupMemberForNonMember( @AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                                     @PathVariable("groupId") Long groupId ) {
+
+        List<GroupGetMemberResponseDto> responseDto = groupService.getGroupMemberForNonMember( groupId );
 
         return new BaseResponse<>( responseDto );
     }

--- a/src/main/java/scs/planus/domain/group/dto/GroupGetMemberResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupGetMemberResponseDto.java
@@ -1,0 +1,25 @@
+package scs.planus.domain.group.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.member.entity.Member;
+
+@Getter
+@Builder
+public class GroupGetMemberResponseDto {
+    private Long memberId;
+    private String nickname;
+    private boolean leader;
+    private String description;
+    private String profileImageUrl;
+
+    public static GroupGetMemberResponseDto of( Member member, boolean isLeader ) {
+        return GroupGetMemberResponseDto.builder()
+                .memberId( member.getId() )
+                .nickname( member.getNickname() )
+                .leader( isLeader )
+                .description( member.getDescription() )
+                .profileImageUrl( member.getProfileImageUrl() )
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/group/dto/GroupGetMemberResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupGetMemberResponseDto.java
@@ -9,15 +9,15 @@ import scs.planus.domain.member.entity.Member;
 public class GroupGetMemberResponseDto {
     private Long memberId;
     private String nickname;
-    private boolean leader;
+    private Boolean isLeader;
     private String description;
     private String profileImageUrl;
 
-    public static GroupGetMemberResponseDto of( Member member, boolean isLeader ) {
+    public static GroupGetMemberResponseDto of( Member member, Boolean isLeader ) {
         return GroupGetMemberResponseDto.builder()
                 .memberId( member.getId() )
                 .nickname( member.getNickname() )
-                .leader( isLeader )
+                .isLeader( isLeader )
                 .description( member.getDescription() )
                 .profileImageUrl( member.getProfileImageUrl() )
                 .build();

--- a/src/main/java/scs/planus/domain/group/dto/GroupGetResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupGetResponseDto.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class GroupGetResponseDto {
     private Long id;
     private String name;
+    private Boolean isJoined;
     private String notice;
     private String groupImageUrl;
     private Integer memberCount;
@@ -21,15 +22,16 @@ public class GroupGetResponseDto {
     private List<GroupTagResponseDto> groupTags;
 
 
-    public static GroupGetResponseDto of( Group group, String leaderName, List<GroupTagResponseDto> groupTagNameList ) {
+    public static GroupGetResponseDto of( Group group, List<GroupTagResponseDto> groupTagNameList, Boolean isJoined ) {
         return GroupGetResponseDto.builder()
                 .id( group.getId() )
                 .name( group.getName() )
+                .isJoined( isJoined )
                 .notice( group.getNotice() )
                 .groupImageUrl( group.getGroupImageUrl() )
                 .memberCount( group.getGroupMembers().size() )
                 .limitCount( group.getLimitCount() )
-                .leaderName( leaderName )
+                .leaderName( group.getLeaderName() )
                 .groupTags( groupTagNameList )
                 .build();
     }

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
@@ -16,4 +17,10 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             "where gm.group= :group " +
             "and gm.leader= true")
     Optional<GroupMember> findWithGroupAndLeaderByGroup(@Param("group") Group group );
+
+    @Query("select gm " +
+            "from GroupMember gm " +
+            "join fetch gm.member " +
+            "where gm.group= :group ")
+    List<GroupMember> findAllWithMemberByGroup(@Param("group") Group group );
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
+import scs.planus.domain.member.entity.Member;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,18 +19,18 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             "and gm.leader= true")
     Optional<GroupMember> findWithGroupAndLeaderByGroup(@Param("group") Group group );
 
-    @Query("select gm " +
-            "from GroupMember gm " +
-            "join fetch gm.member " +
-            "where gm.group= :group ")
-    List<GroupMember> findAllWithMemberByGroup(@Param("group") Group group );
-
     @Query("select gm from GroupMember gm " +
             "join fetch gm.group g " +
             "join fetch gm.member m " +
             "where m.id = :memberId and g.id = :groupId")
     Optional<GroupMember> findByMemberIdAndGroupId(@Param("memberId") Long memberId,
                                                    @Param("groupId") Long groupId);
+
+    @Query("select gm " +
+            "from GroupMember gm " +
+            "join fetch gm.member " +
+            "where gm.group= :group ")
+    List<GroupMember> findAllWithMemberByGroup(@Param("group") Group group );
 
     @Query("select gm from GroupMember gm " +
             "join fetch gm.group g " +

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -58,7 +58,7 @@ public class GroupService {
         return GroupResponseDto.of( saveGroup );
     }
 
-    public GroupGetResponseDto getGroupForNonMember(Long groupId ) {
+    public GroupGetResponseDto getGroupDetailForNonMember(Long groupId ) {
         Group group = groupRepository.findWithGroupMemberById( groupId )
                 .orElseThrow(() ->  new PlanusException(NOT_EXIST_GROUP));
 

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -75,6 +75,17 @@ public class GroupService {
         return GroupGetResponseDto.of( group, leaderName, groupTagResponseDtos );
     }
 
+    public List<GroupGetMemberResponseDto> getGroupMemberForNonMember(Long groupId) {
+        Group group = groupRepository.findByIdAndStatus( groupId )
+                .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_GROUP ); });
+
+        List<GroupMember> allGroupMembers = groupMemberRepository.findAllWithMemberByGroup(group);
+
+        return allGroupMembers.stream()
+                .map( gm -> GroupGetMemberResponseDto.of( gm.getMember(), gm.isLeader() ) )
+                .collect(Collectors.toList());
+    }
+
     @Transactional
     public GroupResponseDto updateGroupDetail( Long memberId, Long groupId, GroupDetailUpdateRequestDto requestDto, MultipartFile multipartFile ) {
         Group group = groupRepository.findByIdAndStatus( groupId )

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -5,19 +5,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import scs.planus.domain.group.dto.GroupCreateRequestDto;
-import scs.planus.domain.group.dto.GroupDetailUpdateRequestDto;
-import scs.planus.domain.group.dto.GroupGetResponseDto;
-import scs.planus.domain.group.dto.GroupNoticeUpdateRequestDto;
-import scs.planus.domain.group.dto.GroupResponseDto;
-import scs.planus.domain.group.dto.GroupTagResponseDto;
-import scs.planus.domain.group.dto.mygroup.GroupBelongInResponseDto;
+import scs.planus.domain.group.dto.*;
 import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.group.entity.GroupJoin;
 import scs.planus.domain.group.entity.GroupMember;
 import scs.planus.domain.group.entity.GroupTag;
-import scs.planus.domain.group.repository.GroupMemberRepository;
-import scs.planus.domain.group.repository.GroupRepository;
-import scs.planus.domain.group.repository.GroupTagRepository;
+import scs.planus.domain.group.repository.*;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.domain.tag.dto.TagCreateRequestDto;
@@ -40,6 +33,7 @@ public class GroupService {
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final GroupMemberQueryRepository groupMemberQueryRepository;
     private final GroupTagRepository groupTagRepository;
     private final GroupTagService groupTagService;
     private final TagService tagService;
@@ -64,12 +58,15 @@ public class GroupService {
         return GroupResponseDto.of( saveGroup );
     }
 
-    public GroupGetResponseDto getGroupDetailForNonMember(Long groupId ) {
+    public GroupGetResponseDto getGroupDetailForNonMember( Long memberId, Long groupId ) {
         Group group = groupRepository.findWithGroupMemberById( groupId )
-                .orElseThrow(() ->  new PlanusException(NOT_EXIST_GROUP));
+                .orElseThrow(() ->  new PlanusException( NOT_EXIST_GROUP ));
 
-        // 그룹 리더 이름 조회
-        String leaderName = group.getLeaderName();
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> new PlanusException( NONE_USER ));
+
+        // 가입한 그룹인지 검증
+        Boolean isJoined = groupMemberQueryRepository.existByMemberIdAndGroupId( member.getId(), groupId );
 
         // 그룹 테그 조회 후 List<dto>로 변경
         List<GroupTag> groupTags = groupTagRepository.findAllByGroup( group );
@@ -78,7 +75,7 @@ public class GroupService {
                         .map( GroupTagResponseDto::of )
                         .collect( Collectors.toList() );
 
-        return GroupGetResponseDto.of( group, leaderName, groupTagResponseDtos );
+        return GroupGetResponseDto.of( group, groupTagResponseDtos, isJoined );
     }
 
     public List<GroupGetMemberResponseDto> getGroupMemberForNonMember(Long groupId) {


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 비회원이 그룹의 정보를 조회 할때, 그룹에 가입되어있는 회원들의 리스트를 조회하는 기능을 구현하였습니다.
- `group` 정보로 모든 `groupMember` 와 `Member` 객체를 조회하기 위해 `groupMemberRepository` 에 `.findAllWithMemberByGroup()` 쿼리를 구형하였습니다.
- 조회된 각 Member 들을 `GroupGetMemberResponseDto` 로 변환한 다음 `List` 로 담아 응답합니다.

### :: 특이사항
- 상세 정보 조회와 그룹 회원 정보 API 명을 직관적으로 나타내기 위해, 각각 `getGroupDetailForNonMember` 와 `getGroupMemberForNonMember` 로 수정하였습니다.
- 그룹원들 중 `Leader `를 구분해주기 위해 `GroupGetMemberResponseDto` 에 `boolen leader` 필드를 추가하여, `Leader` 는 `true`로, 나머지 그룹원들은 `false` 로 반환하도록 하였습니다.
