### PR TITLE
[Feat] 나의 그룹 전체 보기 구현 및 온라인 상태 변경 구현

### DIFF
--- a/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
@@ -1,0 +1,30 @@
+package scs.planus.domain.group.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
+import scs.planus.domain.group.service.MyGroupService;
+import scs.planus.global.auth.entity.PrincipalDetails;
+import scs.planus.global.common.response.BaseResponse;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/app")
+@RequiredArgsConstructor
+@Slf4j
+public class MyGroupController {
+
+    private final MyGroupService myGroupService;
+
+    @GetMapping("/my-groups")
+    public BaseResponse<List<MyGroupResponseDto>> getMyGroups(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        Long memberId = principalDetails.getId();
+        List<MyGroupResponseDto> responseDtos = myGroupService.getMyGroups(memberId);
+        return new BaseResponse<>(responseDtos);
+    }
+}

--- a/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
@@ -4,8 +4,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
 import scs.planus.domain.group.service.MyGroupService;
 import scs.planus.global.auth.entity.PrincipalDetails;
@@ -26,5 +29,13 @@ public class MyGroupController {
         Long memberId = principalDetails.getId();
         List<MyGroupResponseDto> responseDtos = myGroupService.getMyGroups(memberId);
         return new BaseResponse<>(responseDtos);
+    }
+
+    @PatchMapping("/my-groups/{groupId}/online-status")
+    public BaseResponse<MyGroupOnlineStatusResponseDto> updateOnlineStatus(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                           @PathVariable Long groupId) {
+        Long memberId = principalDetails.getId();
+        MyGroupOnlineStatusResponseDto responseDto = myGroupService.changeOnlineStatus(memberId, groupId);
+        return new BaseResponse<>(responseDto);
     }
 }

--- a/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupOnlineStatusResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupOnlineStatusResponseDto.java
@@ -1,0 +1,18 @@
+package scs.planus.domain.group.dto.mygroup;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.group.entity.GroupMember;
+
+@Getter
+@Builder
+public class MyGroupOnlineStatusResponseDto {
+
+    private Long groupMemberId;
+
+    public static MyGroupOnlineStatusResponseDto of(GroupMember groupMember) {
+        return MyGroupOnlineStatusResponseDto.builder()
+                .groupMemberId(groupMember.getId())
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupResponseDto.java
@@ -1,0 +1,39 @@
+package scs.planus.domain.group.dto.mygroup;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.group.dto.GroupTagResponseDto;
+import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.group.entity.GroupTag;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class MyGroupResponseDto {
+
+    private Long groupId;
+    private String groupName;
+    private Long totalCount;
+    private Long limitCount;
+    private Long onlineCount;
+    private String leaderName;
+    private Boolean isOnline;
+    private List<GroupTagResponseDto> groupTags;
+
+    public static MyGroupResponseDto of(Group group, List<GroupTag> groupTags) {
+        List<GroupTagResponseDto> groupTagDtos = groupTags.stream()
+                .map(GroupTagResponseDto::of)
+                .collect(Collectors.toList());
+
+        return MyGroupResponseDto.builder()
+                .groupId(group.getId())
+                .groupName(group.getName())
+                .limitCount(group.getLimitCount())
+                .leaderName(group.getLeaderName())
+                .totalCount((long) group.getGroupMembers().size())
+                .groupTags(groupTagDtos)
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupResponseDto.java
@@ -4,10 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 import scs.planus.domain.group.dto.GroupTagResponseDto;
 import scs.planus.domain.group.entity.Group;
-import scs.planus.domain.group.entity.GroupTag;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -23,11 +21,7 @@ public class MyGroupResponseDto {
     private String leaderName;
     private List<GroupTagResponseDto> groupTags;
 
-    public static MyGroupResponseDto of(Group group, List<GroupTag> groupTags, Boolean onlineStatus, Long onlineCount) {
-        List<GroupTagResponseDto> groupTagDtos = groupTags.stream()
-                .map(GroupTagResponseDto::of)
-                .collect(Collectors.toList());
-
+    public static MyGroupResponseDto of(Group group, List<GroupTagResponseDto> eachGroupTagDtos, Boolean onlineStatus, Long onlineCount) {
         return MyGroupResponseDto.builder()
                 .groupId(group.getId())
                 .groupImageUrl(group.getGroupImageUrl())
@@ -37,7 +31,7 @@ public class MyGroupResponseDto {
                 .totalCount((long) group.getGroupMembers().size())
                 .limitCount(group.getLimitCount())
                 .leaderName(group.getLeaderName())
-                .groupTags(groupTagDtos)
+                .groupTags(eachGroupTagDtos)
                 .build();
     }
 }

--- a/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupResponseDto.java
@@ -14,25 +14,29 @@ import java.util.stream.Collectors;
 public class MyGroupResponseDto {
 
     private Long groupId;
+    private String groupImageUrl;
     private String groupName;
+    private Boolean isOnline;
+    private Long onlineCount;
     private Long totalCount;
     private Long limitCount;
-    private Long onlineCount;
     private String leaderName;
-    private Boolean isOnline;
     private List<GroupTagResponseDto> groupTags;
 
-    public static MyGroupResponseDto of(Group group, List<GroupTag> groupTags) {
+    public static MyGroupResponseDto of(Group group, List<GroupTag> groupTags, Boolean onlineStatus, Long onlineCount) {
         List<GroupTagResponseDto> groupTagDtos = groupTags.stream()
                 .map(GroupTagResponseDto::of)
                 .collect(Collectors.toList());
 
         return MyGroupResponseDto.builder()
                 .groupId(group.getId())
+                .groupImageUrl(group.getGroupImageUrl())
                 .groupName(group.getName())
+                .isOnline(onlineStatus)
+                .onlineCount(onlineCount)
+                .totalCount((long) group.getGroupMembers().size())
                 .limitCount(group.getLimitCount())
                 .leaderName(group.getLeaderName())
-                .totalCount((long) group.getGroupMembers().size())
                 .groupTags(groupTagDtos)
                 .build();
     }

--- a/src/main/java/scs/planus/domain/group/entity/GroupMember.java
+++ b/src/main/java/scs/planus/domain/group/entity/GroupMember.java
@@ -62,4 +62,8 @@ public class GroupMember extends BaseTimeEntity {
                 .group(group)
                 .build();
     }
+
+    public void changeOnlineStatus() {
+        this.onlineStatus = !this.onlineStatus;
+    }
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -23,4 +23,10 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             "join fetch gm.member m " +
             "where g.status = 'ACTIVE' and m.id = :memberId")
     List<GroupMember> findAllByActiveGroupAndMemberId(@Param("memberId") Long memberId);
+
+    @Query("select gm from GroupMember gm " +
+            "join fetch gm.group g " +
+            "join fetch gm.member m " +
+            "where g in :groups")
+    List<GroupMember> findAllGroupMemberInGroups(@Param("groups") List<Group> groups);
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -21,6 +21,13 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     @Query("select gm from GroupMember gm " +
             "join fetch gm.group g " +
             "join fetch gm.member m " +
+            "where m.id = :memberId and g.id = :groupId")
+    Optional<GroupMember> findByMemberIdAndGroupId(@Param("memberId") Long memberId,
+                                                   @Param("groupId") Long groupId);
+
+    @Query("select gm from GroupMember gm " +
+            "join fetch gm.group g " +
+            "join fetch gm.member m " +
             "where g.status = 'ACTIVE' and m.id = :memberId")
     List<GroupMember> findAllByActiveGroupAndMemberId(@Param("memberId") Long memberId);
 

--- a/src/main/java/scs/planus/domain/group/repository/GroupTagRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupTagRepository.java
@@ -14,4 +14,11 @@ public interface GroupTagRepository extends JpaRepository<GroupTag, Long> {
             "join fetch gt.tag t " +
             "where gt.group= :group ")
     List<GroupTag> findAllByGroup(@Param("group") Group group);
+
+    @Query("select gt " +
+            "from GroupTag gt " +
+            "join fetch gt.group g " +
+            "join fetch gt.tag t " +
+            "where g in :groups ")
+    List<GroupTag> findAllTagInGroups(@Param("groups") List<Group> groups);
 }

--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -80,13 +80,16 @@ public class MyGroupService {
                             .filter(groupTag -> groupTag.getGroup().getId().equals(group.getId()))
                             .map(GroupTagResponseDto::of)
                             .collect(Collectors.toList());
-                    List<GroupMember> eachGroupMembers = allGroupMembers.stream()
+
+                    Boolean onlineStatus = myGroupMembers.stream()
                             .filter(groupMember -> groupMember.getGroup().getId().equals(group.getId()))
-                            .collect(Collectors.toList());
-                    Boolean onlineStatus = myGroupMembers.stream().filter(groupMember -> groupMember.getGroup().getId().equals(group.getId()))
                             .map(GroupMember::isOnlineStatus)
                             .findFirst().orElseThrow(() -> new PlanusException(INTERNAL_SERVER_ERROR));
-                    long onlineCount = eachGroupMembers.stream().filter(GroupMember::isOnlineStatus).count();
+
+                    long onlineCount = allGroupMembers.stream()
+                            .filter(groupMember -> groupMember.getGroup().getId().equals(group.getId()))
+                            .filter(GroupMember::isOnlineStatus)
+                            .count();
 
                     return MyGroupResponseDto.of(group, eachGroupTagDtos, onlineStatus, onlineCount);
                 })

--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -5,9 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import scs.planus.domain.group.dto.mygroup.GroupBelongInResponseDto;
-import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
 import scs.planus.domain.group.repository.GroupMemberRepository;
+import scs.planus.domain.group.repository.GroupTagRepository;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.global.exception.PlanusException;
@@ -25,18 +25,15 @@ public class MyGroupService {
 
     private final MemberRepository memberRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final GroupTagRepository groupTagRepository;
 
     public List<GroupBelongInResponseDto> getMyGroupsInDropDown(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
         List<GroupMember> groupMembers = groupMemberRepository.findAllByActiveGroupAndMemberId(member.getId());
-        List<Group> groups = groupMembers.stream()
-                .map(GroupMember::getGroup)
-                .collect(Collectors.toList());
-
-        List<GroupBelongInResponseDto> responseDtos = groups.stream()
-                .map(GroupBelongInResponseDto::of)
+        List<GroupBelongInResponseDto> responseDtos = groupMembers.stream()
+                .map(gm -> GroupBelongInResponseDto.of(gm.getGroup()))
                 .collect(Collectors.toList());
 
         return responseDtos;

--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import scs.planus.domain.group.dto.GroupTagResponseDto;
 import scs.planus.domain.group.dto.mygroup.GroupBelongInResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
 import scs.planus.domain.group.entity.Group;
@@ -62,8 +63,9 @@ public class MyGroupService {
         List<GroupTag> allGroupTags = groupTagRepository.findAllTagInGroups(myGroups);
 
         List<MyGroupResponseDto> responseDtos = myGroups.stream().map(group -> {
-                    List<GroupTag> eachGroupTags = allGroupTags.stream()
+                    List<GroupTagResponseDto> eachGroupTagDtos = allGroupTags.stream()
                             .filter(groupTag -> groupTag.getGroup().getId().equals(group.getId()))
+                            .map(GroupTagResponseDto::of)
                             .collect(Collectors.toList());
                     List<GroupMember> eachGroupMembers = allGroupMembers.stream()
                             .filter(groupMember -> groupMember.getGroup().getId().equals(group.getId()))
@@ -73,7 +75,7 @@ public class MyGroupService {
                             .findFirst().orElseThrow(() -> new PlanusException(INTERNAL_SERVER_ERROR));
                     long onlineCount = eachGroupMembers.stream().filter(GroupMember::isOnlineStatus).count();
 
-                    return MyGroupResponseDto.of(group, eachGroupTags, onlineStatus, onlineCount);
+                    return MyGroupResponseDto.of(group, eachGroupTagDtos, onlineStatus, onlineCount);
                 })
                 .collect(Collectors.toList());
 

--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -5,7 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import scs.planus.domain.group.dto.mygroup.GroupBelongInResponseDto;
+import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
+import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
+import scs.planus.domain.group.entity.GroupTag;
 import scs.planus.domain.group.repository.GroupMemberRepository;
 import scs.planus.domain.group.repository.GroupTagRepository;
 import scs.planus.domain.member.entity.Member;
@@ -34,6 +37,23 @@ public class MyGroupService {
         List<GroupMember> groupMembers = groupMemberRepository.findAllByActiveGroupAndMemberId(member.getId());
         List<GroupBelongInResponseDto> responseDtos = groupMembers.stream()
                 .map(gm -> GroupBelongInResponseDto.of(gm.getGroup()))
+                .collect(Collectors.toList());
+
+        return responseDtos;
+    }
+
+    public List<MyGroupResponseDto> getMyGroups(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        List<GroupMember> groupMembers = groupMemberRepository.findAllByActiveGroupAndMemberId(member.getId());
+
+        List<MyGroupResponseDto> responseDtos = groupMembers.stream()
+                .map(groupMember -> {
+                    Group group = groupMember.getGroup();
+                    List<GroupTag> groupTags = groupTagRepository.findAllByGroup(group);
+                    return MyGroupResponseDto.of(group, groupTags);
+                })
                 .collect(Collectors.toList());
 
         return responseDtos;

--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import scs.planus.domain.group.dto.GroupTagResponseDto;
 import scs.planus.domain.group.dto.mygroup.GroupBelongInResponseDto;
+import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
@@ -19,8 +20,7 @@ import scs.planus.global.exception.PlanusException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static scs.planus.global.exception.CustomExceptionStatus.INTERNAL_SERVER_ERROR;
-import static scs.planus.global.exception.CustomExceptionStatus.NONE_USER;
+import static scs.planus.global.exception.CustomExceptionStatus.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -52,6 +52,19 @@ public class MyGroupService {
         List<MyGroupResponseDto> responseDtos = getMyGroupResponseDtos(myGroupMembers);
 
         return responseDtos;
+    }
+
+    @Transactional
+    public MyGroupOnlineStatusResponseDto changeOnlineStatus(Long memberId, Long groupId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(member.getId(), groupId)
+                .orElseThrow(() -> new PlanusException(NOT_JOINED_GROUP));
+
+        groupMember.changeOnlineStatus();
+
+        return MyGroupOnlineStatusResponseDto.of(groupMember);
     }
 
     private List<MyGroupResponseDto> getMyGroupResponseDtos(List<GroupMember> myGroupMembers) {


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 나의 그룹 전체 보기 구현
- 온라인 상태 변경 구현

### :: 특이사항
### 🔥 나의 그룹 전체 보기 구현
1. memberId를 통해 속한 GroupMember를 가져옵니다.
2. 1을 통해 얻어온 GroupMember로부터 Group 정보를 얻어옵니다.
3. 2에서 얻어온 Group을 통해 GroupMember 전체를 in 절을 사용하여 불러옵니다. (OnlineCount 용)
4. 2에서 얻어온 Group을 통해 GroupTag 전체를 in 절을 사용하여 불러옵니다. (GroupTag 조회용)
- 위의 과정에서 fetch join과 default-batch-size를 통해 성능 최적화를 이뤄냈습니다.
  - default-batch-size = 100을 기준으로,
  - in 절 사용 X -> GroupTag에서 1+N문제 발생
  - in 절 사용 O -> 처음에 모든 정보를 로딩한 후 사용 -> 1+N 문제 해결

### 🔥 온라인 상태 변경 구현
- `/app/my-groups/{groupId}/online-status`
- 위의 URL를 임시로 설정하였습니다. 보다 나은 url 명이 있다면 말해주세요😊
  - 이후, 알람 설정 등의 기능이 추가될 수 있어서 위와 같이 url을 설정하였습니다! - `/app/my-groups/{groupId}` 로 안한 이유
