### PR TITLE
[Feat] GroupTodo CRUD 구현

### DIFF
--- a/src/main/java/scs/planus/domain/category/repository/TodoCategoryRepository.java
+++ b/src/main/java/scs/planus/domain/category/repository/TodoCategoryRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.repository.query.Param;
 import scs.planus.domain.category.entity.GroupTodoCategory;
 import scs.planus.domain.category.entity.MemberTodoCategory;
 import scs.planus.domain.category.entity.TodoCategory;
-import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.member.entity.Member;
 
 import java.util.List;
@@ -31,8 +30,8 @@ public interface TodoCategoryRepository extends JpaRepository<TodoCategory, Long
      * Query For Group Todo Category
      */
     @Query("select gc from GroupTodoCategory gc " +
-            "where gc.group= :group")
-    List<GroupTodoCategory> findGroupTodoCategoryAllByGroup(@Param("group") Group group);
+            "where gc.group.id= :groupId")
+    List<GroupTodoCategory> findGroupTodoCategoryAllByGroup(@Param("groupId") Long groupId);
 
     @Query("select gc from GroupTodoCategory gc " +
             "where gc.id= :categoryId " +

--- a/src/main/java/scs/planus/domain/category/service/GroupTodoCategoryService.java
+++ b/src/main/java/scs/planus/domain/category/service/GroupTodoCategoryService.java
@@ -11,10 +11,9 @@ import scs.planus.domain.category.entity.Color;
 import scs.planus.domain.category.entity.GroupTodoCategory;
 import scs.planus.domain.category.repository.TodoCategoryRepository;
 import scs.planus.domain.group.entity.Group;
-import scs.planus.domain.group.repository.GroupMemberQueryRepository;
+import scs.planus.domain.group.entity.GroupMember;
+import scs.planus.domain.group.repository.GroupMemberRepository;
 import scs.planus.domain.group.repository.GroupRepository;
-import scs.planus.domain.member.entity.Member;
-import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.global.exception.PlanusException;
 
 import java.util.List;
@@ -27,100 +26,100 @@ import static scs.planus.global.exception.CustomExceptionStatus.*;
 @RequiredArgsConstructor
 @Slf4j
 public class GroupTodoCategoryService {
+
     private final TodoCategoryRepository todoCategoryRepository;
-    private final MemberRepository memberRepository;
-    private final GroupMemberQueryRepository groupMemberQueryRepository;
     private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
 
-    public List<TodoCategoryGetResponseDto> findAll(Long memberId, Long groupId ) {
-        Member member = memberRepository.findById( memberId )
-                .orElseThrow(() -> new PlanusException( NONE_USER ));
+    public List<TodoCategoryGetResponseDto> findAll(Long memberId, Long groupId) {
+        GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId)
+                .orElseThrow(() -> {
+                    groupRepository.findById(groupId)
+                            .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
+                    return new PlanusException(NOT_JOINED_GROUP);
+                });
 
-        Group group = groupRepository.findByIdAndStatus( groupId )
-                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
-
-        Boolean hasTodoAuthority = groupMemberQueryRepository
-                .existByMemberIdAndGroupIdAndTodoAuthority( member.getId(), group.getId() );
+        boolean hasTodoAuthority = groupMember.isTodoAuthority();
 
         if (!hasTodoAuthority) {
-            throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
+            throw new PlanusException(DO_NOT_HAVE_TODO_AUTHORITY);
         }
 
-        List<GroupTodoCategory> groupTodoCategories = todoCategoryRepository.findGroupTodoCategoryAllByGroup( group );
+        List<GroupTodoCategory> groupTodoCategories = todoCategoryRepository.findGroupTodoCategoryAllByGroup(groupId);
 
         return groupTodoCategories.stream()
-                .map( TodoCategoryGetResponseDto::of )
-                .collect( Collectors.toList() );
+                .map(TodoCategoryGetResponseDto::of)
+                .collect(Collectors.toList());
     }
 
     @Transactional
-    public TodoCategoryResponseDto createCategory(Long memberId, Long groupId, TodoCategoryRequestDto requestDto ) {
-        Member member = memberRepository.findById( memberId )
-                .orElseThrow(() -> new PlanusException( NONE_USER ));
+    public TodoCategoryResponseDto createCategory(Long memberId, Long groupId, TodoCategoryRequestDto requestDto) {
+        GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId)
+                .orElseThrow(() -> {
+                    groupRepository.findById(groupId)
+                            .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
+                    return new PlanusException(NOT_JOINED_GROUP);
+                });
 
-        Group group = groupRepository.findByIdAndStatus( groupId )
-                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
-
-        Boolean hasTodoAuthority = groupMemberQueryRepository
-                .existByMemberIdAndGroupIdAndTodoAuthority( member.getId(), group.getId() );
+        Group group = groupMember.getGroup();
+        boolean hasTodoAuthority = groupMember.isTodoAuthority();
 
         if (!hasTodoAuthority) {
-            throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
+            throw new PlanusException(DO_NOT_HAVE_TODO_AUTHORITY);
         }
 
         Color color = Color.of(requestDto.getColor());
 
-        GroupTodoCategory groupTodoCategory = requestDto.toGroupTodoCategoryEntity( group, color );
-        GroupTodoCategory saveGroupTodoCategory = todoCategoryRepository.save( groupTodoCategory );
+        GroupTodoCategory groupTodoCategory = requestDto.toGroupTodoCategoryEntity(group, color);
+        GroupTodoCategory saveGroupTodoCategory = todoCategoryRepository.save(groupTodoCategory);
 
-        return TodoCategoryResponseDto.of( saveGroupTodoCategory );
+        return TodoCategoryResponseDto.of(saveGroupTodoCategory);
     }
 
     @Transactional
-    public TodoCategoryResponseDto changeCategory(Long memberId, Long groupId, Long categoryId, TodoCategoryRequestDto requestDto ) {
-        Member member = memberRepository.findById( memberId )
-                .orElseThrow(() -> new PlanusException( NONE_USER ));
+    public TodoCategoryResponseDto changeCategory(Long memberId, Long groupId, Long categoryId, TodoCategoryRequestDto requestDto) {
+        GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId)
+                .orElseThrow(() -> {
+                    groupRepository.findById(groupId)
+                            .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
+                    return new PlanusException(NOT_JOINED_GROUP);
+                });
 
-        Group group = groupRepository.findByIdAndStatus( groupId )
-                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
-
-        Boolean hasTodoAuthority = groupMemberQueryRepository
-                .existByMemberIdAndGroupIdAndTodoAuthority( member.getId(), group.getId() );
+        boolean hasTodoAuthority = groupMember.isTodoAuthority();
 
         if (!hasTodoAuthority) {
-            throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
+            throw new PlanusException(DO_NOT_HAVE_TODO_AUTHORITY);
         }
 
-        GroupTodoCategory groupTodoCategory = todoCategoryRepository.findGroupTodoCategoryByIdAndStatus( categoryId )
-                .orElseThrow(() -> new PlanusException( NOT_EXIST_CATEGORY ));
+        GroupTodoCategory groupTodoCategory = todoCategoryRepository.findGroupTodoCategoryByIdAndStatus(categoryId)
+                .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
 
-        Color color = Color.of( requestDto.getColor() );
-        groupTodoCategory.change( requestDto.getName(), color );
+        Color color = Color.of(requestDto.getColor());
+        groupTodoCategory.change(requestDto.getName(), color);
 
-        return TodoCategoryResponseDto.of( groupTodoCategory );
+        return TodoCategoryResponseDto.of(groupTodoCategory);
     }
 
     @Transactional
-    public TodoCategoryResponseDto deleteCategory(Long memberId, Long groupId, Long categoryId ) {
-        Member member = memberRepository.findById( memberId )
-                .orElseThrow(() -> new PlanusException( NONE_USER ));
+    public TodoCategoryResponseDto deleteCategory(Long memberId, Long groupId, Long categoryId) {
+        GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId)
+                .orElseThrow(() -> {
+                    groupRepository.findById(groupId)
+                            .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
+                    return new PlanusException(NOT_JOINED_GROUP);
+                });
 
-        Group group = groupRepository.findByIdAndStatus( groupId )
-                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
-
-        Boolean hasTodoAuthority = groupMemberQueryRepository
-                .existByMemberIdAndGroupIdAndTodoAuthority( member.getId(), group.getId() );
+        boolean hasTodoAuthority = groupMember.isTodoAuthority();
 
         if (!hasTodoAuthority) {
-            throw new PlanusException( DO_NOT_HAVE_TODO_AUTHORITY );
+            throw new PlanusException(DO_NOT_HAVE_TODO_AUTHORITY);
         }
 
-        GroupTodoCategory groupTodoCategory = todoCategoryRepository.findGroupTodoCategoryByIdAndStatus( categoryId )
-                .orElseThrow(() -> new PlanusException( NOT_EXIST_CATEGORY ));
+        GroupTodoCategory groupTodoCategory = todoCategoryRepository.findGroupTodoCategoryByIdAndStatus(categoryId)
+                .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
 
         groupTodoCategory.changeStatusToInactive();
 
-        return TodoCategoryResponseDto.of( groupTodoCategory );
+        return TodoCategoryResponseDto.of(groupTodoCategory);
     }
-
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -22,7 +22,7 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     @Query("select gm from GroupMember gm " +
             "join fetch gm.group g " +
             "join fetch gm.member m " +
-            "where m.id = :memberId and g.id = :groupId")
+            "where m.id = :memberId and g.id = :groupId and gm.status = 'ACTIVE'")
     Optional<GroupMember> findByMemberIdAndGroupId(@Param("memberId") Long memberId,
                                                    @Param("groupId") Long groupId);
 

--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -170,7 +170,7 @@ public class MyGroupService {
             throw new PlanusException(NOT_JOINED_GROUP);
         }
 
-        List<MemberTodo> todos = todoQueryRepository.findDailyTodosByDate(memberId, groupId, date);
+        List<MemberTodo> todos = todoQueryRepository.findMemberDailyTodosByDate(memberId, groupId, date);
 
         // TODO -> 리팩토링 필요. TodoCalendarService에서 구현된 메서드
         List<TodoDailyScheduleDto> dailySchedules = todos.stream()

--- a/src/main/java/scs/planus/domain/todo/controller/GroupTodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/GroupTodoController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -48,4 +49,26 @@ public class GroupTodoController {
         TodoDetailsResponseDto responseDto = groupTodoService.getOneTodo(memberId, groupId, todoId);
         return new BaseResponse<>(responseDto);
     }
+
+
+    @PatchMapping("/my-groups/{groupId}/todos/{todoId}")
+    @Operation(summary = "Group Todo 변경 API")
+    public BaseResponse<TodoDetailsResponseDto> updateTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                 @PathVariable Long groupId,
+                                                                 @PathVariable Long todoId,
+                                                                 @Valid @RequestBody TodoRequestDto todoRequestDto) {
+        Long memberId = principalDetails.getId();
+        TodoDetailsResponseDto responseDto = groupTodoService.updateTodo(memberId, groupId, todoId, todoRequestDto);
+        return new BaseResponse<>(responseDto);
+    }
+
+//
+//    @DeleteMapping("/my-groups/{groupId}/todos/{todoId}")
+//    @Operation(summary = "Group Todo 삭제 API")
+//    public BaseResponse<TodoResponseDto> deleteTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
+//                                                    @PathVariable Long todoId) {
+//        Long memberId = principalDetails.getId();
+//        TodoResponseDto responseDto = groupTodoService.deleteTodo(memberId, todoId);
+//        return new BaseResponse<>(responseDto);
+//    }
 }

--- a/src/main/java/scs/planus/domain/todo/controller/GroupTodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/GroupTodoController.java
@@ -5,11 +5,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
 import scs.planus.domain.todo.dto.TodoRequestDto;
 import scs.planus.domain.todo.dto.TodoResponseDto;
 import scs.planus.domain.todo.service.GroupTodoService;
@@ -34,6 +36,16 @@ public class GroupTodoController {
                                                     @Valid @RequestBody TodoRequestDto todoRequestDto) {
         Long memberId = principalDetails.getId();
         TodoResponseDto responseDto = groupTodoService.createGroupTodo(memberId, groupId, todoRequestDto);
+        return new BaseResponse<>(responseDto);
+    }
+
+    @GetMapping("/my-groups/{groupId}/todos/{todoId}")
+    @Operation(summary = "Group Todo 조회 API")
+    public BaseResponse<TodoDetailsResponseDto>  getTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                               @PathVariable Long groupId,
+                                                               @PathVariable Long todoId) {
+        Long memberId = principalDetails.getId();
+        TodoDetailsResponseDto responseDto = groupTodoService.getOneTodo(memberId, groupId, todoId);
         return new BaseResponse<>(responseDto);
     }
 }

--- a/src/main/java/scs/planus/domain/todo/controller/GroupTodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/GroupTodoController.java
@@ -1,0 +1,39 @@
+package scs.planus.domain.todo.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import scs.planus.domain.todo.dto.TodoRequestDto;
+import scs.planus.domain.todo.dto.TodoResponseDto;
+import scs.planus.domain.todo.service.GroupTodoService;
+import scs.planus.global.auth.entity.PrincipalDetails;
+import scs.planus.global.common.response.BaseResponse;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/app")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "GroupTodo", description = "GroupTodo API Document")
+public class GroupTodoController {
+
+    private final GroupTodoService groupTodoService;
+
+    @PostMapping("/my-groups/{groupId}/todos")
+    @Operation(summary = "Group Todo 생성 API")
+    public BaseResponse<TodoResponseDto> createTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                    @PathVariable Long groupId,
+                                                    @Valid @RequestBody TodoRequestDto todoRequestDto) {
+        Long memberId = principalDetails.getId();
+        TodoResponseDto responseDto = groupTodoService.createGroupTodo(memberId, groupId, todoRequestDto);
+        return new BaseResponse<>(responseDto);
+    }
+}

--- a/src/main/java/scs/planus/domain/todo/controller/GroupTodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/GroupTodoController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -50,7 +51,6 @@ public class GroupTodoController {
         return new BaseResponse<>(responseDto);
     }
 
-
     @PatchMapping("/my-groups/{groupId}/todos/{todoId}")
     @Operation(summary = "Group Todo 변경 API")
     public BaseResponse<TodoDetailsResponseDto> updateTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
@@ -62,13 +62,13 @@ public class GroupTodoController {
         return new BaseResponse<>(responseDto);
     }
 
-//
-//    @DeleteMapping("/my-groups/{groupId}/todos/{todoId}")
-//    @Operation(summary = "Group Todo 삭제 API")
-//    public BaseResponse<TodoResponseDto> deleteTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
-//                                                    @PathVariable Long todoId) {
-//        Long memberId = principalDetails.getId();
-//        TodoResponseDto responseDto = groupTodoService.deleteTodo(memberId, todoId);
-//        return new BaseResponse<>(responseDto);
-//    }
+    @DeleteMapping("/my-groups/{groupId}/todos/{todoId}")
+    @Operation(summary = "Group Todo 삭제 API")
+    public BaseResponse<TodoResponseDto> deleteTodo(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                    @PathVariable Long groupId,
+                                                    @PathVariable Long todoId) {
+        Long memberId = principalDetails.getId();
+        TodoResponseDto responseDto = groupTodoService.deleteTodo(memberId, groupId, todoId);
+        return new BaseResponse<>(responseDto);
+    }
 }

--- a/src/main/java/scs/planus/domain/todo/dto/TodoRequestDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoRequestDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import scs.planus.domain.category.entity.TodoCategory;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.member.entity.Member;
+import scs.planus.domain.todo.entity.GroupTodo;
 import scs.planus.domain.todo.entity.MemberTodo;
 
 import javax.validation.constraints.NotBlank;
@@ -46,6 +47,18 @@ public class TodoRequestDto {
                 .startTime(startTime)
                 .description(description)
                 .member(member)
+                .group(group)
+                .build();
+    }
+
+    public GroupTodo toGroupTodoEntity(Group group, TodoCategory todoCategory) {
+        return GroupTodo.builder()
+                .title(title)
+                .todoCategory(todoCategory)
+                .startDate(startDate)
+                .endDate(endDate)
+                .startTime(startTime)
+                .description(description)
                 .group(group)
                 .build();
     }

--- a/src/main/java/scs/planus/domain/todo/entity/GroupTodo.java
+++ b/src/main/java/scs/planus/domain/todo/entity/GroupTodo.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import scs.planus.domain.category.entity.TodoCategory;
 import scs.planus.domain.group.entity.Group;
 
+import javax.persistence.CascadeType;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
@@ -21,13 +22,12 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GroupTodo extends Todo {
 
-    @OneToMany(mappedBy = "groupTodo")
+    @OneToMany(mappedBy = "groupTodo", cascade = CascadeType.ALL, orphanRemoval = true)
     List<GroupTodoCompletion> groupTodoCompletions = new ArrayList<>();
 
     @Builder
     public GroupTodo(String title, String description, LocalTime startTime, LocalDate startDate, LocalDate endDate, boolean showDDay, boolean completion,
-                     TodoCategory todoCategory, Group group, List<GroupTodoCompletion> groupTodoCompletions) {
+                     TodoCategory todoCategory, Group group) {
         super(title, description, startTime, startDate, endDate, showDDay, completion, todoCategory, group);
-        this.groupTodoCompletions = groupTodoCompletions;
     }
 }

--- a/src/main/java/scs/planus/domain/todo/entity/GroupTodoCompletion.java
+++ b/src/main/java/scs/planus/domain/todo/entity/GroupTodoCompletion.java
@@ -21,7 +21,7 @@ public class GroupTodoCompletion {
 
     private boolean completion;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 

--- a/src/main/java/scs/planus/domain/todo/entity/GroupTodoCompletion.java
+++ b/src/main/java/scs/planus/domain/todo/entity/GroupTodoCompletion.java
@@ -38,4 +38,11 @@ public class GroupTodoCompletion {
         }
         this.groupTodo = groupTodo;
     }
+
+    public static GroupTodoCompletion createGroupTodoCompletion(Member member, GroupTodo groupTodo) {
+        return GroupTodoCompletion.builder()
+                .member(member)
+                .groupTodo(groupTodo)
+                .build();
+    }
 }

--- a/src/main/java/scs/planus/domain/todo/repository/GroupTodoCompletionRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/GroupTodoCompletionRepository.java
@@ -1,0 +1,7 @@
+package scs.planus.domain.todo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import scs.planus.domain.todo.entity.GroupTodoCompletion;
+
+public interface GroupTodoCompletionRepository extends JpaRepository<GroupTodoCompletion, Long> {
+}

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -90,6 +90,9 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
+    /**
+     * Query For GroupTodo
+     */
     public Optional<GroupTodo> findOneGroupTodoById(Long groupId, Long todoId) {
         return Optional.ofNullable(queryFactory
                 .selectFrom(groupTodo)

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -23,7 +23,7 @@ public class TodoQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public Optional<MemberTodo> findOneTodoById(Long todoId, Long memberId) {
+    public Optional<MemberTodo> findOneMemberTodoById(Long todoId, Long memberId) {
         return Optional.ofNullable(queryFactory
                 .selectFrom(memberTodo)
                 .join(memberTodo.member, member)
@@ -33,7 +33,7 @@ public class TodoQueryRepository {
                 .fetchOne());
     }
 
-    public List<MemberTodo> findPeriodTodosByDate(Long memberId, LocalDate from, LocalDate to) {
+    public List<MemberTodo> findMemberPeriodTodosByDate(Long memberId, LocalDate from, LocalDate to) {
         return queryFactory
                 .selectFrom(memberTodo)
                 .join(memberTodo.member, member).fetchJoin()
@@ -43,7 +43,7 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
-    public List<MemberTodo> findDailyTodosByDate(Long memberId, LocalDate date) {
+    public List<MemberTodo> findMemberDailyTodosByDate(Long memberId, LocalDate date) {
         return queryFactory
                 .selectFrom(memberTodo)
                 .join(memberTodo.member, member)
@@ -54,7 +54,7 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
-    public List<MemberTodo> findDailyTodosByDate(Long memberId, Long groupId, LocalDate date) {
+    public List<MemberTodo> findMemberDailyTodosByDate(Long memberId, Long groupId, LocalDate date) {
         return queryFactory
                 .selectFrom(memberTodo)
                 .join(memberTodo.member, member)

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -5,6 +5,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
+import scs.planus.domain.Status;
+import scs.planus.domain.todo.entity.GroupTodo;
 import scs.planus.domain.todo.entity.MemberTodo;
 
 import java.time.LocalDate;
@@ -14,6 +16,7 @@ import java.util.Optional;
 import static scs.planus.domain.category.entity.QTodoCategory.todoCategory;
 import static scs.planus.domain.group.entity.QGroup.group;
 import static scs.planus.domain.member.entity.QMember.member;
+import static scs.planus.domain.todo.entity.QGroupTodo.groupTodo;
 import static scs.planus.domain.todo.entity.QMemberTodo.memberTodo;
 
 @Repository
@@ -87,12 +90,25 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
+    public Optional<GroupTodo> findOneGroupTodoById(Long groupId, Long todoId) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(groupTodo)
+                .join(groupTodo.group, group).fetchJoin()
+                .join(groupTodo.todoCategory, todoCategory).fetchJoin()
+                .where(isActiveGroup(), groupTodo.id.eq(todoId), groupIdEq(groupId))
+                .fetchOne());
+    }
+
     private BooleanExpression memberIdEq(Long memberId) {
         return member.id.eq(memberId);
     }
 
     private BooleanExpression groupIdEq(Long groupId) {
         return group.id.eq(groupId);
+    }
+
+    private BooleanExpression isActiveGroup() {
+        return group.status.eq(Status.ACTIVE);
     }
 
     private BooleanExpression dateBetween(LocalDate date) {

--- a/src/main/java/scs/planus/domain/todo/service/GroupTodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/GroupTodoService.java
@@ -11,6 +11,7 @@ import scs.planus.domain.group.entity.GroupMember;
 import scs.planus.domain.group.repository.GroupMemberQueryRepository;
 import scs.planus.domain.group.repository.GroupMemberRepository;
 import scs.planus.domain.group.repository.GroupRepository;
+import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
 import scs.planus.domain.todo.dto.TodoRequestDto;
 import scs.planus.domain.todo.dto.TodoResponseDto;
 import scs.planus.domain.todo.entity.GroupTodo;
@@ -57,6 +58,7 @@ public class GroupTodoService {
 
         GroupTodo groupTodo = requestDto.toGroupTodoEntity(group, groupTodoCategory);
 
+        // TODO 연관된 다른 메서드들이 많아 @Param을 group으로 진행 -> 이후 일관성있도록 리펙토링 필요
         List<GroupMember> groupMembers = groupMemberRepository.findAllWithMemberByGroupAndStatus(group);
         groupMembers.stream()
                 .map(GroupMember::getMember)
@@ -66,5 +68,18 @@ public class GroupTodoService {
 
         todoRepository.save(groupTodo);
         return TodoResponseDto.of(groupTodo);
+    }
+
+    public TodoDetailsResponseDto getOneTodo(Long memberId, Long groupId, Long todoId) {
+        GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId)
+                .orElseThrow(() -> {
+                    groupRepository.findById(groupId)
+                            .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
+                    return new PlanusException(NOT_JOINED_GROUP);
+                });
+
+        GroupTodo groupTodo = todoQueryRepository.findOneGroupTodoById(groupId, todoId)
+                .orElseThrow(() -> new PlanusException(NONE_TODO));
+        return TodoDetailsResponseDto.of(groupTodo);
     }
 }

--- a/src/main/java/scs/planus/domain/todo/service/GroupTodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/GroupTodoService.java
@@ -1,0 +1,65 @@
+package scs.planus.domain.todo.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import scs.planus.domain.category.entity.GroupTodoCategory;
+import scs.planus.domain.category.repository.TodoCategoryRepository;
+import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.group.entity.GroupMember;
+import scs.planus.domain.group.repository.GroupMemberQueryRepository;
+import scs.planus.domain.group.repository.GroupMemberRepository;
+import scs.planus.domain.group.repository.GroupRepository;
+import scs.planus.domain.todo.dto.TodoRequestDto;
+import scs.planus.domain.todo.dto.TodoResponseDto;
+import scs.planus.domain.todo.entity.GroupTodo;
+import scs.planus.domain.todo.entity.GroupTodoCompletion;
+import scs.planus.domain.todo.repository.GroupTodoCompletionRepository;
+import scs.planus.domain.todo.repository.TodoRepository;
+import scs.planus.global.exception.PlanusException;
+
+import java.util.List;
+
+import static scs.planus.global.exception.CustomExceptionStatus.*;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class GroupTodoService {
+
+    private final GroupRepository groupRepository;
+    private final GroupMemberQueryRepository groupMemberQueryRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final TodoCategoryRepository todoCategoryRepository;
+    private final TodoRepository todoRepository;
+    private final GroupTodoCompletionRepository groupTodoCompletionRepository;
+
+    @Transactional
+    public TodoResponseDto createGroupTodo(Long memberId, Long groupId, TodoRequestDto requestDto) {
+        Group group = groupRepository.findByIdAndStatus(groupId)
+                .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
+
+        Boolean hasTodoAuthority = groupMemberQueryRepository.existByMemberIdAndGroupIdAndTodoAuthority(memberId, group.getId());
+
+        if (!hasTodoAuthority) {
+            throw new PlanusException(DO_NOT_HAVE_TODO_AUTHORITY);
+        }
+
+        GroupTodoCategory groupTodoCategory = todoCategoryRepository.findGroupTodoCategoryByIdAndStatus(requestDto.getCategoryId())
+                .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
+
+        GroupTodo groupTodo = requestDto.toGroupTodoEntity(group, groupTodoCategory);
+
+        List<GroupMember> groupMembers = groupMemberRepository.findAllWithMemberByGroupAndStatus(group);
+        groupMembers.stream()
+                .map(GroupMember::getMember)
+                .forEach(member -> {
+                    GroupTodoCompletion.createGroupTodoCompletion(member, groupTodo);
+                });
+
+        todoRepository.save(groupTodo);
+        return TodoResponseDto.of(groupTodo);
+    }
+}

--- a/src/main/java/scs/planus/domain/todo/service/GroupTodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/GroupTodoService.java
@@ -112,4 +112,26 @@ public class GroupTodoService {
 
         return TodoDetailsResponseDto.of(groupTodo);
     }
+
+    @Transactional
+    public TodoResponseDto deleteTodo(Long memberId, Long groupId, Long todoId) {
+        GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId)
+                .orElseThrow(() -> {
+                    groupRepository.findById(groupId)
+                            .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
+                    return new PlanusException(NOT_JOINED_GROUP);
+                });
+
+        boolean hasTodoAuthority = groupMember.isTodoAuthority();
+
+        if (!hasTodoAuthority) {
+            throw new PlanusException(DO_NOT_HAVE_TODO_AUTHORITY);
+        }
+
+        GroupTodo groupTodo = todoQueryRepository.findOneGroupTodoById(groupId, todoId)
+                .orElseThrow(() -> new PlanusException(NONE_TODO));
+
+        todoRepository.delete(groupTodo);
+        return TodoResponseDto.of(groupTodo);
+    }
 }

--- a/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoCalendarService.java
@@ -42,7 +42,7 @@ public class TodoCalendarService {
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
         Validator.validateStartDateBeforeEndDate(from, to);
-        List<MemberTodo> todos = todoQueryRepository.findPeriodTodosByDate(member.getId(), from, to);
+        List<MemberTodo> todos = todoQueryRepository.findMemberPeriodTodosByDate(member.getId(), from, to);
         List<TodoDetailsResponseDto> responseDtos = todos.stream()
                 .map(TodoDetailsResponseDto::of)
                 .collect(Collectors.toList());
@@ -55,7 +55,7 @@ public class TodoCalendarService {
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
         Validator.validateStartDateBeforeEndDate(from, to);
-        List<MemberTodo> todos = todoQueryRepository.findPeriodTodosByDate(member.getId(), from, to);
+        List<MemberTodo> todos = todoQueryRepository.findMemberPeriodTodosByDate(member.getId(), from, to);
         List<TodoPeriodResponseDto> responseDtos = todos.stream()
                 .map(TodoPeriodResponseDto::of)
                 .collect(Collectors.toList());
@@ -66,7 +66,7 @@ public class TodoCalendarService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
-        List<MemberTodo> todos = todoQueryRepository.findDailyTodosByDate(member.getId(), date);
+        List<MemberTodo> todos = todoQueryRepository.findMemberDailyTodosByDate(member.getId(), date);
         List<TodoDailyScheduleDto> todoDailyScheduleDtos = getDailySchedules(todos);
         List<TodoDailyDto> todoDailyDtos = getDailyTodos(todos);
 

--- a/src/main/java/scs/planus/domain/todo/service/TodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/TodoService.java
@@ -53,7 +53,7 @@ public class TodoService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
-        Todo todo = todoQueryRepository.findOneTodoById(todoId, member.getId())
+        Todo todo = todoQueryRepository.findOneMemberTodoById(todoId, member.getId())
                 .orElseThrow(() -> new PlanusException(NONE_TODO));
 
         return TodoDetailsResponseDto.of(todo);
@@ -64,7 +64,7 @@ public class TodoService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
-        Todo todo = todoQueryRepository.findOneTodoById(todoId, member.getId())
+        Todo todo = todoQueryRepository.findOneMemberTodoById(todoId, member.getId())
                 .orElseThrow(() -> new PlanusException(NONE_TODO));
 
         TodoCategory todoCategory = todoCategoryRepository.findById(requestDto.getCategoryId())
@@ -84,7 +84,7 @@ public class TodoService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
-        Todo todo = todoQueryRepository.findOneTodoById(todoId, member.getId())
+        Todo todo = todoQueryRepository.findOneMemberTodoById(todoId, member.getId())
                 .orElseThrow(() -> new PlanusException(NONE_TODO));
 
         todo.changeCompletion();
@@ -96,7 +96,7 @@ public class TodoService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new PlanusException(NONE_USER));
 
-        Todo todo = todoQueryRepository.findOneTodoById(todoId, member.getId())
+        Todo todo = todoQueryRepository.findOneMemberTodoById(todoId, member.getId())
                 .orElseThrow(() -> new PlanusException(NONE_TODO));
 
         todoRepository.delete(todo);


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- GroupTodo CRUD 구현

### :: 특이사항
- GroupTodoCategory / GroupTodo에서, GroupMember를 통해 아래와 같이 예외처리를 진행하였습니다.
``` java
        GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId)
                .orElseThrow(() -> {
                   // Group이 존재하지 않는다면, NOT_EXIST_GROUP
                    groupRepository.findById(groupId)
                            .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));

                   // Group이 존재한다면 NOT_JOINED_GROUP
                    return new PlanusException(NOT_JOINED_GROUP);
                });

        // GroupTodoCategory / GroupTodo는 Todo 권한을 갖는 사람들만 접근 가능
        boolean hasTodoAuthority = groupMember.isTodoAuthority();

        if (!hasTodoAuthority) {
            throw new PlanusException(DO_NOT_HAVE_TODO_AUTHORITY);
        }
```
- GroupTodo를 조회하는 API의 경우, 권한이 없더라도 볼 수 있어야하므로 `!hasTodoAuthority` 조건을 넣지 않았습니다.
- `CascadeType.ALL, orphanRemoval = true` 조건을 통해, GroupTodo가 생성되거나 제거될 때 이에 맞춰 GroupTodoCompletion이 생성 / 삭제 되도록 구현하였습니다.