### PR TITLE
[Fix]:  isOnline이 잘못된 값을 내뱉던 점 수정

### DIFF
--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -74,7 +74,7 @@ public class MyGroupService {
 
         List<MyGroupResponseDto> responseDtos = myGroups.stream().map(group -> {
                     List<GroupTagResponseDto> eachGroupTagDtos = getEachGroupTags(group, allGroupTags);
-                    Boolean onlineStatus = isOnlineStatus(member, myGroupMembers);
+                    Boolean onlineStatus = isOnlineStatus(member, group, myGroupMembers);
                     int onlineCount = getOnlineCount(group, allGroupMembers);
 
                     return MyGroupResponseDto.of(group, eachGroupTagDtos, onlineStatus, onlineCount);
@@ -104,7 +104,7 @@ public class MyGroupService {
                 .collect(Collectors.toList());
 
         Boolean isLeader = isGroupLeader(member, myGroupMembers);
-        Boolean onlineStatus = isOnlineStatus(member, myGroupMembers);
+        Boolean onlineStatus = isOnlineStatus(member, group, myGroupMembers);
         int onlineCount = getOnlineCount(group, myGroupMembers);
 
         // TODO 파라미터가 너무 많음 -> 리팩토링 필요
@@ -199,6 +199,14 @@ public class MyGroupService {
         return MyGroupOnlineStatusResponseDto.of(groupMember);
     }
 
+    private Boolean isOnlineStatus(Member member, Group group, List<GroupMember> myGroupMembers) {
+        return myGroupMembers.stream()
+                .filter(groupMember ->
+                    groupMember.getGroup().equals(group) && groupMember.getMember().equals(member))
+                .map(GroupMember::isOnlineStatus)
+                .findFirst().orElseThrow(() -> new PlanusException(INTERNAL_SERVER_ERROR));
+    }
+
     private Boolean isGroupLeader(Member member, List<GroupMember> myGroupMembers) {
         return myGroupMembers.stream().filter(groupMember -> groupMember.getMember().getId().equals(member.getId()))
                 .map(GroupMember::isLeader)
@@ -210,13 +218,6 @@ public class MyGroupService {
                 .filter(groupTag -> groupTag.getGroup().getId().equals(group.getId()))
                 .map(GroupTagResponseDto::of)
                 .collect(Collectors.toList());
-    }
-
-    private Boolean isOnlineStatus(Member member, List<GroupMember> myGroupMembers) {
-        return myGroupMembers.stream()
-                .filter(groupMember -> groupMember.getMember().getId().equals(member.getId()))
-                .map(GroupMember::isOnlineStatus)
-                .findFirst().orElseThrow(() -> new PlanusException(INTERNAL_SERVER_ERROR));
     }
 
     private int getOnlineCount(Group group, List<GroupMember> allGroupMembers) {


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [X]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- isOnline이 잘못된 값을 내뱉던 점 수정

### :: 특이사항
- MyGroup 전체 조회 / 개별 조회에서 isOnline이 이상하던 점을 수정하였습니다.
- 전체 조회 시:
  - 현재 스트림을 통해 반복되고 있는 group 과 일치하는 onlineStatus를 반환
- 개별 조회 시:
  - 개별 그룹에 속한 모든 GroupMembers에 대해 member (본인)과 일치하는 onlineStatus을 반환
