### PR TITLE
[Feat] 속한 그룹 조회 기능 구현 및 그룹 지정 Todo 필터링 구현

### DIFF
--- a/src/main/java/scs/planus/domain/group/dto/GroupBelongInResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupBelongInResponseDto.java
@@ -1,0 +1,21 @@
+package scs.planus.domain.group.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.group.entity.Group;
+
+@Getter
+@Builder
+public class GroupBelongInResponseDto {
+
+    private Long groupId;
+    private String groupName;
+
+    public static GroupBelongInResponseDto of(Group group) {
+        return GroupBelongInResponseDto
+                .builder()
+                .groupId(group.getId())
+                .groupName(group.getName())
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberQueryRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberQueryRepository.java
@@ -1,9 +1,11 @@
 package scs.planus.domain.group.repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
+import scs.planus.domain.Status;
 
 import static scs.planus.domain.group.entity.QGroup.group;
 import static scs.planus.domain.group.entity.QGroupMember.groupMember;
@@ -21,8 +23,20 @@ public class GroupMemberQueryRepository {
                 .from(groupMember)
                 .join(groupMember.member, member)
                 .join(groupMember.group, group)
-                .where(member.id.eq(memberId), group.id.eq(groupId))
+                .where(isActiveGroup(), memberIdEq(memberId), groupIdEq(groupId))
                 .fetchFirst();
         return fetchOne != null;
+    }
+
+    private BooleanExpression memberIdEq(Long memberId) {
+        return member.id.eq(memberId);
+    }
+
+    private BooleanExpression groupIdEq(Long groupId) {
+        return group.id.eq(groupId);
+    }
+
+    private BooleanExpression isActiveGroup() {
+        return group.status.eq(Status.ACTIVE);
     }
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberQueryRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberQueryRepository.java
@@ -1,0 +1,28 @@
+package scs.planus.domain.group.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import static scs.planus.domain.group.entity.QGroup.group;
+import static scs.planus.domain.group.entity.QGroupMember.groupMember;
+import static scs.planus.domain.member.entity.QMember.member;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class GroupMemberQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public Boolean existByMemberIdAndGroupId(Long memberId, Long groupId) {
+        Integer fetchOne = queryFactory.selectOne()
+                .from(groupMember)
+                .join(groupMember.member, member)
+                .join(groupMember.group, group)
+                .where(member.id.eq(memberId), group.id.eq(groupId))
+                .fetchFirst();
+        return fetchOne != null;
+    }
+}

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
@@ -15,5 +16,11 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             "join fetch gm.member " +
             "where gm.group= :group " +
             "and gm.leader= true")
-    Optional<GroupMember> findWithGroupAndLeaderByGroup(@Param("group") Group group );
+    Optional<GroupMember> findWithGroupAndLeaderByGroup(@Param("group") Group group);
+
+    @Query("select gm from GroupMember gm " +
+            "join fetch gm.group g " +
+            "join fetch gm.member m " +
+            "where g.status = 'ACTIVE' and m.id = :memberId")
+    List<GroupMember> findAllByActiveGroupAndMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import scs.planus.domain.group.entity.Group;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
@@ -14,6 +15,11 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             "where g.id= :groupId " +
             "and g.status= 'ACTIVE'")
     Optional<Group> findWithGroupMemberById(@Param("groupId") Long groupId);
+
+    @Query("select g from Group g " +
+            "join fetch g.groupMembers gm " +
+            "where g.status = 'ACTIVE' and gm.member.id= :memberId")
+    List<Group> findAllMyGroupByMemberId(@Param("memberId") Long memberId);
 
     @Query("select g " +
             "from Group g " +

--- a/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
@@ -5,7 +5,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import scs.planus.domain.group.entity.Group;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
@@ -15,11 +14,6 @@ public interface GroupRepository extends JpaRepository<Group, Long> {
             "where g.id= :groupId " +
             "and g.status= 'ACTIVE'")
     Optional<Group> findWithGroupMemberById(@Param("groupId") Long groupId);
-
-    @Query("select g from Group g " +
-            "join fetch g.groupMembers gm " +
-            "where g.status = 'ACTIVE' and gm.member.id= :memberId")
-    List<Group> findAllMyGroupByMemberId(@Param("memberId") Long memberId);
 
     @Query("select g " +
             "from Group g " +

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -175,7 +175,11 @@ public class GroupService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
-        List<Group> groups = groupRepository.findAllMyGroupByMemberId(member.getId());
+        List<GroupMember> groupMembers = groupMemberRepository.findAllByActiveGroupAndMemberId(member.getId());
+        List<Group> groups = groupMembers.stream()
+                .map(GroupMember::getGroup)
+                .collect(Collectors.toList());
+
         List<GroupBelongInResponseDto> responseDtos = groups.stream()
                 .map(GroupBelongInResponseDto::of)
                 .collect(Collectors.toList());

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -5,6 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import scs.planus.domain.group.dto.GroupBelongInResponseDto;
+import scs.planus.domain.group.dto.GroupCreateRequestDto;
+import scs.planus.domain.group.dto.GroupGetResponseDto;
+import scs.planus.domain.group.dto.GroupResponseDto;
+import scs.planus.domain.group.dto.GroupTagResponseDto;
 import scs.planus.domain.group.dto.*;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
@@ -164,6 +169,18 @@ public class GroupService {
         groupMemberRepository.save(groupMember);
 
         return GroupResponseDto.of( group );
+    }
+
+    public List<GroupBelongInResponseDto> getMyGroups(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        List<Group> groups = groupRepository.findAllMyGroupByMemberId(member.getId());
+        List<GroupBelongInResponseDto> responseDtos = groups.stream()
+                .map(GroupBelongInResponseDto::of)
+                .collect(Collectors.toList());
+
+        return responseDtos;
     }
 
     private void validateLeaderPermission( Member member, Group group ) {

--- a/src/main/java/scs/planus/domain/todo/controller/TodoCalendarController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoCalendarController.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,7 +31,7 @@ public class TodoCalendarController {
     @GetMapping("/todos/calendar")
     public BaseResponse<List<TodoDetailsResponseDto>> getTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
-                                                               @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to){
+                                                               @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
         Long memberId = principalDetails.getId();
         List<TodoDetailsResponseDto> responseDtos = todoCalendarService.getPeriodDetailTodos(memberId, from, to);
         return new BaseResponse<>(responseDtos);
@@ -57,6 +58,16 @@ public class TodoCalendarController {
     public BaseResponse<List<GroupBelongInResponseDto>> getMyGroups(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         Long memberId = principalDetails.getId();
         List<GroupBelongInResponseDto> responseDtos = todoCalendarService.getAllMyGroup(memberId);
+        return new BaseResponse<>(responseDtos);
+    }
+
+    @GetMapping("/todos/calendar/my-groups/{groupId}")
+    public BaseResponse<List<TodoDetailsResponseDto>> getGroupTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                    @PathVariable Long groupId,
+                                                                    @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
+                                                                    @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
+        Long memberId = principalDetails.getId();
+        List<TodoDetailsResponseDto> responseDtos = todoCalendarService.getPeriodDetailGroupTodos(memberId, groupId, from, to);
         return new BaseResponse<>(responseDtos);
     }
 }

--- a/src/main/java/scs/planus/domain/todo/controller/TodoCalendarController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoCalendarController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import scs.planus.domain.group.dto.GroupBelongInResponseDto;
 import scs.planus.domain.todo.dto.TodoDailyResponseDto;
 import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
 import scs.planus.domain.todo.dto.TodoPeriodResponseDto;
@@ -49,6 +50,13 @@ public class TodoCalendarController {
                                                             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         Long memberId = principalDetails.getId();
         TodoDailyResponseDto responseDtos = todoCalendarService.getDailyTodos(memberId, date);
+        return new BaseResponse<>(responseDtos);
+    }
+
+    @GetMapping("/todos/calendar/my-groups")
+    public BaseResponse<List<GroupBelongInResponseDto>> getMyGroups(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        Long memberId = principalDetails.getId();
+        List<GroupBelongInResponseDto> responseDtos = todoCalendarService.getAllMyGroup(memberId);
         return new BaseResponse<>(responseDtos);
     }
 }

--- a/src/main/java/scs/planus/domain/todo/controller/TodoCalendarController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoCalendarController.java
@@ -26,7 +26,7 @@ public class TodoCalendarController {
 
     private final TodoCalendarService todoCalendarService;
 
-    @GetMapping("/todos")
+    @GetMapping("/todos/calendar")
     public BaseResponse<List<TodoDetailsResponseDto>> getTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to){
@@ -35,7 +35,7 @@ public class TodoCalendarController {
         return new BaseResponse<>(responseDtos);
     }
 
-    @GetMapping("/todos/period")
+    @GetMapping("/todos//calendar/period")
     public BaseResponse<List<TodoPeriodResponseDto>> getPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                     @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
                                                                     @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
@@ -44,7 +44,7 @@ public class TodoCalendarController {
         return new BaseResponse<>(responseDtos);
     }
 
-    @GetMapping("/todos/daily")
+    @GetMapping("/todos/calendar/daily")
     public BaseResponse<TodoDailyResponseDto> getDailyTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         Long memberId = principalDetails.getId();

--- a/src/main/java/scs/planus/domain/todo/controller/TodoCalendarController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoCalendarController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import scs.planus.domain.todo.dto.TodoDailyResponseDto;
 import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
 import scs.planus.domain.todo.dto.TodoPeriodResponseDto;
-import scs.planus.domain.todo.service.TodoCalenderService;
+import scs.planus.domain.todo.service.TodoCalendarService;
 import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.common.response.BaseResponse;
 
@@ -22,16 +22,16 @@ import java.util.List;
 @RequestMapping("/app")
 @RequiredArgsConstructor
 @Slf4j
-public class TodoCalenderController {
+public class TodoCalendarController {
 
-    private final TodoCalenderService todoCalenderService;
+    private final TodoCalendarService todoCalendarService;
 
     @GetMapping("/todos")
     public BaseResponse<List<TodoDetailsResponseDto>> getTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to){
         Long memberId = principalDetails.getId();
-        List<TodoDetailsResponseDto> responseDtos = todoCalenderService.getPeriodDetailTodos(memberId, from, to);
+        List<TodoDetailsResponseDto> responseDtos = todoCalendarService.getPeriodDetailTodos(memberId, from, to);
         return new BaseResponse<>(responseDtos);
     }
 
@@ -40,7 +40,7 @@ public class TodoCalenderController {
                                                                     @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
                                                                     @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
         Long memberId = principalDetails.getId();
-        List<TodoPeriodResponseDto> responseDtos = todoCalenderService.getPeriodTodos(memberId, from, to);
+        List<TodoPeriodResponseDto> responseDtos = todoCalendarService.getPeriodTodos(memberId, from, to);
         return new BaseResponse<>(responseDtos);
     }
 
@@ -48,7 +48,7 @@ public class TodoCalenderController {
     public BaseResponse<TodoDailyResponseDto> getDailyTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         Long memberId = principalDetails.getId();
-        TodoDailyResponseDto responseDtos = todoCalenderService.getDailyTodos(memberId, date);
+        TodoDailyResponseDto responseDtos = todoCalendarService.getDailyTodos(memberId, date);
         return new BaseResponse<>(responseDtos);
     }
 }

--- a/src/main/java/scs/planus/domain/todo/controller/TodoCalendarController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoCalendarController.java
@@ -70,4 +70,14 @@ public class TodoCalendarController {
         List<TodoDetailsResponseDto> responseDtos = todoCalendarService.getPeriodDetailGroupTodos(memberId, groupId, from, to);
         return new BaseResponse<>(responseDtos);
     }
+
+    @GetMapping("/todos/calendar/my-groups/{groupId}/period")
+    public BaseResponse<List<TodoPeriodResponseDto>> getPeriodGroupTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                         @PathVariable Long groupId,
+                                                                         @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
+                                                                         @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
+        Long memberId = principalDetails.getId();
+        List<TodoPeriodResponseDto> responseDtos = todoCalendarService.getPeriodGroupTodos(memberId, groupId, from, to);
+        return new BaseResponse<>(responseDtos);
+    }
 }

--- a/src/main/java/scs/planus/domain/todo/controller/TodoCalendarController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/TodoCalendarController.java
@@ -36,7 +36,7 @@ public class TodoCalendarController {
         return new BaseResponse<>(responseDtos);
     }
 
-    @GetMapping("/todos//calendar/period")
+    @GetMapping("/todos/calendar/period")
     public BaseResponse<List<TodoPeriodResponseDto>> getPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                     @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
                                                                     @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -65,17 +65,6 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
-    public List<Todo> findPeriodGroupTodosDetailByDate(Long memberId, Long groupId, LocalDate from, LocalDate to) {
-        return queryFactory
-                .selectFrom(todo)
-                .join(todo.member, member)
-                .leftJoin(todo.group, group).fetchJoin()
-                .join(todo.todoCategory, todoCategory).fetchJoin()
-                .where(memberIdEq(memberId), groupIdEq(groupId), periodBetween(from, to))
-                .orderBy(todo.startDate.asc())
-                .fetch();
-    }
-
     public List<Todo> findPeriodGroupTodosByDate(Long memberId, Long groupId, LocalDate from, LocalDate to) {
         return queryFactory
                 .selectFrom(todo)

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -54,7 +54,7 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
-    public List<Todo> findPeriodTodosDetailByDate(Long memberId, LocalDate from, LocalDate to) {
+    public List<Todo> findPeriodGroupTodosDetailByDate(Long memberId, LocalDate from, LocalDate to) {
         return queryFactory
                 .selectFrom(todo)
                 .join(todo.member, member)
@@ -65,7 +65,7 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
-    public List<Todo> findPeriodTodosDetailByDate(Long memberId, Long groupId, LocalDate from, LocalDate to) {
+    public List<Todo> findPeriodGroupTodosDetailByDate(Long memberId, Long groupId, LocalDate from, LocalDate to) {
         return queryFactory
                 .selectFrom(todo)
                 .join(todo.member, member)

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -87,19 +87,19 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
-    private BooleanExpression periodBetween(LocalDate from, LocalDate to) {
-        return todo.startDate.between(from, to).or(todo.endDate.between(from, to));
-    }
-
-    private BooleanExpression dateBetween(LocalDate date) {
-        return todo.startDate.loe(date).and(todo.endDate.goe(date));
-    }
-
     private BooleanExpression memberIdEq(Long memberId) {
         return member.id.eq(memberId);
     }
 
     private BooleanExpression groupIdEq(Long groupId) {
         return group.id.eq(groupId);
+    }
+
+    private BooleanExpression dateBetween(LocalDate date) {
+        return todo.startDate.loe(date).and(todo.endDate.goe(date));
+    }
+
+    private BooleanExpression periodBetween(LocalDate from, LocalDate to) {
+        return todo.startDate.between(from, to).or(todo.endDate.between(from, to));
     }
 }

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -76,6 +76,17 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
+    public List<Todo> findPeriodGroupTodosByDate(Long memberId, Long groupId, LocalDate from, LocalDate to) {
+        return queryFactory
+                .selectFrom(todo)
+                .join(todo.member, member)
+                .leftJoin(todo.group, group).fetchJoin()
+                .join(todo.todoCategory, todoCategory).fetchJoin()
+                .where(memberIdEq(memberId), groupIdEq(groupId), periodBetween(from, to))
+                .orderBy(todo.startDate.asc())
+                .fetch();
+    }
+
     private BooleanExpression periodBetween(LocalDate from, LocalDate to) {
         return todo.startDate.between(from, to).or(todo.endDate.between(from, to));
     }

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -65,6 +65,17 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
+    public List<Todo> findPeriodTodosDetailByDate(Long memberId, Long groupId, LocalDate from, LocalDate to) {
+        return queryFactory
+                .selectFrom(todo)
+                .join(todo.member, member)
+                .leftJoin(todo.group, group).fetchJoin()
+                .join(todo.todoCategory, todoCategory).fetchJoin()
+                .where(memberIdEq(memberId), groupIdEq(groupId), periodBetween(from, to))
+                .orderBy(todo.startDate.asc())
+                .fetch();
+    }
+
     private BooleanExpression periodBetween(LocalDate from, LocalDate to) {
         return todo.startDate.between(from, to).or(todo.endDate.between(from, to));
     }
@@ -75,5 +86,9 @@ public class TodoQueryRepository {
 
     private BooleanExpression memberIdEq(Long memberId) {
         return member.id.eq(memberId);
+    }
+
+    private BooleanExpression groupIdEq(Long groupId) {
+        return group.id.eq(groupId);
     }
 }

--- a/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
@@ -42,7 +42,7 @@ public class TodoCalendarService {
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
         Validator.validateStartDateBeforeEndDate(from, to);
-        List<Todo> todos = todoQueryRepository.findPeriodTodosDetailByDate(member.getId(), from, to);
+        List<Todo> todos = todoQueryRepository.findPeriodGroupTodosDetailByDate(member.getId(), from, to);
         List<TodoDetailsResponseDto> responseDtos = todos.stream()
                 .map(TodoDetailsResponseDto::of)
                 .collect(Collectors.toList());
@@ -92,7 +92,7 @@ public class TodoCalendarService {
         }
 
         Validator.validateStartDateBeforeEndDate(from, to);
-        List<Todo> todos = todoQueryRepository.findPeriodTodosDetailByDate(member.getId(), groupId, from, to);
+        List<Todo> todos = todoQueryRepository.findPeriodGroupTodosDetailByDate(member.getId(), groupId, from, to);
         List<TodoDetailsResponseDto> responseDtos = todos.stream()
                 .map(TodoDetailsResponseDto::of)
                 .collect(Collectors.toList());

--- a/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
@@ -74,10 +74,7 @@ public class TodoCalendarService {
     }
 
     public List<GroupBelongInResponseDto> getAllMyGroup(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new PlanusException(NONE_USER));
-
-        List<GroupBelongInResponseDto> responseDtos = groupService.getMyGroups(member.getId());
+        List<GroupBelongInResponseDto> responseDtos = groupService.getMyGroups(memberId);
         return responseDtos;
     }
 

--- a/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
@@ -26,7 +26,7 @@ import static scs.planus.global.exception.CustomExceptionStatus.NONE_USER;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Slf4j
-public class TodoCalenderService {
+public class TodoCalendarService {
 
     private final MemberRepository memberRepository;
     private final TodoQueryRepository todoQueryRepository;

--- a/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import scs.planus.domain.group.dto.GroupBelongInResponseDto;
+import scs.planus.domain.group.service.GroupService;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.domain.todo.dto.TodoDailyDto;
@@ -28,6 +30,7 @@ import static scs.planus.global.exception.CustomExceptionStatus.NONE_USER;
 @Slf4j
 public class TodoCalendarService {
 
+    private final GroupService groupService;
     private final MemberRepository memberRepository;
     private final TodoQueryRepository todoQueryRepository;
 
@@ -65,6 +68,14 @@ public class TodoCalendarService {
         List<TodoDailyDto> todoDailyDtos = getDailyTodos(todos);
 
         return TodoDailyResponseDto.of(todoDailyScheduleDtos, todoDailyDtos);
+    }
+
+    public List<GroupBelongInResponseDto> getAllMyGroup(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        List<GroupBelongInResponseDto> responseDtos = groupService.getMyGroups(member.getId());
+        return responseDtos;
     }
 
     private List<TodoDailyScheduleDto> getDailySchedules(List<Todo> todos) {

--- a/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
@@ -42,7 +42,7 @@ public class TodoCalendarService {
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
         Validator.validateStartDateBeforeEndDate(from, to);
-        List<Todo> todos = todoQueryRepository.findPeriodGroupTodosDetailByDate(member.getId(), from, to);
+        List<Todo> todos = todoQueryRepository.findPeriodTodosByDate(member.getId(), from, to);
         List<TodoDetailsResponseDto> responseDtos = todos.stream()
                 .map(TodoDetailsResponseDto::of)
                 .collect(Collectors.toList());
@@ -89,7 +89,7 @@ public class TodoCalendarService {
         }
 
         Validator.validateStartDateBeforeEndDate(from, to);
-        List<Todo> todos = todoQueryRepository.findPeriodGroupTodosDetailByDate(member.getId(), groupId, from, to);
+        List<Todo> todos = todoQueryRepository.findPeriodGroupTodosByDate(member.getId(), groupId, from, to);
         List<TodoDetailsResponseDto> responseDtos = todos.stream()
                 .map(TodoDetailsResponseDto::of)
                 .collect(Collectors.toList());

--- a/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
@@ -84,7 +84,7 @@ public class TodoCalendarService {
 
         boolean isJoined = groupMemberQueryRepository.existByMemberIdAndGroupId(member.getId(), groupId);
 
-        if (isJoined) {
+        if (!isJoined) {
             throw new PlanusException(NOT_JOINED_GROUP);
         }
 

--- a/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
@@ -97,6 +97,25 @@ public class TodoCalendarService {
         return responseDtos;
     }
 
+    public List<TodoPeriodResponseDto> getPeriodGroupTodos(Long memberId, Long groupId, LocalDate from, LocalDate to) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        boolean isJoined = groupMemberQueryRepository.existByMemberIdAndGroupId(member.getId(), groupId);
+
+        if (!isJoined) {
+            throw new PlanusException(NOT_JOINED_GROUP);
+        }
+
+        Validator.validateStartDateBeforeEndDate(from, to);
+        List<Todo> todos = todoQueryRepository.findPeriodGroupTodosByDate(member.getId(), groupId, from, to);
+        List<TodoPeriodResponseDto> responseDtos = todos.stream()
+                .map(TodoPeriodResponseDto::of)
+                .collect(Collectors.toList());
+
+        return responseDtos;
+    }
+
     private List<TodoDailyScheduleDto> getDailySchedules(List<Todo> todos) {
         return todos.stream()
                 .filter(todo -> todo.getStartTime() != null)

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -39,6 +39,9 @@ public enum CustomExceptionStatus implements ResponseStatus {
     NOT_EXIST_LEADER(BAD_REQUEST, 2601, "해당 그룹에 그룹장이 존재하지 않습니다."),
     NOT_GROUP_LEADER_PERMISSION(BAD_REQUEST, 2602, "그룹을 수정할 권한이 없습니다."),
 
+    // groupMember excepion
+    NOT_JOINED_GROUP(BAD_REQUEST, 2700, "가입하지 않은 그룹 입니다."),
+
     // s3 exception
     INVALID_FILE(BAD_REQUEST, 5000, "잘못되거나 존재하지 않는 파일입니다."),
     INVALID_FILE_EXTENSION(BAD_REQUEST, 5001, "잘못된 확장자입니다. jpeg / jpg / png / heic 파일을 선택해주세요.")


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 속한 그룹 조회 기능 구현
- 그룹 지정 Todo 필터링 구현

### :: 특이사항
###  🔥 속한 그룹 조회 기능 구현
- `/app/todos/calendar/my-groups`
- 캘린더 탭에서의 그룹 드롭 다운 리스트를 구현하였습니다.
- `GroupService.getMyGroups()`
  - 일대다 fetch join을 피하기 위하여, memberId를 갖는GroupMember를 조회한 후, stream을 이용하여 group 정보를 가져왔습니다.

###  🔥 그룹 지정 Todo 필터링 구현
- `/app/todos/calendar/my-groups/{groupId}`
- 그룹 선택 시, 그룹별 Todo를 필터링하는 기능을 구현하였습니다.
- GroupMemberQueryRepository.existByMemberIdAndGroupId
- 그 이전에, PathVariable로 들어온 groupId에 대해, 자신이 속한 그룹인지 아닌지 검증하는 과정을 구현하였습니다. 
  - Query-dsl을 통해, exists를 count 쿼리 대신하여 구현하였습니다. 
