### PR TITLE
[Feat] 그룹 가입 신청 기능 구현

### DIFF
--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -81,12 +81,12 @@ public class GroupController {
         return new BaseResponse<>( responseDto );
     }
 
-    @PostMapping("/groups/{groupId}")
-    public BaseResponse<GroupResponseDto> joinGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                    @PathVariable("groupId") Long groupId ) {
+    @PostMapping("/group-joins/{groupId}")
+    public BaseResponse<GroupJoinResponseDto> joinGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                        @PathVariable("groupId") Long groupId ) {
         Long memberId = principalDetails.getId();
-        GroupResponseDto responseDto = groupService.joinGroup( groupId, memberId );
+        GroupJoinResponseDto responseDto = groupService.joinGroup( memberId, groupId );
 
-        return new BaseResponse<>(responseDto);
+        return new BaseResponse<>( responseDto );
     }
 }

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -81,7 +81,7 @@ public class GroupController {
         return new BaseResponse<>( responseDto );
     }
 
-    @PostMapping("/group-joins/{groupId}")
+    @PostMapping("/groups/{groupId}/joins")
     public BaseResponse<GroupJoinResponseDto> joinGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                         @PathVariable("groupId") Long groupId ) {
         Long memberId = principalDetails.getId();

--- a/src/main/java/scs/planus/domain/group/dto/GroupJoinResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupJoinResponseDto.java
@@ -1,0 +1,17 @@
+package scs.planus.domain.group.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.group.entity.GroupJoin;
+
+@Getter
+@Builder
+public class GroupJoinResponseDto {
+    private Long groupJoinId;
+
+    public static GroupJoinResponseDto of( GroupJoin groupJoin ) {
+        return GroupJoinResponseDto.builder()
+                .groupJoinId( groupJoin.getId() )
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/group/entity/GroupJoin.java
+++ b/src/main/java/scs/planus/domain/group/entity/GroupJoin.java
@@ -1,9 +1,6 @@
 package scs.planus.domain.group.entity;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import scs.planus.domain.BaseTimeEntity;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.Status;
@@ -36,4 +33,18 @@ public class GroupJoin extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
     private Group group;
+
+    @Builder
+    public GroupJoin( Member member, Group group ) {
+        this.status = Status.INACTIVE;
+        this.member = member;
+        this.group = group;
+    }
+
+    public static GroupJoin createGroupJoin(Member member, Group group ) {
+        return GroupJoin.builder()
+                .member( member )
+                .group( group )
+                .build();
+    }
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupJoinRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupJoinRepository.java
@@ -1,0 +1,7 @@
+package scs.planus.domain.group.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scs.planus.domain.group.entity.GroupJoin;
+
+public interface GroupJoinRepository extends JpaRepository<GroupJoin, Long> {
+}

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -35,6 +35,7 @@ public class GroupService {
     private final GroupMemberRepository groupMemberRepository;
     private final GroupMemberQueryRepository groupMemberQueryRepository;
     private final GroupTagRepository groupTagRepository;
+    private final GroupJoinRepository groupJoinRepository;
     private final GroupTagService groupTagService;
     private final TagService tagService;
 
@@ -163,21 +164,26 @@ public class GroupService {
     }
 
     @Transactional
-    public GroupResponseDto joinGroup(Long groupId, Long memberId) {
-        Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> {
-                    throw new PlanusException(NOT_EXIST_GROUP);
-                });
+    public GroupJoinResponseDto joinGroup( Long memberId, Long groupId ) {
+        Group group = groupRepository.findByIdAndStatus(groupId)
+                .orElseThrow(() -> { throw new PlanusException( NOT_EXIST_GROUP ); });
 
         Member member = memberRepository.findById( memberId )
-                .orElseThrow(() -> {
-                    throw new PlanusException(NONE_USER);
-                });
+                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
 
-        GroupMember groupMember = GroupMember.creatGroupMember(member, group);
-        groupMemberRepository.save(groupMember);
+        List<GroupMember> allGroupMembers = groupMemberRepository.findAllWithMemberByGroup( group );
 
-        return GroupResponseDto.of( group );
+        // 제한 인원 초과 검증
+        validateExceedLimit( group, allGroupMembers );
+
+        // 가입 여부 검증
+        boolean isJoined = groupMemberQueryRepository.existByMemberIdAndGroupId( member.getId(), groupId );
+        if (isJoined) {throw new PlanusException( ALREADY_JOINED_GROUP );}
+
+        GroupJoin groupJoin = GroupJoin.createJoinForm( member, group );
+        GroupJoin saveGroupJoin = groupJoinRepository.save( groupJoin );
+
+        return GroupJoinResponseDto.of( saveGroupJoin );
     }
 
     private void validateLeaderPermission( Member member, Group group ) {
@@ -186,5 +192,12 @@ public class GroupService {
 
         if ( !member.equals( groupLeader.getMember() ) )
             throw new PlanusException( NOT_GROUP_LEADER_PERMISSION );
+    }
+
+    private void validateExceedLimit( Group group, List<GroupMember> allGroupMembers ) {
+        // 제한 인원을 초과하지 않았는지
+        if ( allGroupMembers.size() >= group.getLimitCount() ) {
+            throw new PlanusException( EXCEED_GROUP_LIMIT_COUNT );
+        }
     }
 }

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -180,7 +180,7 @@ public class GroupService {
         boolean isJoined = groupMemberQueryRepository.existByMemberIdAndGroupId( member.getId(), groupId );
         if (isJoined) {throw new PlanusException( ALREADY_JOINED_GROUP );}
 
-        GroupJoin groupJoin = GroupJoin.createJoinForm( member, group );
+        GroupJoin groupJoin = GroupJoin.createGroupJoin( member, group );
         GroupJoin saveGroupJoin = groupJoinRepository.save( groupJoin );
 
         return GroupJoinResponseDto.of( saveGroupJoin );

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -177,7 +177,7 @@ public class GroupService {
         validateExceedLimit( group, allGroupMembers );
 
         // 가입 여부 검증
-        boolean isJoined = groupMemberQueryRepository.existByMemberIdAndGroupId( member.getId(), groupId );
+        Boolean isJoined = groupMemberQueryRepository.existByMemberIdAndGroupId( member.getId(), groupId );
         if (isJoined) {throw new PlanusException( ALREADY_JOINED_GROUP );}
 
         GroupJoin groupJoin = GroupJoin.createGroupJoin( member, group );

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -38,6 +38,8 @@ public enum CustomExceptionStatus implements ResponseStatus {
     NOT_EXIST_GROUP(BAD_REQUEST, 2600, "존재하지 않는 그룹 입니다."),
     NOT_EXIST_LEADER(BAD_REQUEST, 2601, "해당 그룹에 그룹장이 존재하지 않습니다."),
     NOT_GROUP_LEADER_PERMISSION(BAD_REQUEST, 2602, "그룹을 수정할 권한이 없습니다."),
+    EXCEED_GROUP_LIMIT_COUNT(BAD_REQUEST, 2603, "그룹 제한 인원을 초과하였습니다."),
+    ALREADY_JOINED_GROUP(BAD_REQUEST, 2604, "이미 가입된 그룹입니다."),
 
     // groupMember excepion
     NOT_JOINED_GROUP(BAD_REQUEST, 2700, "가입하지 않은 그룹 입니다."),


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 기존에 임시로 만들어 놨던 `JoinGroup` API 재구현

### :: 특이사항
1. 가입 하려는 그룹의 인원이 초과하지 않았는지 검증 -> 제한 인원과 같거나 크면 `EXCEED_GROUP_LIMIT_COUNT` 예외 발생
2. 가입 여부 검증 -> 이미 가입 되어 있다면 참가 신청을 못하게 해야 함으로 `ALREADY_JOINED_GROUP` 예외 발생
3. `createGroupJoin` 생성 메소드로 `GroupJoin` 엔티티 생성 후 저장
4. GroupJoin id 리턴

- 그룹원 수 조회시 새로운 쿼리를 만들지 않고 findAllWithMemberByGroup() 을 재활용 하였습니다. 그룹원 수만 찾아오는 `count` 쿼리가 더 나은지 의견 부탁드립니다!
