### PR TITLE
[Feat] 가입한 그룹 개별 조회 및 가입한 그룹원 캘린더 조회

### DIFF
--- a/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import scs.planus.domain.group.dto.mygroup.MyGroupDetailResponseDto;
+import scs.planus.domain.group.dto.mygroup.MyGroupGetMemberResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
 import scs.planus.domain.group.service.MyGroupService;
@@ -37,6 +38,14 @@ public class MyGroupController {
                                                                  @PathVariable Long groupId) {
         Long memberId = principalDetails.getId();
         MyGroupDetailResponseDto responseDto = myGroupService.getMyEachGroupDetail(memberId, groupId);
+        return new BaseResponse<>(responseDto);
+    }
+
+    @GetMapping("/my-groups/{groupId}/members")
+    public BaseResponse<List<MyGroupGetMemberResponseDto>> getGroupMembersForMember(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                                    @PathVariable("groupId") Long groupId ) {
+        Long memberId = principalDetails.getId();
+        List<MyGroupGetMemberResponseDto> responseDto = myGroupService.getGroupMembersForMember(memberId, groupId);
         return new BaseResponse<>(responseDto);
     }
 

--- a/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
@@ -2,11 +2,13 @@ package scs.planus.domain.group.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import scs.planus.domain.group.dto.mygroup.MyGroupDetailResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupGetMemberResponseDto;
@@ -14,9 +16,11 @@ import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
 import scs.planus.domain.group.service.MyGroupService;
 import scs.planus.domain.member.dto.MemberResponseDto;
+import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
 import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.common.response.BaseResponse;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -57,6 +61,17 @@ public class MyGroupController {
         Long loginId = principalDetails.getId();
         MemberResponseDto responseDto = myGroupService.getGroupMemberDetail(loginId, groupId, memberId);
         return new BaseResponse<>(responseDto);
+    }
+
+    @GetMapping("/my-groups/{groupId}/members/{memberId}/calendar/period")
+    public BaseResponse<List<TodoDetailsResponseDto>> getGroupMemberPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                                @PathVariable Long groupId,
+                                                                                @PathVariable Long memberId,
+                                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
+                                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
+        Long loginId = principalDetails.getId();
+        List<TodoDetailsResponseDto> responseDtos = myGroupService.getGroupMemberPeriodTodos(loginId, groupId, memberId, from, to);
+        return new BaseResponse<>(responseDtos);
     }
 
     @PatchMapping("/my-groups/{groupId}/online-status")

--- a/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import scs.planus.domain.group.dto.mygroup.MyGroupDetailResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
 import scs.planus.domain.group.service.MyGroupService;
@@ -27,8 +28,16 @@ public class MyGroupController {
     @GetMapping("/my-groups")
     public BaseResponse<List<MyGroupResponseDto>> getMyGroups(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         Long memberId = principalDetails.getId();
-        List<MyGroupResponseDto> responseDtos = myGroupService.getMyGroups(memberId);
+        List<MyGroupResponseDto> responseDtos = myGroupService.getMyAllGroups(memberId);
         return new BaseResponse<>(responseDtos);
+    }
+
+    @GetMapping("/my-groups/{groupId}")
+    public BaseResponse<MyGroupDetailResponseDto> getMyEachGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                 @PathVariable Long groupId) {
+        Long memberId = principalDetails.getId();
+        MyGroupDetailResponseDto responseDto = myGroupService.getMyEachGroupDetail(memberId, groupId);
+        return new BaseResponse<>(responseDto);
     }
 
     @PatchMapping("/my-groups/{groupId}/online-status")

--- a/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
@@ -15,7 +15,6 @@ import scs.planus.domain.group.dto.mygroup.MyGroupGetMemberResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
 import scs.planus.domain.group.service.MyGroupService;
-import scs.planus.domain.member.dto.MemberResponseDto;
 import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
 import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.common.response.BaseResponse;
@@ -54,16 +53,7 @@ public class MyGroupController {
         return new BaseResponse<>(responseDto);
     }
 
-    @GetMapping("/my-groups/{groupId}/members/{memberId}")
-    public BaseResponse<MemberResponseDto> getGroupMemberInfo(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                              @PathVariable Long groupId,
-                                                              @PathVariable Long memberId) {
-        Long loginId = principalDetails.getId();
-        MemberResponseDto responseDto = myGroupService.getGroupMemberDetail(loginId, groupId, memberId);
-        return new BaseResponse<>(responseDto);
-    }
-
-    @GetMapping("/my-groups/{groupId}/members/{memberId}/calendar/period")
+    @GetMapping("/my-groups/{groupId}/members/{memberId}/calendar")
     public BaseResponse<List<TodoDetailsResponseDto>> getGroupMemberPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                                 @PathVariable Long groupId,
                                                                                 @PathVariable Long memberId,

--- a/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
@@ -13,6 +13,7 @@ import scs.planus.domain.group.dto.mygroup.MyGroupGetMemberResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
 import scs.planus.domain.group.service.MyGroupService;
+import scs.planus.domain.member.dto.MemberResponseDto;
 import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.common.response.BaseResponse;
 
@@ -46,6 +47,15 @@ public class MyGroupController {
                                                                                     @PathVariable("groupId") Long groupId ) {
         Long memberId = principalDetails.getId();
         List<MyGroupGetMemberResponseDto> responseDto = myGroupService.getGroupMembersForMember(memberId, groupId);
+        return new BaseResponse<>(responseDto);
+    }
+
+    @GetMapping("/my-groups/{groupId}/members/{memberId}")
+    public BaseResponse<MemberResponseDto> getGroupMemberInfo(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                              @PathVariable Long groupId,
+                                                              @PathVariable Long memberId) {
+        Long loginId = principalDetails.getId();
+        MemberResponseDto responseDto = myGroupService.getGroupMemberDetail(loginId, groupId, memberId);
         return new BaseResponse<>(responseDto);
     }
 

--- a/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
@@ -15,6 +15,7 @@ import scs.planus.domain.group.dto.mygroup.MyGroupGetMemberResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
 import scs.planus.domain.group.service.MyGroupService;
+import scs.planus.domain.todo.dto.TodoDailyResponseDto;
 import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
 import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.common.response.BaseResponse;
@@ -61,6 +62,16 @@ public class MyGroupController {
                                                                                 @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
         Long loginId = principalDetails.getId();
         List<TodoDetailsResponseDto> responseDtos = myGroupService.getGroupMemberPeriodTodos(loginId, groupId, memberId, from, to);
+        return new BaseResponse<>(responseDtos);
+    }
+
+    @GetMapping("/my-groups/{groupId}/members/{memberId}/calendar/daily")
+    public BaseResponse<TodoDailyResponseDto> getGroupMemberPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                                @PathVariable Long groupId,
+                                                                                @PathVariable Long memberId,
+                                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+        Long loginId = principalDetails.getId();
+        TodoDailyResponseDto responseDtos = myGroupService.getGroupMemberDailyTodos(loginId, groupId, memberId, date);
         return new BaseResponse<>(responseDtos);
     }
 

--- a/src/main/java/scs/planus/domain/group/dto/GroupCreateRequestDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupCreateRequestDto.java
@@ -22,5 +22,5 @@ public class GroupCreateRequestDto {
     @NotNull(message = "[request] 그룹 제한 인원을 설정해 주세요.")
     @Max(value = 50, message = "[request] 그룹 제한 인원은 50명 이하로 입력해 주세요.")
     @Min(value = 2, message = "[request] 그룹 제한 인원은 2명 이상으로 입력해 주세요.")
-    private Long limitCount;
+    private int limitCount;
 }

--- a/src/main/java/scs/planus/domain/group/dto/GroupDetailUpdateRequestDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupDetailUpdateRequestDto.java
@@ -15,5 +15,5 @@ public class GroupDetailUpdateRequestDto {
 
     @Max(value = 50, message = "[request] 그룹 제한 인원은 50명 이하로 입력해 주세요.")
     @Min(value = 2, message = "[request] 그룹 제한 인원은 2명 이상으로 입력해 주세요.")
-    private Long limitCount;
+    private int limitCount;
 }

--- a/src/main/java/scs/planus/domain/group/dto/GroupGetResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupGetResponseDto.java
@@ -16,8 +16,8 @@ public class GroupGetResponseDto {
     private Boolean isJoined;
     private String notice;
     private String groupImageUrl;
-    private Integer memberCount;
-    private Long limitCount;
+    private int memberCount;
+    private int limitCount;
     private String leaderName;
     private List<GroupTagResponseDto> groupTags;
 

--- a/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupDetailResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupDetailResponseDto.java
@@ -1,0 +1,39 @@
+package scs.planus.domain.group.dto.mygroup;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.group.dto.GroupTagResponseDto;
+import scs.planus.domain.group.entity.Group;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MyGroupDetailResponseDto {
+
+    private Long groupId;
+    private String groupImageUrl;
+    private String groupName;
+    private Boolean isOnline;
+    private int onlineCount;
+    private int memberCount;
+    private int limitCount;
+    private String leaderName;
+    private String notice;
+    private List<GroupTagResponseDto> groupTags;
+
+    public static MyGroupDetailResponseDto of(Group group, List<GroupTagResponseDto> eachGroupTagDtos, Boolean onlineStatus, int onlineCount) {
+        return MyGroupDetailResponseDto.builder()
+                .groupId(group.getId())
+                .groupImageUrl(group.getGroupImageUrl())
+                .groupName(group.getName())
+                .isOnline(onlineStatus)
+                .onlineCount(onlineCount)
+                .memberCount(group.getGroupMembers().size()) // 추가쿼리 발생
+                .limitCount(group.getLimitCount())
+                .leaderName(group.getLeaderName()) // 추가쿼리 발생
+                .notice(group.getNotice())
+                .groupTags(eachGroupTagDtos)
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupDetailResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupDetailResponseDto.java
@@ -14,6 +14,7 @@ public class MyGroupDetailResponseDto {
     private Long groupId;
     private String groupImageUrl;
     private String groupName;
+    private Boolean isLeader;
     private Boolean isOnline;
     private int onlineCount;
     private int memberCount;
@@ -22,11 +23,13 @@ public class MyGroupDetailResponseDto {
     private String notice;
     private List<GroupTagResponseDto> groupTags;
 
-    public static MyGroupDetailResponseDto of(Group group, List<GroupTagResponseDto> eachGroupTagDtos, Boolean onlineStatus, int onlineCount) {
+    public static MyGroupDetailResponseDto of(Group group, List<GroupTagResponseDto> eachGroupTagDtos,
+                                              Boolean isLeader, Boolean onlineStatus, int onlineCount) {
         return MyGroupDetailResponseDto.builder()
                 .groupId(group.getId())
                 .groupImageUrl(group.getGroupImageUrl())
                 .groupName(group.getName())
+                .isLeader(isLeader)
                 .isOnline(onlineStatus)
                 .onlineCount(onlineCount)
                 .memberCount(group.getGroupMembers().size()) // 추가쿼리 발생

--- a/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupGetMemberResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupGetMemberResponseDto.java
@@ -1,0 +1,28 @@
+package scs.planus.domain.group.dto.mygroup;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.member.entity.Member;
+
+@Getter
+@Builder
+public class MyGroupGetMemberResponseDto {
+
+    private Long memberId;
+    private String nickname;
+    private Boolean isLeader;
+    private Boolean isOnline;
+    private String description;
+    private String profileImageUrl;
+
+    public static MyGroupGetMemberResponseDto of(Member member, Boolean isLeader, Boolean isOnline) {
+        return MyGroupGetMemberResponseDto.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .isLeader(isLeader)
+                .isOnline(isOnline)
+                .description(member.getDescription())
+                .profileImageUrl(member.getProfileImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupResponseDto.java
@@ -15,22 +15,22 @@ public class MyGroupResponseDto {
     private String groupImageUrl;
     private String groupName;
     private Boolean isOnline;
-    private Long onlineCount;
-    private Long totalCount;
-    private Long limitCount;
+    private int onlineCount;
+    private int memberCount;
+    private int limitCount;
     private String leaderName;
     private List<GroupTagResponseDto> groupTags;
 
-    public static MyGroupResponseDto of(Group group, List<GroupTagResponseDto> eachGroupTagDtos, Boolean onlineStatus, Long onlineCount) {
+    public static MyGroupResponseDto of(Group group, List<GroupTagResponseDto> eachGroupTagDtos, Boolean onlineStatus, int onlineCount) {
         return MyGroupResponseDto.builder()
                 .groupId(group.getId())
                 .groupImageUrl(group.getGroupImageUrl())
                 .groupName(group.getName())
                 .isOnline(onlineStatus)
                 .onlineCount(onlineCount)
-                .totalCount((long) group.getGroupMembers().size())
+                .memberCount(group.getGroupMembers().size()) // 추가쿼리 발생
                 .limitCount(group.getLimitCount())
-                .leaderName(group.getLeaderName())
+                .leaderName(group.getLeaderName()) // 추가쿼리 발생
                 .groupTags(eachGroupTagDtos)
                 .build();
     }

--- a/src/main/java/scs/planus/domain/group/entity/Group.java
+++ b/src/main/java/scs/planus/domain/group/entity/Group.java
@@ -30,7 +30,7 @@ public class Group extends BaseTimeEntity {
 
     private String groupImageUrl;
 
-    private Long limitCount;
+    private int limitCount;
 
     @Enumerated(EnumType.STRING)
     private GroupScope scope;
@@ -45,7 +45,7 @@ public class Group extends BaseTimeEntity {
     private List<GroupTag> groupTags = new ArrayList<>();
 
     @Builder
-    public Group(String name, String notice, String groupImageUrl, Long limitCount, GroupScope scope, Status status) {
+    public Group(String name, String notice, String groupImageUrl, int limitCount, GroupScope scope, Status status) {
         this.name = name;
         this.notice = notice;
         this.groupImageUrl = groupImageUrl;
@@ -54,7 +54,7 @@ public class Group extends BaseTimeEntity {
         this.status = status;
     }
 
-    public static Group creatGroup( String name, String notice, Long limitCount, String groupImageUrl ) {
+    public static Group creatGroup( String name, String notice, int limitCount, String groupImageUrl ) {
         return Group.builder()
                 .name( name )
                 .notice( notice )
@@ -73,7 +73,7 @@ public class Group extends BaseTimeEntity {
                 .getMember().getNickname();
     }
 
-    public void updateDetail(Long limitCount, String groupImageUrl ) {
+    public void updateDetail(int limitCount, String groupImageUrl ) {
         this.limitCount = limitCount;
         this.groupImageUrl = groupImageUrl;
     }

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -30,8 +30,8 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             "from GroupMember gm " +
             "join fetch gm.group g " +
             "join fetch gm.member m " +
-            "where g = :group " +
-            "and gm.status= 'ACTIVE'")
+            "where g = :group and gm.status= 'ACTIVE' " +
+            "order by gm.leader DESC, gm.onlineStatus DESC")
     List<GroupMember> findAllWithMemberByGroupAndStatus(@Param("group") Group group );
 
     @Query("select gm from GroupMember gm " +

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -28,8 +28,9 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
 
     @Query("select gm " +
             "from GroupMember gm " +
-            "join fetch gm.member " +
-            "where gm.group= :group " +
+            "join fetch gm.group g " +
+            "join fetch gm.member m " +
+            "where g = :group " +
             "and gm.status= 'ACTIVE'")
     List<GroupMember> findAllWithMemberByGroupAndStatus(@Param("group") Group group );
 

--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -17,6 +17,7 @@ import scs.planus.domain.group.repository.GroupMemberQueryRepository;
 import scs.planus.domain.group.repository.GroupMemberRepository;
 import scs.planus.domain.group.repository.GroupRepository;
 import scs.planus.domain.group.repository.GroupTagRepository;
+import scs.planus.domain.member.dto.MemberResponseDto;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.global.exception.PlanusException;
@@ -100,6 +101,7 @@ public class MyGroupService {
         // TODO 파라미터가 너무 많음 -> 리팩토링 필요
         return MyGroupDetailResponseDto.of(group, groupTagResponseDtos, isLeader, onlineStatus, onlineCount);
     }
+
     public List<MyGroupGetMemberResponseDto> getGroupMembersForMember(Long memberId, Long groupId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
@@ -118,6 +120,20 @@ public class MyGroupService {
                 .collect(Collectors.toList());
 
         return responseDtos;
+    }
+
+    public MemberResponseDto getGroupMemberDetail(Long loginId, Long groupId, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new PlanusException(NONE_USER));
+
+        Boolean isLoginMemberJoined = groupMemberQueryRepository.existByMemberIdAndGroupId(loginId, groupId);
+        Boolean isMemberJoined = groupMemberQueryRepository.existByMemberIdAndGroupId(memberId, groupId);
+
+        if (!isLoginMemberJoined || !isMemberJoined) {
+            throw new PlanusException(NOT_JOINED_GROUP);
+        }
+
+        return MemberResponseDto.of(member);
     }
 
     @Transactional

--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -11,7 +11,9 @@ import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
 import scs.planus.domain.group.entity.GroupTag;
+import scs.planus.domain.group.repository.GroupMemberQueryRepository;
 import scs.planus.domain.group.repository.GroupMemberRepository;
+import scs.planus.domain.group.repository.GroupRepository;
 import scs.planus.domain.group.repository.GroupTagRepository;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
@@ -29,7 +31,9 @@ import static scs.planus.global.exception.CustomExceptionStatus.*;
 public class MyGroupService {
 
     private final MemberRepository memberRepository;
+    private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final GroupMemberQueryRepository groupMemberQueryRepository;
     private final GroupTagRepository groupTagRepository;
 
     public List<GroupBelongInResponseDto> getMyGroupsInDropDown(Long memberId) {
@@ -86,7 +90,7 @@ public class MyGroupService {
                             .map(GroupMember::isOnlineStatus)
                             .findFirst().orElseThrow(() -> new PlanusException(INTERNAL_SERVER_ERROR));
 
-                    long onlineCount = allGroupMembers.stream()
+                    int onlineCount = (int) allGroupMembers.stream()
                             .filter(groupMember -> groupMember.getGroup().getId().equals(group.getId()))
                             .filter(GroupMember::isOnlineStatus)
                             .count();

--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import scs.planus.domain.group.dto.GroupTagResponseDto;
 import scs.planus.domain.group.dto.mygroup.GroupBelongInResponseDto;
+import scs.planus.domain.group.dto.mygroup.MyGroupDetailResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
 import scs.planus.domain.group.entity.Group;
@@ -48,7 +49,7 @@ public class MyGroupService {
         return responseDtos;
     }
 
-    public List<MyGroupResponseDto> getMyGroups(Long memberId) {
+    public List<MyGroupResponseDto> getMyAllGroups(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
@@ -72,7 +73,7 @@ public class MyGroupService {
         return responseDtos;
     }
 
-    public MyGroupResponseDto getEachGroup(Long memberId, Long groupId) {
+    public MyGroupDetailResponseDto getMyEachGroupDetail(Long memberId, Long groupId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
@@ -86,6 +87,7 @@ public class MyGroupService {
 
         List<GroupMember> myGroupMembers = groupMemberRepository.findAllWithMemberByGroupAndStatus(group);
         List<GroupTag> groupTags = groupTagRepository.findAllByGroup(group);
+
         List<GroupTagResponseDto> groupTagResponseDtos = groupTags.stream()
                 .map(GroupTagResponseDto::of)
                 .collect(Collectors.toList());
@@ -93,7 +95,7 @@ public class MyGroupService {
         Boolean onlineStatus = isOnlineStatus(myGroupMembers, member);
         int onlineCount = getOnlineCount(myGroupMembers, group);
 
-        return MyGroupResponseDto.of(group,groupTagResponseDtos, onlineStatus, onlineCount);
+        return MyGroupDetailResponseDto.of(group,groupTagResponseDtos, onlineStatus, onlineCount);
     }
 
     @Transactional

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -54,6 +54,17 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
+    public List<Todo> findDailyTodosByDate(Long memberId, Long groupId, LocalDate date) {
+        return queryFactory
+                .selectFrom(todo)
+                .join(todo.member, member)
+                .leftJoin(todo.group, group).fetchJoin()
+                .join(todo.todoCategory, todoCategory).fetchJoin()
+                .where(memberIdEq(memberId), groupIdEq(groupId), dateBetween(date))
+                .orderBy(todo.startTime.asc())
+                .fetch();
+    }
+
     public List<Todo> findPeriodGroupTodosDetailByDate(Long memberId, LocalDate from, LocalDate to) {
         return queryFactory
                 .selectFrom(todo)


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 가입한 그룹 개별 조회
- 가입한 그룹원 캘린더 조회

### :: 특이사항
### 🔥 가입한 그룹 개별 조회
- `/app/my-groups/{groupId}` : 개별 그룹 조회 API 
- `/app/my-groups/{groupId}/members` : 개별 그룹원 조회 API
  - 리더가 제일 먼저오고, 그 이후는 online 상태의 그룹원이 오도록 정렬하였습니다.

### 🔥 가입한 그룹원 캘린더 조회
- `/app/my-groups/{groupId}/members/{memberId}/calendar` : 그룹원 월별 캘린더 조회 API
- `/app/my-groups/{groupId}/members/{memberId}/calendar/daily` : 그룹원 일별 투두 조회 API