### PR TITLE
[Feat] 그룹 가입 신청 내역 조회 API 구현

### DIFF
--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -109,4 +109,14 @@ public class GroupController {
         return new BaseResponse<>( responseDto );
     }
 
+    @PostMapping("/groups/joins/{groupJoinId}/reject")
+    public BaseResponse<GroupJoinResponseDto> rejectGroupJoin(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                              @PathVariable("groupJoinId") Long groupJoinId ){
+
+        Long memberId = principalDetails.getId();
+        GroupJoinResponseDto responseDto = groupService.rejectGroupJoin( memberId, groupJoinId );
+
+        return new BaseResponse<>( responseDto );
+    }
+
 }

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -99,4 +99,14 @@ public class GroupController {
         return new BaseResponse<>( responseDto );
     }
 
+    @PostMapping("/groups/joins/{groupJoinId}/accept")
+    public BaseResponse<GroupMemberResponseDto> acceptGroupJoin(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                @PathVariable("groupJoinId") Long groupJoinId ){
+
+        Long memberId = principalDetails.getId();
+        GroupMemberResponseDto responseDto = groupService.acceptGroupJoin( memberId, groupJoinId );
+
+        return new BaseResponse<>( responseDto );
+    }
+
 }

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -89,4 +89,14 @@ public class GroupController {
 
         return new BaseResponse<>( responseDto );
     }
+
+    @GetMapping("/groups/joins")
+    public BaseResponse<List<GroupJoinGetResponseDto>> getAllGroupJoin(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Long memberId = principalDetails.getId();
+        List<GroupJoinGetResponseDto> responseDto = groupService.getAllGroupJoin( memberId );
+
+        return new BaseResponse<>( responseDto );
+    }
+
 }

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -119,4 +119,15 @@ public class GroupController {
         return new BaseResponse<>( responseDto );
     }
 
+    @DeleteMapping("/groups/{groupId}/members/{memberId}")
+    public BaseResponse<GroupMemberResponseDto> killGroupMember(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                @PathVariable("groupId") Long groupId,
+                                                                @PathVariable("memberId") Long memberId ){
+
+        Long leaderId = principalDetails.getId();
+        GroupMemberResponseDto responseDto = groupService.killGroupMember( leaderId, memberId, groupId );
+
+        return new BaseResponse<>( responseDto );
+    }
+
 }

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -120,7 +120,7 @@ public class GroupController {
     }
 
     @DeleteMapping("/groups/{groupId}/members/{memberId}")
-    public BaseResponse<GroupMemberResponseDto> killGroupMember(@AuthenticationPrincipal PrincipalDetails principalDetails,
+    public BaseResponse<GroupMemberResponseDto> withdrawGroupMember(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                 @PathVariable("groupId") Long groupId,
                                                                 @PathVariable("memberId") Long memberId ){
 

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -125,7 +125,7 @@ public class GroupController {
                                                                 @PathVariable("memberId") Long memberId ){
 
         Long leaderId = principalDetails.getId();
-        GroupMemberResponseDto responseDto = groupService.killGroupMember( leaderId, memberId, groupId );
+        GroupMemberResponseDto responseDto = groupService.withdrawGroupMember( leaderId, memberId, groupId );
 
         return new BaseResponse<>( responseDto );
     }

--- a/src/main/java/scs/planus/domain/group/dto/GroupJoinGetResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupJoinGetResponseDto.java
@@ -14,7 +14,6 @@ public class GroupJoinGetResponseDto {
     private String memberName;
     private String memberDescription;
     private String memberProfileImageUrl;
-    private String acceptStatus;
 
     public static GroupJoinGetResponseDto of( GroupJoin groupJoin ) {
         return GroupJoinGetResponseDto.builder()
@@ -25,7 +24,6 @@ public class GroupJoinGetResponseDto {
                 .memberName( groupJoin.getMember().getNickname() )
                 .memberDescription( groupJoin.getMember().getDescription() )
                 .memberProfileImageUrl( groupJoin.getMember().getProfileImageUrl() )
-                .acceptStatus( groupJoin.getStatus().toString() )
                 .build();
     }
 }

--- a/src/main/java/scs/planus/domain/group/dto/GroupJoinGetResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupJoinGetResponseDto.java
@@ -1,0 +1,31 @@
+package scs.planus.domain.group.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.group.entity.GroupJoin;
+
+@Getter
+@Builder
+public class GroupJoinGetResponseDto {
+    private Long groupJoinId;
+    private Long groupId;
+    private String groupName;
+    private Long memberId;
+    private String memberName;
+    private String memberDescription;
+    private String memberProfileImageUrl;
+    private String acceptStatus;
+
+    public static GroupJoinGetResponseDto of( GroupJoin groupJoin ) {
+        return GroupJoinGetResponseDto.builder()
+                .groupJoinId( groupJoin.getId() )
+                .groupId( groupJoin.getGroup().getId() )
+                .groupName( groupJoin.getGroup().getName() )
+                .memberId( groupJoin.getMember().getId() )
+                .memberName( groupJoin.getMember().getNickname() )
+                .memberDescription( groupJoin.getMember().getDescription() )
+                .memberProfileImageUrl( groupJoin.getMember().getProfileImageUrl() )
+                .acceptStatus( groupJoin.getStatus().toString() )
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/group/dto/GroupMemberResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupMemberResponseDto.java
@@ -1,0 +1,17 @@
+package scs.planus.domain.group.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.group.entity.GroupMember;
+
+@Getter
+@Builder
+public class GroupMemberResponseDto {
+    private Long groupMemberId;
+
+    public static GroupMemberResponseDto of(GroupMember groupMember ) {
+        return GroupMemberResponseDto.builder()
+                .groupMemberId( groupMember.getId() )
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/group/entity/GroupJoin.java
+++ b/src/main/java/scs/planus/domain/group/entity/GroupJoin.java
@@ -5,14 +5,7 @@ import scs.planus.domain.BaseTimeEntity;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.Status;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+import javax.persistence.*;
 
 @Entity
 @Getter
@@ -24,6 +17,7 @@ public class GroupJoin extends BaseTimeEntity {
     @Column(name = "group_join_id")
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     private Status status;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/scs/planus/domain/group/entity/GroupMember.java
+++ b/src/main/java/scs/planus/domain/group/entity/GroupMember.java
@@ -66,4 +66,8 @@ public class GroupMember extends BaseTimeEntity {
     public void changeOnlineStatus() {
         this.onlineStatus = !this.onlineStatus;
     }
+
+    public void changeStatusToInactive() {
+        this.status = Status.INACTIVE;
+    }
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupJoinRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupJoinRepository.java
@@ -1,7 +1,19 @@
 package scs.planus.domain.group.repository;
 
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupJoin;
 
+import java.util.List;
+
 public interface GroupJoinRepository extends JpaRepository<GroupJoin, Long> {
+
+    @Query("select gj " +
+            "from GroupJoin gj " +
+            "join fetch gj.group " +
+            "join fetch gj.member " +
+            "where gj.group in :groups ")
+    List<GroupJoin> findAllByGroupIn(@Param("groups") List<Group> groups);
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupJoinRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupJoinRepository.java
@@ -7,6 +7,7 @@ import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupJoin;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface GroupJoinRepository extends JpaRepository<GroupJoin, Long> {
 
@@ -16,4 +17,11 @@ public interface GroupJoinRepository extends JpaRepository<GroupJoin, Long> {
             "join fetch gj.member " +
             "where gj.group in :groups ")
     List<GroupJoin> findAllByGroupIn(@Param("groups") List<Group> groups);
+
+    @Query("select gj from GroupJoin gj " +
+            "join fetch gj.group " +
+            "join fetch gj.member " +
+            "where gj.id= :groupJoinId " +
+            "and gj.status = 'INACTIVE'")
+    Optional<GroupJoin> findWithGroupById(@Param("groupJoinId") Long groupJoinId );
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -43,4 +43,12 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             "join fetch gm.member m " +
             "where g in :groups")
     List<GroupMember> findAllGroupMemberInGroups(@Param("groups") List<Group> groups);
+
+    @Query("select gm " +
+            "from GroupMember gm " +
+            "join fetch gm.group " +
+            "join fetch gm.member " +
+            "where gm.member= :member " +
+            "and gm.leader= true")
+    List<GroupMember> findWithGroupByLeaderMember(@Param("member") Member member);
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -29,8 +29,9 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     @Query("select gm " +
             "from GroupMember gm " +
             "join fetch gm.member " +
-            "where gm.group= :group ")
-    List<GroupMember> findAllWithMemberByGroup(@Param("group") Group group );
+            "where gm.group= :group " +
+            "and gm.status= 'ACTIVE'")
+    List<GroupMember> findAllWithMemberByGroupAndStatus(@Param("group") Group group );
 
     @Query("select gm from GroupMember gm " +
             "join fetch gm.group g " +

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -237,6 +237,27 @@ public class GroupService {
         return GroupJoinResponseDto.of( groupJoin );
     }
 
+    @Transactional
+    public GroupMemberResponseDto killGroupMember(Long leaderId, Long memberId, Long groupId) {
+        Member leader = memberRepository.findById( leaderId )
+                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+
+        Member killMember = memberRepository.findById( memberId )
+                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+
+        Group group = groupRepository.findByIdAndStatus( groupId )
+                .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_GROUP ); });
+
+        GroupMember killGroupMember = groupMemberRepository.findByMemberIdAndGroupId( killMember.getId(), group.getId() )
+                .orElseThrow(() -> new PlanusException(NOT_JOINED_GROUP));
+
+        validateLeaderPermission( leader, group );
+
+        killGroupMember.changeStatusToInactive();
+
+        return GroupMemberResponseDto.of( killGroupMember );
+    }
+
     private void validateLeaderPermission( Member member, Group group ) {
         GroupMember groupLeader = groupMemberRepository.findWithGroupAndLeaderByGroup( group )
                 .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_LEADER ); });

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -83,7 +83,7 @@ public class GroupService {
         Group group = groupRepository.findByIdAndStatus( groupId )
                 .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_GROUP ); });
 
-        List<GroupMember> allGroupMembers = groupMemberRepository.findAllWithMemberByGroup(group);
+        List<GroupMember> allGroupMembers = groupMemberRepository.findAllWithMemberByGroupAndStatus(group);
 
         return allGroupMembers.stream()
                 .map( gm -> GroupGetMemberResponseDto.of( gm.getMember(), gm.isLeader() ) )
@@ -171,7 +171,7 @@ public class GroupService {
         Member member = memberRepository.findById( memberId )
                 .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
 
-        List<GroupMember> allGroupMembers = groupMemberRepository.findAllWithMemberByGroup( group );
+        List<GroupMember> allGroupMembers = groupMemberRepository.findAllWithMemberByGroupAndStatus( group );
 
         // 제한 인원 초과 검증
         validateExceedLimit( group, allGroupMembers );

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -222,6 +222,21 @@ public class GroupService {
         return GroupMemberResponseDto.of( saveGroupMember );
     }
 
+    @Transactional
+    public GroupJoinResponseDto rejectGroupJoin( Long memberId, Long groupJoinId ) {
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+
+        GroupJoin groupJoin = groupJoinRepository.findWithGroupById( groupJoinId )
+                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP_JOIN ));
+
+        validateLeaderPermission( member, groupJoin.getGroup() );
+
+        groupJoinRepository.delete( groupJoin );
+
+        return GroupJoinResponseDto.of( groupJoin );
+    }
+
     private void validateLeaderPermission( Member member, Group group ) {
         GroupMember groupLeader = groupMemberRepository.findWithGroupAndLeaderByGroup( group )
                 .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_LEADER ); });

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -238,24 +238,24 @@ public class GroupService {
     }
 
     @Transactional
-    public GroupMemberResponseDto killGroupMember(Long leaderId, Long memberId, Long groupId) {
+    public GroupMemberResponseDto withdrawGroupMember(Long leaderId, Long memberId, Long groupId) {
         Member leader = memberRepository.findById( leaderId )
                 .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
 
-        Member killMember = memberRepository.findById( memberId )
+        Member withdrawMember = memberRepository.findById( memberId )
                 .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
 
         Group group = groupRepository.findByIdAndStatus( groupId )
                 .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_GROUP ); });
 
-        GroupMember killGroupMember = groupMemberRepository.findByMemberIdAndGroupId( killMember.getId(), group.getId() )
+        GroupMember withdrawGroupMember = groupMemberRepository.findByMemberIdAndGroupId( withdrawMember.getId(), group.getId() )
                 .orElseThrow(() -> new PlanusException(NOT_JOINED_GROUP));
 
         validateLeaderPermission( leader, group );
 
-        killGroupMember.changeStatusToInactive();
+        withdrawGroupMember.changeStatusToInactive();
 
-        return GroupMemberResponseDto.of( killGroupMember );
+        return GroupMemberResponseDto.of( withdrawGroupMember );
     }
 
     private void validateLeaderPermission( Member member, Group group ) {

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -186,6 +186,24 @@ public class GroupService {
         return GroupJoinResponseDto.of( saveGroupJoin );
     }
 
+    public List<GroupJoinGetResponseDto> getAllGroupJoin(Long memberId ) {
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+
+        // 내가 리더인 그룹들 조회
+        List<GroupMember> groupMembers = groupMemberRepository.findWithGroupByLeaderMember(member);
+        List<Group> groups = groupMembers.stream()
+                .map(GroupMember::getGroup)
+                .collect(Collectors.toList());
+
+        // 내가 리더인 그룹에 들어온 가입 신청 조회
+        List<GroupJoin> allGroupJoinsOfGroups = groupJoinRepository.findAllByGroupIn(groups);
+
+        return allGroupJoinsOfGroups.stream()
+                .map(GroupJoinGetResponseDto::of)
+                .collect(Collectors.toList());
+    }
+
     private void validateLeaderPermission( Member member, Group group ) {
         GroupMember groupLeader = groupMemberRepository.findWithGroupAndLeaderByGroup( group )
                 .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_LEADER ); });

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -204,6 +204,24 @@ public class GroupService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
+    public GroupMemberResponseDto acceptGroupJoin( Long memberId, Long groupJoinId ) {
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+
+        GroupJoin groupJoin = groupJoinRepository.findWithGroupById( groupJoinId )
+                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP_JOIN ));
+
+        validateLeaderPermission( member, groupJoin.getGroup() );
+
+        GroupMember groupMember = GroupMember.creatGroupMember( groupJoin.getMember(), groupJoin.getGroup() );
+        GroupMember saveGroupMember = groupMemberRepository.save( groupMember );
+
+        groupJoinRepository.delete( groupJoin );
+
+        return GroupMemberResponseDto.of( saveGroupMember );
+    }
+
     private void validateLeaderPermission( Member member, Group group ) {
         GroupMember groupLeader = groupMemberRepository.findWithGroupAndLeaderByGroup( group )
                 .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_LEADER ); });

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -40,6 +40,7 @@ public enum CustomExceptionStatus implements ResponseStatus {
     NOT_GROUP_LEADER_PERMISSION(BAD_REQUEST, 2602, "그룹을 수정할 권한이 없습니다."),
     EXCEED_GROUP_LIMIT_COUNT(BAD_REQUEST, 2603, "그룹 제한 인원을 초과하였습니다."),
     ALREADY_JOINED_GROUP(BAD_REQUEST, 2604, "이미 가입된 그룹입니다."),
+    NOT_EXIST_GROUP_JOIN(BAD_REQUEST, 2605, "존재 하지 않는 그룹 가입 신청서 입니다."),
 
     // groupMember excepion
     NOT_JOINED_GROUP(BAD_REQUEST, 2700, "가입하지 않은 그룹 입니다."),


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
### 🔥 그룹 가입 신청 내력 조회 (리더용)
- 내가 리더인 그룹에 들어온 모든 가입신청 내역을 조회하는 API 를 구현하였습니다.
- 신청인과 신청 그룹의 정보를 담은 `GroupJoinGetResponseDto` 를 구현하였습니다.

### 🔥 그룹 가입 승인 (리더용)
- 리더용 그룹 가입 승인 API를 구현하였습니다.
- 신청인 `Id` 로 `GroupMember` 를 생성하고 `GroupJoin` 은 삭제 하였습니다.
- `GroupMember` 를 생성한뒤 `Id`로 응답하기 위해 `GroupMemberResponseDto` 를 구현하였습니다.
- `GroupJoin` 조회 쿼리를 구현하였습니다. 이 `GroupJoin` 으로 부터 `Group` 과 `Member` 를 필요로 하기 때문에, `Fetch Join` 을 통해 성능을 최적화 하였습니다.
- "존재 하지 않는 그룹 가입 신청서 입니다." 에 대한 예외를 추가 하였습니다.

### 🔥 그룹 가입 거절 (리더용)
- 리더용 그룹 가입 거절 API를 구현하였습니다.
- 사용자가 그룹의 리더인지 validate 한 뒤 `GroupJoin` 를 삭제 하도록 구현하였습니다.

### 🔥 그룹 회원 강제 탈퇴 (Soft) (리더용)
- 리더용 그룹 회원 강제 탈퇴 API를 구현하였습니다.
- `GroupMember` 엔티티 내에 `상태수정 메소드`를 구현하였습니다.
- 리더, 탈퇴 대상자, 그룹 모두 찾아온 뒤, 해당 `GroupMember` 의 `Status` 를 `INACTIVE` 로 변경시켜 주었습니다.
 
### :: 특이사항
- 여러 `group` 에 있는 각각의 `groupJoin` 들을 조회하는 쿼리에서 `List<Group>`을 파라미터로 넘기고, JPQL에서 `in` 절을 활용하여 `N + 1` 문제를 해결하였습니다.
- ⚠️ `GroupMemberRepository` 에서 `group` 으로 모든 `groupMember` 를 조회하는 쿼리에 `gm.status= 'ACTIVE'` 조건을 추가하였습니다!
- 서비스단의 그룹 회원 강제 탈퇴 기능에서 과도한 검증으로 쿼리수가 너무 많이 발생하는것 같은 느낌도 들어서 의견 주시면 감사하겠습니다!
