### PR TITLE
[Feat] GroupTodoCategory CRUD API 구현 및 MemberTodoCategory API 에 상속 리펙토링 적용

### DIFF
--- a/src/main/java/scs/planus/domain/category/controller/GroupTodoCategoryController.java
+++ b/src/main/java/scs/planus/domain/category/controller/GroupTodoCategoryController.java
@@ -5,9 +5,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import scs.planus.domain.category.dto.CategoryGetResponseDto;
-import scs.planus.domain.category.dto.CategoryRequestDto;
-import scs.planus.domain.category.dto.CategoryResponseDto;
+import scs.planus.domain.category.dto.TodoCategoryGetResponseDto;
+import scs.planus.domain.category.dto.TodoCategoryRequestDto;
+import scs.planus.domain.category.dto.TodoCategoryResponseDto;
 import scs.planus.domain.category.service.GroupTodoCategoryService;
 import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.common.response.BaseResponse;
@@ -24,45 +24,45 @@ public class GroupTodoCategoryController {
 
     @GetMapping("/my-groups/{groupId}/categories")
     @Operation(summary = "전체 Group Category 조회 API")
-    public BaseResponse<List<CategoryGetResponseDto>> getAllGroupCategories(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                            @PathVariable("groupId") Long groupId) {
+    public BaseResponse<List<TodoCategoryGetResponseDto>> getAllGroupCategories(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                                @PathVariable("groupId") Long groupId) {
 
         Long memberId = principalDetails.getId();
-        List<CategoryGetResponseDto> responseDto = groupTodoCategoryService.findAll( memberId, groupId );
+        List<TodoCategoryGetResponseDto> responseDto = groupTodoCategoryService.findAll( memberId, groupId );
 
         return new BaseResponse<>(responseDto);
     }
 
     @PostMapping("/my-groups/{groupId}/categories")
     @Operation(summary = "Group Category 생성 API")
-    public BaseResponse<CategoryResponseDto> createGroupCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                 @PathVariable("groupId") Long groupId,
-                                                                 @Valid @RequestBody CategoryRequestDto requestDto){
+    public BaseResponse<TodoCategoryResponseDto> createGroupCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                     @PathVariable("groupId") Long groupId,
+                                                                     @Valid @RequestBody TodoCategoryRequestDto requestDto){
         Long memberId = principalDetails.getId();
-        CategoryResponseDto responseDto = groupTodoCategoryService.createCategory( memberId, groupId, requestDto );
+        TodoCategoryResponseDto responseDto = groupTodoCategoryService.createCategory( memberId, groupId, requestDto );
 
         return new BaseResponse<>(responseDto);
     }
 
     @PatchMapping("/my-groups/{groupId}/categories/{categoryId}")
     @Operation(summary = "Group Category 변경 API")
-    public BaseResponse<CategoryResponseDto> modifyGroupCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                 @PathVariable("groupId") Long groupId,
-                                                                 @PathVariable("categoryId") Long categoryId,
-                                                                 @RequestBody CategoryRequestDto requestDto) {
+    public BaseResponse<TodoCategoryResponseDto> modifyGroupCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                     @PathVariable("groupId") Long groupId,
+                                                                     @PathVariable("categoryId") Long categoryId,
+                                                                     @RequestBody TodoCategoryRequestDto requestDto) {
         Long memberId = principalDetails.getId();
-        CategoryResponseDto responseDto = groupTodoCategoryService.changeCategory( memberId, groupId, categoryId, requestDto);
+        TodoCategoryResponseDto responseDto = groupTodoCategoryService.changeCategory( memberId, groupId, categoryId, requestDto);
 
         return new BaseResponse<>(responseDto);
     }
 
     @DeleteMapping("/my-groups/{groupId}/categories/{categoryId}")
     @Operation(summary = "Group Category 삭제(soft) API")
-    public BaseResponse<CategoryResponseDto> deleteGroupCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                 @PathVariable("groupId") Long groupId,
-                                                                 @PathVariable("categoryId") Long categoryId) {
+    public BaseResponse<TodoCategoryResponseDto> deleteGroupCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                     @PathVariable("groupId") Long groupId,
+                                                                     @PathVariable("categoryId") Long categoryId) {
         Long memberId = principalDetails.getId();
-        CategoryResponseDto responseDto = groupTodoCategoryService.deleteCategory( memberId, groupId, categoryId );
+        TodoCategoryResponseDto responseDto = groupTodoCategoryService.deleteCategory( memberId, groupId, categoryId );
 
         return new BaseResponse<>(responseDto);
     }

--- a/src/main/java/scs/planus/domain/category/controller/GroupTodoCategoryController.java
+++ b/src/main/java/scs/planus/domain/category/controller/GroupTodoCategoryController.java
@@ -1,0 +1,69 @@
+package scs.planus.domain.category.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import scs.planus.domain.category.dto.CategoryGetResponseDto;
+import scs.planus.domain.category.dto.CategoryRequestDto;
+import scs.planus.domain.category.dto.CategoryResponseDto;
+import scs.planus.domain.category.service.GroupTodoCategoryService;
+import scs.planus.global.auth.entity.PrincipalDetails;
+import scs.planus.global.common.response.BaseResponse;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/app")
+@RequiredArgsConstructor
+@Tag(name = "Group Category", description = "Group Category API Document")
+public class GroupTodoCategoryController {
+    private final GroupTodoCategoryService groupTodoCategoryService;
+
+    @GetMapping("/my-groups/{groupId}/categories")
+    @Operation(summary = "전체 Group Category 조회 API")
+    public BaseResponse<List<CategoryGetResponseDto>> getAllGroupCategories(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                            @PathVariable("groupId") Long groupId) {
+
+        Long memberId = principalDetails.getId();
+        List<CategoryGetResponseDto> responseDto = groupTodoCategoryService.findAll( memberId, groupId );
+
+        return new BaseResponse<>(responseDto);
+    }
+
+    @PostMapping("/my-groups/{groupId}/categories")
+    @Operation(summary = "Group Category 생성 API")
+    public BaseResponse<CategoryResponseDto> createGroupCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                 @PathVariable("groupId") Long groupId,
+                                                                 @Valid @RequestBody CategoryRequestDto requestDto){
+        Long memberId = principalDetails.getId();
+        CategoryResponseDto responseDto = groupTodoCategoryService.createCategory( memberId, groupId, requestDto );
+
+        return new BaseResponse<>(responseDto);
+    }
+
+    @PatchMapping("/my-groups/{groupId}/categories/{categoryId}")
+    @Operation(summary = "Group Category 변경 API")
+    public BaseResponse<CategoryResponseDto> modifyGroupCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                 @PathVariable("groupId") Long groupId,
+                                                                 @PathVariable("categoryId") Long categoryId,
+                                                                 @RequestBody CategoryRequestDto requestDto) {
+        Long memberId = principalDetails.getId();
+        CategoryResponseDto responseDto = groupTodoCategoryService.changeCategory( memberId, groupId, categoryId, requestDto);
+
+        return new BaseResponse<>(responseDto);
+    }
+
+    @DeleteMapping("/my-groups/{groupId}/categories/{categoryId}")
+    @Operation(summary = "Group Category 삭제(soft) API")
+    public BaseResponse<CategoryResponseDto> deleteGroupCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                 @PathVariable("groupId") Long groupId,
+                                                                 @PathVariable("categoryId") Long categoryId) {
+        Long memberId = principalDetails.getId();
+        CategoryResponseDto responseDto = groupTodoCategoryService.deleteCategory( memberId, groupId, categoryId );
+
+        return new BaseResponse<>(responseDto);
+    }
+}

--- a/src/main/java/scs/planus/domain/category/controller/GroupTodoCategoryController.java
+++ b/src/main/java/scs/planus/domain/category/controller/GroupTodoCategoryController.java
@@ -18,14 +18,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/app")
 @RequiredArgsConstructor
-@Tag(name = "Group Category", description = "Group Category API Document")
+@Tag(name = "Group Todo Category", description = "Group Todo Category API Document")
 public class GroupTodoCategoryController {
     private final GroupTodoCategoryService groupTodoCategoryService;
 
     @GetMapping("/my-groups/{groupId}/categories")
-    @Operation(summary = "전체 Group Category 조회 API")
-    public BaseResponse<List<TodoCategoryGetResponseDto>> getAllGroupCategories(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                                @PathVariable("groupId") Long groupId) {
+    @Operation(summary = "전체 Group Todo Category 조회 API")
+    public BaseResponse<List<TodoCategoryGetResponseDto>> getAllGroupTodoCategories(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                                    @PathVariable("groupId") Long groupId) {
 
         Long memberId = principalDetails.getId();
         List<TodoCategoryGetResponseDto> responseDto = groupTodoCategoryService.findAll( memberId, groupId );
@@ -34,10 +34,10 @@ public class GroupTodoCategoryController {
     }
 
     @PostMapping("/my-groups/{groupId}/categories")
-    @Operation(summary = "Group Category 생성 API")
-    public BaseResponse<TodoCategoryResponseDto> createGroupCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                     @PathVariable("groupId") Long groupId,
-                                                                     @Valid @RequestBody TodoCategoryRequestDto requestDto){
+    @Operation(summary = "Group Todo Category 생성 API")
+    public BaseResponse<TodoCategoryResponseDto> createGroupTodoCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                         @PathVariable("groupId") Long groupId,
+                                                                         @Valid @RequestBody TodoCategoryRequestDto requestDto){
         Long memberId = principalDetails.getId();
         TodoCategoryResponseDto responseDto = groupTodoCategoryService.createCategory( memberId, groupId, requestDto );
 
@@ -45,11 +45,11 @@ public class GroupTodoCategoryController {
     }
 
     @PatchMapping("/my-groups/{groupId}/categories/{categoryId}")
-    @Operation(summary = "Group Category 변경 API")
-    public BaseResponse<TodoCategoryResponseDto> modifyGroupCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                     @PathVariable("groupId") Long groupId,
-                                                                     @PathVariable("categoryId") Long categoryId,
-                                                                     @RequestBody TodoCategoryRequestDto requestDto) {
+    @Operation(summary = "Group Todo Category 변경 API")
+    public BaseResponse<TodoCategoryResponseDto> modifyGroupTodoCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                         @PathVariable("groupId") Long groupId,
+                                                                         @PathVariable("categoryId") Long categoryId,
+                                                                         @RequestBody TodoCategoryRequestDto requestDto) {
         Long memberId = principalDetails.getId();
         TodoCategoryResponseDto responseDto = groupTodoCategoryService.changeCategory( memberId, groupId, categoryId, requestDto);
 
@@ -57,10 +57,10 @@ public class GroupTodoCategoryController {
     }
 
     @DeleteMapping("/my-groups/{groupId}/categories/{categoryId}")
-    @Operation(summary = "Group Category 삭제(soft) API")
-    public BaseResponse<TodoCategoryResponseDto> deleteGroupCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                     @PathVariable("groupId") Long groupId,
-                                                                     @PathVariable("categoryId") Long categoryId) {
+    @Operation(summary = "Group Todo Category 삭제(soft) API")
+    public BaseResponse<TodoCategoryResponseDto> deleteGroupTodoCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                         @PathVariable("groupId") Long groupId,
+                                                                         @PathVariable("categoryId") Long categoryId) {
         Long memberId = principalDetails.getId();
         TodoCategoryResponseDto responseDto = groupTodoCategoryService.deleteCategory( memberId, groupId, categoryId );
 

--- a/src/main/java/scs/planus/domain/category/controller/MemberTodoCategoryController.java
+++ b/src/main/java/scs/planus/domain/category/controller/MemberTodoCategoryController.java
@@ -10,7 +10,7 @@ import scs.planus.global.common.response.BaseResponse;
 import scs.planus.domain.category.dto.CategoryRequestDto;
 import scs.planus.domain.category.dto.CategoryGetResponseDto;
 import scs.planus.domain.category.dto.CategoryResponseDto;
-import scs.planus.domain.category.service.CategoryService;
+import scs.planus.domain.category.service.MemberTodoCategoryService;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -19,15 +19,15 @@ import java.util.List;
 @RequestMapping("/app")
 @RequiredArgsConstructor
 @Tag(name = "Category", description = "Category API Document")
-public class CategoryController {
-    private final CategoryService categoryService;
+public class MemberTodoCategoryController {
+    private final MemberTodoCategoryService memberTodoCategoryService;
 
     @GetMapping("/categories")
     @Operation(summary = "전체 Category 조회 API")
     public BaseResponse<List<CategoryGetResponseDto>> getAllCategory(@AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         Long memberId = principalDetails.getId();
-        List<CategoryGetResponseDto> responseDto = categoryService.findAll(memberId);
+        List<CategoryGetResponseDto> responseDto = memberTodoCategoryService.findAll(memberId);
 
         return new BaseResponse<>(responseDto);
     }
@@ -37,7 +37,7 @@ public class CategoryController {
     public BaseResponse<CategoryResponseDto> createCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                             @Valid @RequestBody CategoryRequestDto requestDto){
         Long memberId = principalDetails.getId();
-        CategoryResponseDto responseDto = categoryService.createCategory( memberId,
+        CategoryResponseDto responseDto = memberTodoCategoryService.createCategory( memberId,
                                                                             requestDto);
 
         return new BaseResponse<>(responseDto);
@@ -48,7 +48,7 @@ public class CategoryController {
     public BaseResponse<CategoryResponseDto> changeCategory(@PathVariable(name = "categoryId") Long categoryId,
                                                             @RequestBody CategoryRequestDto requestDto) {
 
-        CategoryResponseDto responseDto = categoryService.changeCategory( categoryId,
+        CategoryResponseDto responseDto = memberTodoCategoryService.changeCategory( categoryId,
                                                                             requestDto);
 
         return new BaseResponse<>(responseDto);
@@ -58,7 +58,7 @@ public class CategoryController {
     @Operation(summary = "Category 삭제 API")
     public BaseResponse<CategoryResponseDto> deleteCategory(@PathVariable(name = "categoryId") Long categoryId) {
 
-        CategoryResponseDto responseDto = categoryService.deleteCategory(categoryId);
+        CategoryResponseDto responseDto = memberTodoCategoryService.deleteCategory(categoryId);
 
         return new BaseResponse<>(responseDto);
     }

--- a/src/main/java/scs/planus/domain/category/controller/MemberTodoCategoryController.java
+++ b/src/main/java/scs/planus/domain/category/controller/MemberTodoCategoryController.java
@@ -7,9 +7,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.common.response.BaseResponse;
-import scs.planus.domain.category.dto.CategoryRequestDto;
-import scs.planus.domain.category.dto.CategoryGetResponseDto;
-import scs.planus.domain.category.dto.CategoryResponseDto;
+import scs.planus.domain.category.dto.TodoCategoryRequestDto;
+import scs.planus.domain.category.dto.TodoCategoryGetResponseDto;
+import scs.planus.domain.category.dto.TodoCategoryResponseDto;
 import scs.planus.domain.category.service.MemberTodoCategoryService;
 
 import javax.validation.Valid;
@@ -24,20 +24,20 @@ public class MemberTodoCategoryController {
 
     @GetMapping("/categories")
     @Operation(summary = "전체 Category 조회 API")
-    public BaseResponse<List<CategoryGetResponseDto>> getAllCategory(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+    public BaseResponse<List<TodoCategoryGetResponseDto>> getAllCategory(@AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         Long memberId = principalDetails.getId();
-        List<CategoryGetResponseDto> responseDto = memberTodoCategoryService.findAll(memberId);
+        List<TodoCategoryGetResponseDto> responseDto = memberTodoCategoryService.findAll(memberId);
 
         return new BaseResponse<>(responseDto);
     }
 
     @PostMapping("/categories")
     @Operation(summary = "Category 생성 API")
-    public BaseResponse<CategoryResponseDto> createCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                            @Valid @RequestBody CategoryRequestDto requestDto){
+    public BaseResponse<TodoCategoryResponseDto> createCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                @Valid @RequestBody TodoCategoryRequestDto requestDto){
         Long memberId = principalDetails.getId();
-        CategoryResponseDto responseDto = memberTodoCategoryService.createCategory( memberId,
+        TodoCategoryResponseDto responseDto = memberTodoCategoryService.createCategory( memberId,
                                                                             requestDto);
 
         return new BaseResponse<>(responseDto);
@@ -45,10 +45,10 @@ public class MemberTodoCategoryController {
 
     @PatchMapping("/categories/{categoryId}")
     @Operation(summary = "Category 변경 API")
-    public BaseResponse<CategoryResponseDto> changeCategory(@PathVariable(name = "categoryId") Long categoryId,
-                                                            @RequestBody CategoryRequestDto requestDto) {
+    public BaseResponse<TodoCategoryResponseDto> changeCategory(@PathVariable(name = "categoryId") Long categoryId,
+                                                                @RequestBody TodoCategoryRequestDto requestDto) {
 
-        CategoryResponseDto responseDto = memberTodoCategoryService.changeCategory( categoryId,
+        TodoCategoryResponseDto responseDto = memberTodoCategoryService.changeCategory( categoryId,
                                                                             requestDto);
 
         return new BaseResponse<>(responseDto);
@@ -56,9 +56,9 @@ public class MemberTodoCategoryController {
 
     @DeleteMapping("/categories/{categoryId}")
     @Operation(summary = "Category 삭제 API")
-    public BaseResponse<CategoryResponseDto> deleteCategory(@PathVariable(name = "categoryId") Long categoryId) {
+    public BaseResponse<TodoCategoryResponseDto> deleteCategory(@PathVariable(name = "categoryId") Long categoryId) {
 
-        CategoryResponseDto responseDto = memberTodoCategoryService.deleteCategory(categoryId);
+        TodoCategoryResponseDto responseDto = memberTodoCategoryService.deleteCategory(categoryId);
 
         return new BaseResponse<>(responseDto);
     }

--- a/src/main/java/scs/planus/domain/category/controller/MemberTodoCategoryController.java
+++ b/src/main/java/scs/planus/domain/category/controller/MemberTodoCategoryController.java
@@ -18,13 +18,13 @@ import java.util.List;
 @RestController
 @RequestMapping("/app")
 @RequiredArgsConstructor
-@Tag(name = "Category", description = "Category API Document")
+@Tag(name = "Member Todo Category", description = "Member Todo Category API Document")
 public class MemberTodoCategoryController {
     private final MemberTodoCategoryService memberTodoCategoryService;
 
     @GetMapping("/categories")
-    @Operation(summary = "전체 Category 조회 API")
-    public BaseResponse<List<TodoCategoryGetResponseDto>> getAllCategory(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+    @Operation(summary = "전체 Member Todo  Category 조회 API")
+    public BaseResponse<List<TodoCategoryGetResponseDto>> getAllMemberTodoCategory(@AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         Long memberId = principalDetails.getId();
         List<TodoCategoryGetResponseDto> responseDto = memberTodoCategoryService.findAll(memberId);
@@ -33,9 +33,9 @@ public class MemberTodoCategoryController {
     }
 
     @PostMapping("/categories")
-    @Operation(summary = "Category 생성 API")
-    public BaseResponse<TodoCategoryResponseDto> createCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                @Valid @RequestBody TodoCategoryRequestDto requestDto){
+    @Operation(summary = "Member Todo Category 생성 API")
+    public BaseResponse<TodoCategoryResponseDto> createMemberTodoCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                          @Valid @RequestBody TodoCategoryRequestDto requestDto){
         Long memberId = principalDetails.getId();
         TodoCategoryResponseDto responseDto = memberTodoCategoryService.createCategory( memberId,
                                                                             requestDto);
@@ -44,9 +44,10 @@ public class MemberTodoCategoryController {
     }
 
     @PatchMapping("/categories/{categoryId}")
-    @Operation(summary = "Category 변경 API")
-    public BaseResponse<TodoCategoryResponseDto> changeCategory(@PathVariable(name = "categoryId") Long categoryId,
-                                                                @RequestBody TodoCategoryRequestDto requestDto) {
+    @Operation(summary = "Member Todo Category 변경 API")
+    public BaseResponse<TodoCategoryResponseDto> modifyMemberTodoCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                          @PathVariable(name = "categoryId") Long categoryId,
+                                                                          @RequestBody TodoCategoryRequestDto requestDto) {
 
         TodoCategoryResponseDto responseDto = memberTodoCategoryService.changeCategory( categoryId,
                                                                             requestDto);
@@ -55,8 +56,9 @@ public class MemberTodoCategoryController {
     }
 
     @DeleteMapping("/categories/{categoryId}")
-    @Operation(summary = "Category 삭제 API")
-    public BaseResponse<TodoCategoryResponseDto> deleteCategory(@PathVariable(name = "categoryId") Long categoryId) {
+    @Operation(summary = "Member Todo Category 삭제 API")
+    public BaseResponse<TodoCategoryResponseDto> deleteMemberTodoCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                          @PathVariable(name = "categoryId") Long categoryId) {
 
         TodoCategoryResponseDto responseDto = memberTodoCategoryService.deleteCategory(categoryId);
 

--- a/src/main/java/scs/planus/domain/category/dto/CategoryRequestDto.java
+++ b/src/main/java/scs/planus/domain/category/dto/CategoryRequestDto.java
@@ -1,12 +1,10 @@
 package scs.planus.domain.category.dto;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import scs.planus.domain.category.entity.Color;
+import scs.planus.domain.category.entity.GroupTodoCategory;
 import scs.planus.domain.category.entity.MemberTodoCategory;
+import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.member.entity.Member;
 
 import javax.validation.constraints.NotBlank;
@@ -27,6 +25,14 @@ public class CategoryRequestDto {
     public MemberTodoCategory toMemberTodoCategoryEntity(Member member, Color color) {
         return MemberTodoCategory.builder()
                 .member(member)
+                .name(this.name)
+                .color(color)
+                .build();
+    }
+
+    public GroupTodoCategory toGroupTodoCategoryEntity(Group group, Color color) {
+        return GroupTodoCategory.builder()
+                .group(group)
                 .name(this.name)
                 .color(color)
                 .build();

--- a/src/main/java/scs/planus/domain/category/dto/CategoryRequestDto.java
+++ b/src/main/java/scs/planus/domain/category/dto/CategoryRequestDto.java
@@ -24,8 +24,7 @@ public class CategoryRequestDto {
     @NotBlank(message = "[request] 색을 지정해 주세요.")
     private String color;
 
-    public MemberTodoCategory toEntity(Member member) {
-        Color color = Color.isValid(this.color);
+    public MemberTodoCategory toMemberTodoCategoryEntity(Member member, Color color) {
         return MemberTodoCategory.builder()
                 .member(member)
                 .name(this.name)

--- a/src/main/java/scs/planus/domain/category/dto/CategoryResponseDto.java
+++ b/src/main/java/scs/planus/domain/category/dto/CategoryResponseDto.java
@@ -1,16 +1,17 @@
 package scs.planus.domain.category.dto;
 
-import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import scs.planus.domain.category.entity.TodoCategory;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class CategoryResponseDto {
     private Long id;
 
-    public CategoryResponseDto(TodoCategory todoCategory) {
-        this.id = todoCategory.getId();
+    public static CategoryResponseDto of(TodoCategory todoCategory) {
+        return CategoryResponseDto.builder()
+                .id(todoCategory.getId())
+                .build();
     }
 }

--- a/src/main/java/scs/planus/domain/category/dto/TodoCategoryGetResponseDto.java
+++ b/src/main/java/scs/planus/domain/category/dto/TodoCategoryGetResponseDto.java
@@ -8,14 +8,14 @@ import scs.planus.domain.category.entity.TodoCategory;
 
 @Getter
 @Builder
-public class CategoryGetResponseDto {
+public class TodoCategoryGetResponseDto {
     private Long id;
     private String name;
     private Color color;
     private Status status;
 
-    public static CategoryGetResponseDto of(TodoCategory todoCategory) {
-        return CategoryGetResponseDto.builder()
+    public static TodoCategoryGetResponseDto of(TodoCategory todoCategory) {
+        return TodoCategoryGetResponseDto.builder()
                 .id(todoCategory.getId())
                 .name(todoCategory.getName())
                 .color(todoCategory.getColor())

--- a/src/main/java/scs/planus/domain/category/dto/TodoCategoryRequestDto.java
+++ b/src/main/java/scs/planus/domain/category/dto/TodoCategoryRequestDto.java
@@ -14,7 +14,7 @@ import javax.validation.constraints.Size;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class CategoryRequestDto {
+public class TodoCategoryRequestDto {
     @NotBlank(message = "[request] 제목을 입력해 주세요.")
     @Size(min = 1, max = 10, message = "[request] 제목은 1 ~ 10 글자로 입력해 주세요.")
     private String name;

--- a/src/main/java/scs/planus/domain/category/dto/TodoCategoryResponseDto.java
+++ b/src/main/java/scs/planus/domain/category/dto/TodoCategoryResponseDto.java
@@ -6,11 +6,11 @@ import scs.planus.domain.category.entity.TodoCategory;
 
 @Getter
 @Builder
-public class CategoryResponseDto {
+public class TodoCategoryResponseDto {
     private Long id;
 
-    public static CategoryResponseDto of(TodoCategory todoCategory) {
-        return CategoryResponseDto.builder()
+    public static TodoCategoryResponseDto of(TodoCategory todoCategory) {
+        return TodoCategoryResponseDto.builder()
                 .id(todoCategory.getId())
                 .build();
     }

--- a/src/main/java/scs/planus/domain/category/entity/Color.java
+++ b/src/main/java/scs/planus/domain/category/entity/Color.java
@@ -2,17 +2,17 @@ package scs.planus.domain.category.entity;
 
 import scs.planus.global.exception.PlanusException;
 
-import static scs.planus.global.exception.CustomExceptionStatus.INVALID_PARAMETER;
+import java.util.Arrays;
+
+import static scs.planus.global.exception.CustomExceptionStatus.INVALID_CATEGORY_COLOR;
 
 public enum Color {
     BLUE, GOLD, PINK, PURPLE, GREEN, NAVY, RED, YELLOW;
 
-    public static Color isValid(String color) throws PlanusException {
-        for (Color enumColor : Color.values()) {
-            if (enumColor.name().equals(color)) {
-                return enumColor;
-            }
-        }
-        throw new PlanusException(INVALID_PARAMETER);
+    public static Color translate(String color){
+        return Arrays.stream(Color.values())
+                .filter(enumColor -> enumColor.name().equals(color))
+                .findAny()
+                .orElseThrow(() -> new PlanusException(INVALID_CATEGORY_COLOR));
     }
 }

--- a/src/main/java/scs/planus/domain/category/entity/Color.java
+++ b/src/main/java/scs/planus/domain/category/entity/Color.java
@@ -9,7 +9,7 @@ import static scs.planus.global.exception.CustomExceptionStatus.INVALID_CATEGORY
 public enum Color {
     BLUE, GOLD, PINK, PURPLE, GREEN, NAVY, RED, YELLOW;
 
-    public static Color translate(String color){
+    public static Color of(String color){
         return Arrays.stream(Color.values())
                 .filter(enumColor -> enumColor.name().equals(color))
                 .findAny()

--- a/src/main/java/scs/planus/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/scs/planus/domain/category/repository/CategoryRepository.java
@@ -3,13 +3,26 @@ package scs.planus.domain.category.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import scs.planus.domain.category.entity.GroupTodoCategory;
+import scs.planus.domain.category.entity.MemberTodoCategory;
 import scs.planus.domain.category.entity.TodoCategory;
+import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.member.entity.Member;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<TodoCategory, Long> {
-    @Query("select c from TodoCategory c " +
-            "where c.member= :member")
-    List<TodoCategory> findAllByMember(@Param("member") Member member);
+    @Query("select mc from MemberTodoCategory mc " +
+            "where mc.member= :member")
+    List<MemberTodoCategory> findAllByMember(@Param("member") Member member);
+
+    @Query("select gc from GroupTodoCategory gc " +
+            "where gc.group= :group")
+    List<GroupTodoCategory> findAllByGroup(@Param("group") Group group);
+
+    @Query("select gc from GroupTodoCategory gc " +
+            "where gc.id= :categoryId " +
+            "and gc.status= 'ACTIVE' ")
+    Optional<GroupTodoCategory> findByIdAndStatus(@Param("categoryId") Long categoryId);
 }

--- a/src/main/java/scs/planus/domain/category/repository/TodoCategoryRepository.java
+++ b/src/main/java/scs/planus/domain/category/repository/TodoCategoryRepository.java
@@ -12,7 +12,7 @@ import scs.planus.domain.member.entity.Member;
 import java.util.List;
 import java.util.Optional;
 
-public interface CategoryRepository extends JpaRepository<TodoCategory, Long> {
+public interface TodoCategoryRepository extends JpaRepository<TodoCategory, Long> {
     @Query("select mc from MemberTodoCategory mc " +
             "where mc.member= :member")
     List<MemberTodoCategory> findAllByMember(@Param("member") Member member);

--- a/src/main/java/scs/planus/domain/category/service/CategoryService.java
+++ b/src/main/java/scs/planus/domain/category/service/CategoryService.java
@@ -4,16 +4,17 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import scs.planus.domain.category.entity.TodoCategory;
-import scs.planus.global.exception.PlanusException;
-import scs.planus.global.exception.CustomExceptionStatus;
-import scs.planus.domain.category.entity.Color;
-import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.category.dto.CategoryGetResponseDto;
 import scs.planus.domain.category.dto.CategoryRequestDto;
 import scs.planus.domain.category.dto.CategoryResponseDto;
+import scs.planus.domain.category.entity.Color;
+import scs.planus.domain.category.entity.MemberTodoCategory;
+import scs.planus.domain.category.entity.TodoCategory;
 import scs.planus.domain.category.repository.CategoryRepository;
+import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
+import scs.planus.global.exception.CustomExceptionStatus;
+import scs.planus.global.exception.PlanusException;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,9 +36,9 @@ public class CategoryService {
                     throw new PlanusException(CustomExceptionStatus.NONE_USER);
                 });
 
-        List<TodoCategory> todoCategories = categoryRepository.findAllByMember(member);
+        List<MemberTodoCategory> memberTodoCategories = categoryRepository.findAllByMember(member);
 
-        return todoCategories.stream()
+        return memberTodoCategories.stream()
                 .map(CategoryGetResponseDto::of)
                 .collect(Collectors.toList());
     }
@@ -52,10 +53,11 @@ public class CategoryService {
                     throw new PlanusException(CustomExceptionStatus.NONE_USER);
                 });
 
-        TodoCategory todoCategory = requestDto.toEntity(member);
+        Color color = Color.translate(requestDto.getColor());
+        TodoCategory todoCategory = requestDto.toMemberTodoCategoryEntity(member, color);
         TodoCategory saveCategory = categoryRepository.save(todoCategory);
 
-        return new CategoryResponseDto(saveCategory);
+        return CategoryResponseDto.of(saveCategory);
     }
 
     /**
@@ -68,10 +70,10 @@ public class CategoryService {
                     throw new PlanusException(CustomExceptionStatus.NOT_EXIST_CATEGORY);
                 });
 
-        Color color = Color.isValid(requestDto.getColor());
+        Color color = Color.translate(requestDto.getColor());
         findCategory.change(requestDto.getName(), color);
 
-        return new CategoryResponseDto(findCategory);
+        return CategoryResponseDto.of(findCategory);
     }
 
     /**
@@ -86,7 +88,6 @@ public class CategoryService {
 
         findCategory.changeStatusToInactive();
 
-        return new CategoryResponseDto(findCategory);
+        return CategoryResponseDto.of(findCategory);
     }
-
 }

--- a/src/main/java/scs/planus/domain/category/service/GroupTodoCategoryService.java
+++ b/src/main/java/scs/planus/domain/category/service/GroupTodoCategoryService.java
@@ -1,0 +1,126 @@
+package scs.planus.domain.category.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import scs.planus.domain.category.dto.CategoryGetResponseDto;
+import scs.planus.domain.category.dto.CategoryRequestDto;
+import scs.planus.domain.category.dto.CategoryResponseDto;
+import scs.planus.domain.category.entity.Color;
+import scs.planus.domain.category.entity.GroupTodoCategory;
+import scs.planus.domain.category.repository.CategoryRepository;
+import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.group.repository.GroupMemberQueryRepository;
+import scs.planus.domain.group.repository.GroupRepository;
+import scs.planus.domain.member.entity.Member;
+import scs.planus.domain.member.repository.MemberRepository;
+import scs.planus.global.exception.PlanusException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static scs.planus.global.exception.CustomExceptionStatus.*;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class GroupTodoCategoryService {
+    private final CategoryRepository categoryRepository;
+    private final MemberRepository memberRepository;
+    private final GroupMemberQueryRepository groupMemberQueryRepository;
+    private final GroupRepository groupRepository;
+
+    public List<CategoryGetResponseDto> findAll( Long memberId, Long groupId ) {
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> new PlanusException( NONE_USER ));
+
+        Group group = groupRepository.findByIdAndStatus( groupId )
+                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
+
+        Boolean isTodoAuthority = groupMemberQueryRepository
+                .existByMemberIdAndGroupIdAndTodoAuthority( member.getId(), group.getId() );
+
+        if (!isTodoAuthority) {
+            throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
+        }
+
+        List<GroupTodoCategory> groupTodoCategories = categoryRepository.findAllByGroup( group );
+
+        return groupTodoCategories.stream()
+                .map( CategoryGetResponseDto::of )
+                .collect( Collectors.toList() );
+    }
+
+    @Transactional
+    public CategoryResponseDto createCategory( Long memberId, Long groupId, CategoryRequestDto requestDto ) {
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> new PlanusException( NONE_USER ));
+
+        Group group = groupRepository.findByIdAndStatus( groupId )
+                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
+
+        Boolean isTodoAuthority = groupMemberQueryRepository
+                .existByMemberIdAndGroupIdAndTodoAuthority( member.getId(), group.getId() );
+
+        if (!isTodoAuthority) {
+            throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
+        }
+
+        Color color = Color.translate(requestDto.getColor());
+
+        GroupTodoCategory groupTodoCategory = requestDto.toGroupTodoCategoryEntity( group, color );
+        GroupTodoCategory saveGroupTodoCategory = categoryRepository.save( groupTodoCategory );
+
+        return CategoryResponseDto.of( saveGroupTodoCategory );
+    }
+
+    @Transactional
+    public CategoryResponseDto changeCategory( Long memberId, Long groupId, Long categoryId, CategoryRequestDto requestDto ) {
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> new PlanusException( NONE_USER ));
+
+        Group group = groupRepository.findByIdAndStatus( groupId )
+                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
+
+        Boolean isTodoAuthority = groupMemberQueryRepository
+                .existByMemberIdAndGroupIdAndTodoAuthority( member.getId(), group.getId() );
+
+        if (!isTodoAuthority) {
+            throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
+        }
+
+        GroupTodoCategory groupTodoCategory = categoryRepository.findByIdAndStatus( categoryId )
+                .orElseThrow(() -> new PlanusException( NOT_EXIST_CATEGORY ));
+
+        Color color = Color.translate( requestDto.getColor() );
+        groupTodoCategory.change( requestDto.getName(), color );
+
+        return CategoryResponseDto.of( groupTodoCategory );
+    }
+
+    @Transactional
+    public CategoryResponseDto deleteCategory( Long memberId, Long groupId,Long categoryId ) {
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> new PlanusException( NONE_USER ));
+
+        Group group = groupRepository.findByIdAndStatus( groupId )
+                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
+
+        Boolean isTodoAuthority = groupMemberQueryRepository
+                .existByMemberIdAndGroupIdAndTodoAuthority( member.getId(), group.getId() );
+
+        if (!isTodoAuthority) {
+            throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
+        }
+
+        GroupTodoCategory groupTodoCategory = categoryRepository.findByIdAndStatus( categoryId )
+                .orElseThrow(() -> new PlanusException( NOT_EXIST_CATEGORY ));
+
+        groupTodoCategory.changeStatusToInactive();
+
+        return CategoryResponseDto.of( groupTodoCategory );
+    }
+
+}

--- a/src/main/java/scs/planus/domain/category/service/GroupTodoCategoryService.java
+++ b/src/main/java/scs/planus/domain/category/service/GroupTodoCategoryService.java
@@ -68,7 +68,7 @@ public class GroupTodoCategoryService {
             throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
         }
 
-        Color color = Color.translate(requestDto.getColor());
+        Color color = Color.of(requestDto.getColor());
 
         GroupTodoCategory groupTodoCategory = requestDto.toGroupTodoCategoryEntity( group, color );
         GroupTodoCategory saveGroupTodoCategory = todoCategoryRepository.save( groupTodoCategory );
@@ -94,7 +94,7 @@ public class GroupTodoCategoryService {
         GroupTodoCategory groupTodoCategory = todoCategoryRepository.findByIdAndStatus( categoryId )
                 .orElseThrow(() -> new PlanusException( NOT_EXIST_CATEGORY ));
 
-        Color color = Color.translate( requestDto.getColor() );
+        Color color = Color.of( requestDto.getColor() );
         groupTodoCategory.change( requestDto.getName(), color );
 
         return TodoCategoryResponseDto.of( groupTodoCategory );

--- a/src/main/java/scs/planus/domain/category/service/GroupTodoCategoryService.java
+++ b/src/main/java/scs/planus/domain/category/service/GroupTodoCategoryService.java
@@ -4,12 +4,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import scs.planus.domain.category.dto.CategoryGetResponseDto;
-import scs.planus.domain.category.dto.CategoryRequestDto;
-import scs.planus.domain.category.dto.CategoryResponseDto;
+import scs.planus.domain.category.dto.TodoCategoryGetResponseDto;
+import scs.planus.domain.category.dto.TodoCategoryRequestDto;
+import scs.planus.domain.category.dto.TodoCategoryResponseDto;
 import scs.planus.domain.category.entity.Color;
 import scs.planus.domain.category.entity.GroupTodoCategory;
-import scs.planus.domain.category.repository.CategoryRepository;
+import scs.planus.domain.category.repository.TodoCategoryRepository;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.repository.GroupMemberQueryRepository;
 import scs.planus.domain.group.repository.GroupRepository;
@@ -27,12 +27,12 @@ import static scs.planus.global.exception.CustomExceptionStatus.*;
 @RequiredArgsConstructor
 @Slf4j
 public class GroupTodoCategoryService {
-    private final CategoryRepository categoryRepository;
+    private final TodoCategoryRepository todoCategoryRepository;
     private final MemberRepository memberRepository;
     private final GroupMemberQueryRepository groupMemberQueryRepository;
     private final GroupRepository groupRepository;
 
-    public List<CategoryGetResponseDto> findAll( Long memberId, Long groupId ) {
+    public List<TodoCategoryGetResponseDto> findAll(Long memberId, Long groupId ) {
         Member member = memberRepository.findById( memberId )
                 .orElseThrow(() -> new PlanusException( NONE_USER ));
 
@@ -46,15 +46,15 @@ public class GroupTodoCategoryService {
             throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
         }
 
-        List<GroupTodoCategory> groupTodoCategories = categoryRepository.findAllByGroup( group );
+        List<GroupTodoCategory> groupTodoCategories = todoCategoryRepository.findAllByGroup( group );
 
         return groupTodoCategories.stream()
-                .map( CategoryGetResponseDto::of )
+                .map( TodoCategoryGetResponseDto::of )
                 .collect( Collectors.toList() );
     }
 
     @Transactional
-    public CategoryResponseDto createCategory( Long memberId, Long groupId, CategoryRequestDto requestDto ) {
+    public TodoCategoryResponseDto createCategory(Long memberId, Long groupId, TodoCategoryRequestDto requestDto ) {
         Member member = memberRepository.findById( memberId )
                 .orElseThrow(() -> new PlanusException( NONE_USER ));
 
@@ -71,13 +71,13 @@ public class GroupTodoCategoryService {
         Color color = Color.translate(requestDto.getColor());
 
         GroupTodoCategory groupTodoCategory = requestDto.toGroupTodoCategoryEntity( group, color );
-        GroupTodoCategory saveGroupTodoCategory = categoryRepository.save( groupTodoCategory );
+        GroupTodoCategory saveGroupTodoCategory = todoCategoryRepository.save( groupTodoCategory );
 
-        return CategoryResponseDto.of( saveGroupTodoCategory );
+        return TodoCategoryResponseDto.of( saveGroupTodoCategory );
     }
 
     @Transactional
-    public CategoryResponseDto changeCategory( Long memberId, Long groupId, Long categoryId, CategoryRequestDto requestDto ) {
+    public TodoCategoryResponseDto changeCategory(Long memberId, Long groupId, Long categoryId, TodoCategoryRequestDto requestDto ) {
         Member member = memberRepository.findById( memberId )
                 .orElseThrow(() -> new PlanusException( NONE_USER ));
 
@@ -91,17 +91,17 @@ public class GroupTodoCategoryService {
             throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
         }
 
-        GroupTodoCategory groupTodoCategory = categoryRepository.findByIdAndStatus( categoryId )
+        GroupTodoCategory groupTodoCategory = todoCategoryRepository.findByIdAndStatus( categoryId )
                 .orElseThrow(() -> new PlanusException( NOT_EXIST_CATEGORY ));
 
         Color color = Color.translate( requestDto.getColor() );
         groupTodoCategory.change( requestDto.getName(), color );
 
-        return CategoryResponseDto.of( groupTodoCategory );
+        return TodoCategoryResponseDto.of( groupTodoCategory );
     }
 
     @Transactional
-    public CategoryResponseDto deleteCategory( Long memberId, Long groupId,Long categoryId ) {
+    public TodoCategoryResponseDto deleteCategory(Long memberId, Long groupId, Long categoryId ) {
         Member member = memberRepository.findById( memberId )
                 .orElseThrow(() -> new PlanusException( NONE_USER ));
 
@@ -115,12 +115,12 @@ public class GroupTodoCategoryService {
             throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
         }
 
-        GroupTodoCategory groupTodoCategory = categoryRepository.findByIdAndStatus( categoryId )
+        GroupTodoCategory groupTodoCategory = todoCategoryRepository.findByIdAndStatus( categoryId )
                 .orElseThrow(() -> new PlanusException( NOT_EXIST_CATEGORY ));
 
         groupTodoCategory.changeStatusToInactive();
 
-        return CategoryResponseDto.of( groupTodoCategory );
+        return TodoCategoryResponseDto.of( groupTodoCategory );
     }
 
 }

--- a/src/main/java/scs/planus/domain/category/service/MemberTodoCategoryService.java
+++ b/src/main/java/scs/planus/domain/category/service/MemberTodoCategoryService.java
@@ -4,13 +4,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import scs.planus.domain.category.dto.CategoryGetResponseDto;
-import scs.planus.domain.category.dto.CategoryRequestDto;
-import scs.planus.domain.category.dto.CategoryResponseDto;
+import scs.planus.domain.category.dto.TodoCategoryGetResponseDto;
+import scs.planus.domain.category.dto.TodoCategoryRequestDto;
+import scs.planus.domain.category.dto.TodoCategoryResponseDto;
 import scs.planus.domain.category.entity.Color;
 import scs.planus.domain.category.entity.MemberTodoCategory;
 import scs.planus.domain.category.entity.TodoCategory;
-import scs.planus.domain.category.repository.CategoryRepository;
+import scs.planus.domain.category.repository.TodoCategoryRepository;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.global.exception.CustomExceptionStatus;
@@ -24,22 +24,22 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Slf4j
 public class MemberTodoCategoryService {
-    private final CategoryRepository categoryRepository;
+    private final TodoCategoryRepository todoCategoryRepository;
     private final MemberRepository memberRepository;
 
     /**
      * 카테고리 조회
      */
-    public List<CategoryGetResponseDto> findAll(Long memberId) {
+    public List<TodoCategoryGetResponseDto> findAll(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> {
                     throw new PlanusException(CustomExceptionStatus.NONE_USER);
                 });
 
-        List<MemberTodoCategory> memberTodoCategories = categoryRepository.findAllByMember(member);
+        List<MemberTodoCategory> memberTodoCategories = todoCategoryRepository.findAllByMember(member);
 
         return memberTodoCategories.stream()
-                .map(CategoryGetResponseDto::of)
+                .map(TodoCategoryGetResponseDto::of)
                 .collect(Collectors.toList());
     }
 
@@ -47,7 +47,7 @@ public class MemberTodoCategoryService {
      * 새로운 카테고리 생성
      */
     @Transactional
-    public CategoryResponseDto createCategory(Long memberId, CategoryRequestDto requestDto) {
+    public TodoCategoryResponseDto createCategory(Long memberId, TodoCategoryRequestDto requestDto) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> {
                     throw new PlanusException(CustomExceptionStatus.NONE_USER);
@@ -55,17 +55,17 @@ public class MemberTodoCategoryService {
 
         Color color = Color.translate(requestDto.getColor());
         TodoCategory todoCategory = requestDto.toMemberTodoCategoryEntity(member, color);
-        TodoCategory saveCategory = categoryRepository.save(todoCategory);
+        TodoCategory saveCategory = todoCategoryRepository.save(todoCategory);
 
-        return CategoryResponseDto.of(saveCategory);
+        return TodoCategoryResponseDto.of(saveCategory);
     }
 
     /**
      * 카테고리 수정
      */
     @Transactional
-    public CategoryResponseDto changeCategory(Long categoryId, CategoryRequestDto requestDto) {
-        TodoCategory findCategory = categoryRepository.findById(categoryId)
+    public TodoCategoryResponseDto changeCategory(Long categoryId, TodoCategoryRequestDto requestDto) {
+        TodoCategory findCategory = todoCategoryRepository.findById(categoryId)
                 .orElseThrow(() -> {
                     throw new PlanusException(CustomExceptionStatus.NOT_EXIST_CATEGORY);
                 });
@@ -73,21 +73,21 @@ public class MemberTodoCategoryService {
         Color color = Color.translate(requestDto.getColor());
         findCategory.change(requestDto.getName(), color);
 
-        return CategoryResponseDto.of(findCategory);
+        return TodoCategoryResponseDto.of(findCategory);
     }
 
     /**
      * 카테고리 삭제
      */
     @Transactional
-    public CategoryResponseDto deleteCategory(Long categoryId) {
-        TodoCategory findCategory = categoryRepository.findById(categoryId)
+    public TodoCategoryResponseDto deleteCategory(Long categoryId) {
+        TodoCategory findCategory = todoCategoryRepository.findById(categoryId)
                 .orElseThrow(() -> {
                     throw new PlanusException(CustomExceptionStatus.NOT_EXIST_CATEGORY);
                 });
 
         findCategory.changeStatusToInactive();
 
-        return CategoryResponseDto.of(findCategory);
+        return TodoCategoryResponseDto.of(findCategory);
     }
 }

--- a/src/main/java/scs/planus/domain/category/service/MemberTodoCategoryService.java
+++ b/src/main/java/scs/planus/domain/category/service/MemberTodoCategoryService.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Slf4j
-public class CategoryService {
+public class MemberTodoCategoryService {
     private final CategoryRepository categoryRepository;
     private final MemberRepository memberRepository;
 

--- a/src/main/java/scs/planus/domain/category/service/MemberTodoCategoryService.java
+++ b/src/main/java/scs/planus/domain/category/service/MemberTodoCategoryService.java
@@ -53,7 +53,7 @@ public class MemberTodoCategoryService {
                     throw new PlanusException(CustomExceptionStatus.NONE_USER);
                 });
 
-        Color color = Color.translate(requestDto.getColor());
+        Color color = Color.of(requestDto.getColor());
         TodoCategory todoCategory = requestDto.toMemberTodoCategoryEntity(member, color);
         TodoCategory saveCategory = todoCategoryRepository.save(todoCategory);
 
@@ -70,7 +70,7 @@ public class MemberTodoCategoryService {
                     throw new PlanusException(CustomExceptionStatus.NOT_EXIST_CATEGORY);
                 });
 
-        Color color = Color.translate(requestDto.getColor());
+        Color color = Color.of(requestDto.getColor());
         findCategory.change(requestDto.getName(), color);
 
         return TodoCategoryResponseDto.of(findCategory);

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberQueryRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberQueryRepository.java
@@ -28,6 +28,16 @@ public class GroupMemberQueryRepository {
         return fetchOne != null;
     }
 
+    public Boolean existByMemberIdAndGroupIdAndTodoAuthority(Long memberId, Long groupId) {
+        Integer fetchOne = queryFactory.selectOne()
+                .from(groupMember)
+                .join(groupMember.member, member)
+                .join(groupMember.group, group)
+                .where(isActiveGroup(), memberIdEq(memberId), groupIdEq(groupId), isTodoAuthority())
+                .fetchFirst();
+        return fetchOne != null;
+    }
+
     private BooleanExpression memberIdEq(Long memberId) {
         return member.id.eq(memberId);
     }
@@ -38,5 +48,8 @@ public class GroupMemberQueryRepository {
 
     private BooleanExpression isActiveGroup() {
         return group.status.eq(Status.ACTIVE);
+    }
+    private BooleanExpression isTodoAuthority() {
+        return groupMember.todoAuthority.eq(true);
     }
 }

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import scs.planus.domain.category.entity.TodoCategory;
-import scs.planus.domain.category.repository.CategoryRepository;
+import scs.planus.domain.category.repository.TodoCategoryRepository;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.repository.GroupRepository;
 import scs.planus.domain.member.entity.Member;
@@ -28,7 +28,7 @@ import static scs.planus.global.exception.CustomExceptionStatus.*;
 public class TodoService {
 
     private final MemberRepository memberRepository;
-    private final CategoryRepository categoryRepository;
+    private final TodoCategoryRepository todoCategoryRepository;
     private final GroupRepository groupRepository;
     private final TodoRepository todoRepository;
     private final TodoQueryRepository todoQueryRepository;
@@ -38,7 +38,7 @@ public class TodoService {
         Member member = memberRepository.findById(memberId)
                         .orElseThrow(() -> new PlanusException(NONE_USER));
 
-        TodoCategory todoCategory = categoryRepository.findById(requestDto.getCategoryId())
+        TodoCategory todoCategory = todoCategoryRepository.findById(requestDto.getCategoryId())
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
 
         Group group = getGroup(requestDto.getGroupId());
@@ -66,7 +66,7 @@ public class TodoService {
         Todo todo = todoQueryRepository.findOneTodoById(todoId, member.getId())
                 .orElseThrow(() -> new PlanusException(NONE_TODO));
 
-        TodoCategory todoCategory = categoryRepository.findById(requestDto.getCategoryId())
+        TodoCategory todoCategory = todoCategoryRepository.findById(requestDto.getCategoryId())
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
 
         Group group = getGroup(requestDto.getGroupId());

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -29,6 +29,7 @@ public enum CustomExceptionStatus implements ResponseStatus {
 
     // category exception
     NOT_EXIST_CATEGORY(BAD_REQUEST, 2400, "존재하지 않는 카테고리 입니다."),
+    INVALID_CATEGORY_COLOR(BAD_REQUEST, 2401, "소문자가 섞여 있거나, 존재하지 않는 카테고리 색 입니다."),
 
     // to_do exception
     INVALID_DATE(BAD_REQUEST, 2500, "시작 날짜가 끝 날짜보다 늦을 수 없습니다."),

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -42,6 +42,7 @@ public enum CustomExceptionStatus implements ResponseStatus {
     EXCEED_GROUP_LIMIT_COUNT(BAD_REQUEST, 2603, "그룹 제한 인원을 초과하였습니다."),
     ALREADY_JOINED_GROUP(BAD_REQUEST, 2604, "이미 가입된 그룹입니다."),
     NOT_EXIST_GROUP_JOIN(BAD_REQUEST, 2605, "존재 하지 않는 그룹 가입 신청서 입니다."),
+    DO_NOT_HAVE_TODO_AUTHORITY(BAD_REQUEST, 2606, "그룹 투두 권한이 없습니다."),
 
     // groupMember excepion
     NOT_JOINED_GROUP(BAD_REQUEST, 2700, "가입하지 않은 그룹 입니다."),


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
### 🔥 GroupTodoCategory API 구현
- `GroupTodoCategory` 의 CRUD 에 대한 `Controller` 와 `Service` 기능을 구현하였습니다.
- `GroupTodoCategory` 에 대한 모든 기능은 해당 그룹에 대해 투두 권한(`boolean todoAuthority`)이 없으면(`false`) `DO_NOT_HAVE_TODO_AUTHORITY` 예외를 발생 시켰습니다.

### 🔥 MemberTodoCategory API 에 상속 리펙토링 적용
- 기존의 `TodoCategory` 에 대한 `Controller` 와 `Service` 명을 `MemberTodoCategory` 로 변경하였습니다.

### :: 특이사항
- `GroupTodoCategory` 와 `MemberTodoCategory` 가 공통으로 사용하는 `Dto` 와 `Repository` 명은 `TodoCategory`로 통합하였습니다.
- `GroupTodoCategoryController` 의 각 API 에 Swagger `@Operation `적용하였습니다.
- 모든 `ResponseDto` 의 변환 메소드는 `GroupTodoCategory` 와 `MemberTodoCategory` 의 부모인 `TodoCategory` 를 파라미터로 받도록 하여, 두 엔티티가 하나의 `Dto` 를 사용할 수 있도록 구현하였습니다.
- `Enum Color` 에 대한 검증 및 변환 메소드(`translate()`)는 `Dto` 가 아닌 `Service` 단에서 이루어 질 수 있도록 하였습니다.
- 또한 이중 for문을 `Stream` 을 활용하여 가독성을 증가시켰습니다.
