### PR TITLE
[Fix] 태그 중복 버그 해결

### DIFF
--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static scs.planus.global.exception.CustomExceptionStatus.*;
+import static scs.planus.global.util.validator.Validator.validateDuplicateTagName;
 
 @Service
 @Transactional(readOnly = true)
@@ -49,6 +50,7 @@ public class GroupService {
         String groupImageUrl = createGroupImage( multipartFile );
         Group group = Group.creatGroup( requestDto.getName(), requestDto.getNotice(), requestDto.getLimitCount(), groupImageUrl );
 
+        validateDuplicateTagName( requestDto.getTagList() );
         List<Tag> tagList = tagService.transformToTag( requestDto.getTagList() );
         GroupTag.create( group, tagList );
 
@@ -106,6 +108,7 @@ public class GroupService {
         String newGroupImageUrl = updateGroupImage(multipartFile, oldGroupImageUrl);
 
         // 그룹 테그 수정.
+        validateDuplicateTagName( requestDto.getTagList() );
         List<TagCreateRequestDto> addTagDtos = groupTagService.update( group, requestDto.getTagList() );
         List<Tag> addTags = tagService.transformToTag( addTagDtos );
         GroupTag.create( group, addTags );

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -47,8 +47,10 @@ public enum CustomExceptionStatus implements ResponseStatus {
 
     // s3 exception
     INVALID_FILE(BAD_REQUEST, 5000, "잘못되거나 존재하지 않는 파일입니다."),
-    INVALID_FILE_EXTENSION(BAD_REQUEST, 5001, "잘못된 확장자입니다. jpeg / jpg / png / heic 파일을 선택해주세요.")
-    ;
+    INVALID_FILE_EXTENSION(BAD_REQUEST, 5001, "잘못된 확장자입니다. jpeg / jpg / png / heic 파일을 선택해주세요."),
+
+    // tag
+    EXIST_DUPLICATE_TAGS(BAD_REQUEST, 6000, "중복된 태그들이 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -45,12 +45,12 @@ public enum CustomExceptionStatus implements ResponseStatus {
     // groupMember excepion
     NOT_JOINED_GROUP(BAD_REQUEST, 2700, "가입하지 않은 그룹 입니다."),
 
+    // tag
+    EXIST_DUPLICATE_TAGS(BAD_REQUEST, 2800, "중복된 태그들이 존재합니다."),
+
     // s3 exception
     INVALID_FILE(BAD_REQUEST, 5000, "잘못되거나 존재하지 않는 파일입니다."),
-    INVALID_FILE_EXTENSION(BAD_REQUEST, 5001, "잘못된 확장자입니다. jpeg / jpg / png / heic 파일을 선택해주세요."),
-
-    // tag
-    EXIST_DUPLICATE_TAGS(BAD_REQUEST, 6000, "중복된 태그들이 존재합니다.");
+    INVALID_FILE_EXTENSION(BAD_REQUEST, 5001, "잘못된 확장자입니다. jpeg / jpg / png / heic 파일을 선택해주세요.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/scs/planus/global/util/validator/Validator.java
+++ b/src/main/java/scs/planus/global/util/validator/Validator.java
@@ -1,9 +1,13 @@
 package scs.planus.global.util.validator;
 
+import scs.planus.domain.tag.dto.TagCreateRequestDto;
 import scs.planus.global.exception.PlanusException;
 
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
 
+import static scs.planus.global.exception.CustomExceptionStatus.EXIST_DUPLICATE_TAGS;
 import static scs.planus.global.exception.CustomExceptionStatus.INVALID_DATE;
 
 public class Validator {
@@ -13,6 +17,18 @@ public class Validator {
             if (startDate.isAfter(endDate)) {
                 throw new PlanusException(INVALID_DATE);
             }
+        }
+    }
+
+
+    public static void validateDuplicateTagName(List<TagCreateRequestDto> updateTags) {
+        // HashSet 의 add()를 통해 중복된 값이 있으면 false
+        boolean isDuplcate = !updateTags.stream()
+                .map( TagCreateRequestDto::getName )
+                .allMatch( new HashSet<>()::add );
+
+        if (isDuplcate) {
+            throw new PlanusException( EXIST_DUPLICATE_TAGS );
         }
     }
 }


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [x]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 클라이언트에서 그룹 생성, 수정 요청시 Dto 에 `List<TagCreateRequestDto>` 를 담아오게 되는데, 각각의 `TagCreateRequestDto` 들의 `name` 이 중복되면 그대로 누적 저장되는 버그를 발견하여 이를 해결하였습니다.
- util.validator.Validator.Class 에 `validateDuplicateTagName` 으로 구현하여 GroupService 에서 사용하도록 구현하였습니다.
- Set의 `add()` 는 값이 존재하지 않을 경우 True, 존재할 경우 False 를 반환하는데 이를 활용하여 중복된 값의 존재를 검증 하였습니다.
- 중복된 이름의 태그들이 존재할 경우 `EXIST_DUPLICATE_TAGS` 를 발생 시켰습니다.

### :: 특이사항
- 
