### PR TITLE
[Fix] 그룹 가입 신청 여러번 되던 오류 수정

### DIFF
--- a/src/main/java/scs/planus/domain/group/repository/GroupJoinRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupJoinRepository.java
@@ -24,4 +24,9 @@ public interface GroupJoinRepository extends JpaRepository<GroupJoin, Long> {
             "where gj.id= :groupJoinId " +
             "and gj.status = 'INACTIVE'")
     Optional<GroupJoin> findWithGroupById(@Param("groupJoinId") Long groupJoinId );
+
+    @Query("select gj from GroupJoin gj " +
+            "where gj.member.id = :memberId and gj.group.id = :groupId")
+    Optional<GroupJoin> findByMemberIdAndGroupId(@Param("memberId") Long memberId,
+                                                 @Param("groupId") Long groupId);
 }

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -5,12 +5,25 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import scs.planus.domain.group.dto.*;
+import scs.planus.domain.group.dto.GroupCreateRequestDto;
+import scs.planus.domain.group.dto.GroupDetailUpdateRequestDto;
+import scs.planus.domain.group.dto.GroupGetMemberResponseDto;
+import scs.planus.domain.group.dto.GroupGetResponseDto;
+import scs.planus.domain.group.dto.GroupJoinGetResponseDto;
+import scs.planus.domain.group.dto.GroupJoinResponseDto;
+import scs.planus.domain.group.dto.GroupMemberResponseDto;
+import scs.planus.domain.group.dto.GroupNoticeUpdateRequestDto;
+import scs.planus.domain.group.dto.GroupResponseDto;
+import scs.planus.domain.group.dto.GroupTagResponseDto;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupJoin;
 import scs.planus.domain.group.entity.GroupMember;
 import scs.planus.domain.group.entity.GroupTag;
-import scs.planus.domain.group.repository.*;
+import scs.planus.domain.group.repository.GroupJoinRepository;
+import scs.planus.domain.group.repository.GroupMemberQueryRepository;
+import scs.planus.domain.group.repository.GroupMemberRepository;
+import scs.planus.domain.group.repository.GroupRepository;
+import scs.planus.domain.group.repository.GroupTagRepository;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.domain.tag.dto.TagCreateRequestDto;
@@ -158,6 +171,10 @@ public class GroupService {
 
         Member member = memberRepository.findById( memberId )
                 .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+
+        groupJoinRepository.findByMemberIdAndGroupId(memberId, groupId)
+                .ifPresent(groupJoin -> {
+                    throw new PlanusException(ALREADY_APPLY_JOINED_GROUP);});
 
         List<GroupMember> allGroupMembers = groupMemberRepository.findAllWithMemberByGroupAndStatus( group );
 

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -43,6 +43,7 @@ public enum CustomExceptionStatus implements ResponseStatus {
     ALREADY_JOINED_GROUP(BAD_REQUEST, 2604, "이미 가입된 그룹입니다."),
     NOT_EXIST_GROUP_JOIN(BAD_REQUEST, 2605, "존재 하지 않는 그룹 가입 신청서 입니다."),
     DO_NOT_HAVE_TODO_AUTHORITY(BAD_REQUEST, 2606, "그룹 투두 권한이 없습니다."),
+    ALREADY_APPLY_JOINED_GROUP(BAD_REQUEST, 2607, "이미 가입 신청한 그룹입니다."),
 
     // groupMember excepion
     NOT_JOINED_GROUP(BAD_REQUEST, 2700, "가입하지 않은 그룹 입니다."),


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [X]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 그룹 가입 신청 여러번 되던 오류 수정

### :: 특이사항
- `GroupJoinService`의 `joinGroup()`내에 아래와 같은 예외처리를 하여 중복 신청을 해결하였습니다.
``` java
        groupJoinRepository.findByMemberIdAndGroupId(memberId, groupId)
                .ifPresent(groupJoin -> {
                    throw new PlanusException(ALREADY_APPLY_JOINED_GROUP);});
```
