### PR TITLE
[Feat] 내 그룹의 다른 회원의 전체 TodoCategory 조회 API 구현

### DIFF
--- a/src/main/java/scs/planus/domain/category/repository/TodoCategoryRepository.java
+++ b/src/main/java/scs/planus/domain/category/repository/TodoCategoryRepository.java
@@ -14,21 +14,28 @@ import java.util.Optional;
 
 public interface TodoCategoryRepository extends JpaRepository<TodoCategory, Long> {
 
+    /**
+     * Query For Member Todo Category
+     */
     @Query("select mc from MemberTodoCategory mc " +
             "where mc.id = :categoryId and mc.member= :member and mc.status = 'ACTIVE'")
-    Optional<MemberTodoCategory> findByIdAndMember(@Param("categoryId") Long categoryId,
-                                                   @Param("member") Member member);
+    Optional<MemberTodoCategory> findMemberTodoCategoryByIdAndMember(@Param("categoryId") Long categoryId,
+                                                                     @Param("member") Member member);
 
     @Query("select mc from MemberTodoCategory mc " +
             "where mc.member= :member")
-    List<MemberTodoCategory> findAllByMember(@Param("member") Member member);
+    List<MemberTodoCategory> findMemberTodoCategoryAllByMember(@Param("member") Member member);
 
+
+    /**
+     * Query For Group Todo Category
+     */
     @Query("select gc from GroupTodoCategory gc " +
             "where gc.group= :group")
-    List<GroupTodoCategory> findAllByGroup(@Param("group") Group group);
+    List<GroupTodoCategory> findGroupTodoCategoryAllByGroup(@Param("group") Group group);
 
     @Query("select gc from GroupTodoCategory gc " +
             "where gc.id= :categoryId " +
             "and gc.status= 'ACTIVE' ")
-    Optional<GroupTodoCategory> findByIdAndStatus(@Param("categoryId") Long categoryId);
+    Optional<GroupTodoCategory> findGroupTodoCategoryByIdAndStatus(@Param("categoryId") Long categoryId);
 }

--- a/src/main/java/scs/planus/domain/category/service/GroupTodoCategoryService.java
+++ b/src/main/java/scs/planus/domain/category/service/GroupTodoCategoryService.java
@@ -39,10 +39,10 @@ public class GroupTodoCategoryService {
         Group group = groupRepository.findByIdAndStatus( groupId )
                 .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
 
-        Boolean isTodoAuthority = groupMemberQueryRepository
+        Boolean hasTodoAuthority = groupMemberQueryRepository
                 .existByMemberIdAndGroupIdAndTodoAuthority( member.getId(), group.getId() );
 
-        if (!isTodoAuthority) {
+        if (!hasTodoAuthority) {
             throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
         }
 
@@ -61,10 +61,10 @@ public class GroupTodoCategoryService {
         Group group = groupRepository.findByIdAndStatus( groupId )
                 .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
 
-        Boolean isTodoAuthority = groupMemberQueryRepository
+        Boolean hasTodoAuthority = groupMemberQueryRepository
                 .existByMemberIdAndGroupIdAndTodoAuthority( member.getId(), group.getId() );
 
-        if (!isTodoAuthority) {
+        if (!hasTodoAuthority) {
             throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
         }
 
@@ -84,10 +84,10 @@ public class GroupTodoCategoryService {
         Group group = groupRepository.findByIdAndStatus( groupId )
                 .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
 
-        Boolean isTodoAuthority = groupMemberQueryRepository
+        Boolean hasTodoAuthority = groupMemberQueryRepository
                 .existByMemberIdAndGroupIdAndTodoAuthority( member.getId(), group.getId() );
 
-        if (!isTodoAuthority) {
+        if (!hasTodoAuthority) {
             throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
         }
 
@@ -108,10 +108,10 @@ public class GroupTodoCategoryService {
         Group group = groupRepository.findByIdAndStatus( groupId )
                 .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
 
-        Boolean isTodoAuthority = groupMemberQueryRepository
+        Boolean hasTodoAuthority = groupMemberQueryRepository
                 .existByMemberIdAndGroupIdAndTodoAuthority( member.getId(), group.getId() );
 
-        if (!isTodoAuthority) {
+        if (!hasTodoAuthority) {
             throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
         }
 

--- a/src/main/java/scs/planus/domain/category/service/GroupTodoCategoryService.java
+++ b/src/main/java/scs/planus/domain/category/service/GroupTodoCategoryService.java
@@ -46,7 +46,7 @@ public class GroupTodoCategoryService {
             throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
         }
 
-        List<GroupTodoCategory> groupTodoCategories = todoCategoryRepository.findAllByGroup( group );
+        List<GroupTodoCategory> groupTodoCategories = todoCategoryRepository.findGroupTodoCategoryAllByGroup( group );
 
         return groupTodoCategories.stream()
                 .map( TodoCategoryGetResponseDto::of )
@@ -91,7 +91,7 @@ public class GroupTodoCategoryService {
             throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
         }
 
-        GroupTodoCategory groupTodoCategory = todoCategoryRepository.findByIdAndStatus( categoryId )
+        GroupTodoCategory groupTodoCategory = todoCategoryRepository.findGroupTodoCategoryByIdAndStatus( categoryId )
                 .orElseThrow(() -> new PlanusException( NOT_EXIST_CATEGORY ));
 
         Color color = Color.of( requestDto.getColor() );
@@ -115,7 +115,7 @@ public class GroupTodoCategoryService {
             throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
         }
 
-        GroupTodoCategory groupTodoCategory = todoCategoryRepository.findByIdAndStatus( categoryId )
+        GroupTodoCategory groupTodoCategory = todoCategoryRepository.findGroupTodoCategoryByIdAndStatus( categoryId )
                 .orElseThrow(() -> new PlanusException( NOT_EXIST_CATEGORY ));
 
         groupTodoCategory.changeStatusToInactive();

--- a/src/main/java/scs/planus/domain/category/service/MemberTodoCategoryService.java
+++ b/src/main/java/scs/planus/domain/category/service/MemberTodoCategoryService.java
@@ -36,7 +36,7 @@ public class MemberTodoCategoryService {
                     throw new PlanusException(CustomExceptionStatus.NONE_USER);
                 });
 
-        List<MemberTodoCategory> memberTodoCategories = todoCategoryRepository.findAllByMember(member);
+        List<MemberTodoCategory> memberTodoCategories = todoCategoryRepository.findMemberTodoCategoryAllByMember(member);
 
         return memberTodoCategories.stream()
                 .map(TodoCategoryGetResponseDto::of)

--- a/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
@@ -6,12 +6,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import scs.planus.domain.category.dto.TodoCategoryGetResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupDetailResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupGetMemberResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
@@ -91,4 +87,17 @@ public class MyGroupController {
         MyGroupOnlineStatusResponseDto responseDto = myGroupService.changeOnlineStatus(memberId, groupId);
         return new BaseResponse<>(responseDto);
     }
+
+    @GetMapping("/my-groups/{groupId}/members/{memberId}/categories")
+    @Operation(summary = "Group의 대상 회원의 전체 Member Todo Category 조회 API")
+    public BaseResponse<List<TodoCategoryGetResponseDto>> getAllTargetMemberTodoCategories(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                                           @PathVariable("groupId") Long groupId,
+                                                                                           @PathVariable("memberId") Long memberId) {
+
+        Long loginMemberId = principalDetails.getId();
+        List<TodoCategoryGetResponseDto> responseDto = myGroupService.findAllTargetMemberTodoCategories( loginMemberId, groupId, memberId );
+
+        return new BaseResponse<>(responseDto);
+    }
+
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberQueryRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberQueryRepository.java
@@ -33,7 +33,7 @@ public class GroupMemberQueryRepository {
                 .from(groupMember)
                 .join(groupMember.member, member)
                 .join(groupMember.group, group)
-                .where(isActiveGroup(), memberIdEq(memberId), groupIdEq(groupId), isTodoAuthority())
+                .where(isActiveGroup(), memberIdEq(memberId), groupIdEq(groupId), hasTodoAuthority())
                 .fetchFirst();
         return fetchOne != null;
     }
@@ -49,7 +49,7 @@ public class GroupMemberQueryRepository {
     private BooleanExpression isActiveGroup() {
         return group.status.eq(Status.ACTIVE);
     }
-    private BooleanExpression isTodoAuthority() {
+    private BooleanExpression hasTodoAuthority() {
         return groupMember.todoAuthority.eq(true);
     }
 }

--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -249,7 +249,7 @@ public class MyGroupService {
             throw new PlanusException( NOT_JOINED_MEMBER_IN_GROUP );
         }
 
-        List<MemberTodoCategory> targetMemberTodoCategories = todoCategoryRepository.findAllByMember( targetMember );
+        List<MemberTodoCategory> targetMemberTodoCategories = todoCategoryRepository.findMemberTodoCategoryAllByMember( targetMember );
 
         // TODO : 그룹 개인 투두 용으로만 쓴 카테고리 뿐 만 아니라 모두 응답으로 주는 것에 대한 보안 문제
         return targetMemberTodoCategories.stream()

--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -4,12 +4,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import scs.planus.domain.category.dto.TodoCategoryGetResponseDto;
+import scs.planus.domain.category.entity.MemberTodoCategory;
+import scs.planus.domain.category.repository.TodoCategoryRepository;
 import scs.planus.domain.group.dto.GroupTagResponseDto;
-import scs.planus.domain.group.dto.mygroup.GroupBelongInResponseDto;
-import scs.planus.domain.group.dto.mygroup.MyGroupDetailResponseDto;
-import scs.planus.domain.group.dto.mygroup.MyGroupGetMemberResponseDto;
-import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
-import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
+import scs.planus.domain.group.dto.mygroup.*;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
 import scs.planus.domain.group.entity.GroupTag;
@@ -47,6 +46,7 @@ public class MyGroupService {
     private final GroupMemberQueryRepository groupMemberQueryRepository;
     private final GroupTagRepository groupTagRepository;
     private final TodoQueryRepository todoQueryRepository;
+    private final TodoCategoryRepository todoCategoryRepository;
 
     public List<GroupBelongInResponseDto> getMyGroupsInDropDown(Long memberId) {
         Member member = memberRepository.findById(memberId)
@@ -225,5 +225,35 @@ public class MyGroupService {
                 .filter(groupMember -> groupMember.getGroup().getId().equals(group.getId()))
                 .filter(GroupMember::isOnlineStatus)
                 .count();
+    }
+
+    public List<TodoCategoryGetResponseDto> findAllTargetMemberTodoCategories(Long loginMemberId, Long groupId, Long memberId ) {
+        Member loginMember = memberRepository.findById( loginMemberId )
+                .orElseThrow(() -> new PlanusException( NONE_USER ));
+
+        Group group = groupRepository.findByIdAndStatus( groupId )
+                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
+
+        Member targetMember = memberRepository.findById( memberId )
+                .orElseThrow(() -> new PlanusException( NONE_USER ));
+
+        // Member 가 그룹 회원인지 확인
+        Boolean isMemberJoined = groupMemberQueryRepository.existByMemberIdAndGroupId( loginMember.getId(), group.getId() );
+        if (!isMemberJoined) {
+            throw new PlanusException( NOT_JOINED_GROUP );
+        }
+
+        // TargetMember 가 그룹 회원인지 확인
+        Boolean isTargetMemberJoined = groupMemberQueryRepository.existByMemberIdAndGroupId( targetMember.getId(), group.getId() );
+        if (!isTargetMemberJoined) {
+            throw new PlanusException( NOT_JOINED_MEMBER_IN_GROUP );
+        }
+
+        List<MemberTodoCategory> targetMemberTodoCategories = todoCategoryRepository.findAllByMember( targetMember );
+
+        // TODO : 그룹 개인 투두 용으로만 쓴 카테고리 뿐 만 아니라 모두 응답으로 주는 것에 대한 보안 문제
+        return targetMemberTodoCategories.stream()
+                .map( TodoCategoryGetResponseDto::of )
+                .collect( Collectors.toList() );
     }
 }

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -39,7 +39,7 @@ public class TodoService {
         Member member = memberRepository.findById(memberId)
                         .orElseThrow(() -> new PlanusException(NONE_USER));
 
-        TodoCategory todoCategory = todoCategoryRepository.findByIdAndMember(requestDto.getCategoryId(), member)
+        TodoCategory todoCategory = todoCategoryRepository.findMemberTodoCategoryByIdAndMember(requestDto.getCategoryId(), member)
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
 
         Group group = getGroup(requestDto.getGroupId());

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -46,7 +46,7 @@ public enum CustomExceptionStatus implements ResponseStatus {
 
     // groupMember excepion
     NOT_JOINED_GROUP(BAD_REQUEST, 2700, "가입하지 않은 그룹 입니다."),
-    NOT_JOINED_MEMBER_IN_GROUP(BAD_REQUEST, 2700, "그룹에 가입되어 있지 않은 회원입니다."),
+    NOT_JOINED_MEMBER_IN_GROUP(BAD_REQUEST, 2701, "그룹에 가입되어 있지 않은 회원입니다."),
 
     // tag
     EXIST_DUPLICATE_TAGS(BAD_REQUEST, 2800, "중복된 태그들이 존재합니다."),

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -46,6 +46,7 @@ public enum CustomExceptionStatus implements ResponseStatus {
 
     // groupMember excepion
     NOT_JOINED_GROUP(BAD_REQUEST, 2700, "가입하지 않은 그룹 입니다."),
+    NOT_JOINED_MEMBER_IN_GROUP(BAD_REQUEST, 2700, "그룹에 가입되어 있지 않은 회원입니다."),
 
     // tag
     EXIST_DUPLICATE_TAGS(BAD_REQUEST, 2800, "중복된 태그들이 존재합니다."),

--- a/src/main/java/scs/planus/global/util/validator/Validator.java
+++ b/src/main/java/scs/planus/global/util/validator/Validator.java
@@ -4,7 +4,6 @@ import scs.planus.domain.tag.dto.TagCreateRequestDto;
 import scs.planus.global.exception.PlanusException;
 
 import java.time.LocalDate;
-import java.util.HashSet;
 import java.util.List;
 
 import static scs.planus.global.exception.CustomExceptionStatus.EXIST_DUPLICATE_TAGS;
@@ -22,13 +21,14 @@ public class Validator {
 
 
     public static void validateDuplicateTagName(List<TagCreateRequestDto> updateTags) {
-        // HashSet 의 add()를 통해 중복된 값이 있으면 false
-        boolean isDuplcate = !updateTags.stream()
-                .map( TagCreateRequestDto::getName )
-                .allMatch( new HashSet<>()::add );
+        long sizeAfterDistinct = updateTags.stream()
+                .map(TagCreateRequestDto::getName)
+                .distinct()
+                .count();
 
-        if (isDuplcate) {
+        if (sizeAfterDistinct != (long)updateTags.size()) {
             throw new PlanusException( EXIST_DUPLICATE_TAGS );
         }
+
     }
 }


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
### 🔥 내 그룹의 다른 회원의 전체 TodoCategory 조회 API 를 구현하였습니다.
- 내 그룹의 다른 회원의 정보 조회시, 같은 그룹이 아닐 경우 발생하는 예외(`NOT_JOINED_MEMBER_IN_GROUP`)를 추가하였습니다.
- `Member` 가 `Group` 의 회원인지 검증은 기존의 `existByMemberIdAndGroupId` 를 사용하여 구현하였습니다.

- `loginMember` : 로그인 하여 앱을 사용하는 당사자 입니다.
- `targetMember` : `loginMember` 가 조회하려고 하는, 같은 그룹의 대상 회원 입니다.

### :: 특이사항
### ⚠️ 이 API 는 카테고리를 `TodoResponseDto` 에 포함시키기 전까지 임시로 사용합니다.

