### PR TITLE
[Feat] 홈 캘린더 화면에서 그룹 투두 조회 기능 구현 및 그룹 지정 버그 수정

### DIFF
--- a/src/main/java/scs/planus/domain/todo/controller/calendar/MemberTodoCalendarController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/calendar/MemberTodoCalendarController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import scs.planus.domain.group.dto.mygroup.GroupBelongInResponseDto;
-import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
+import scs.planus.domain.todo.dto.calendar.AllTodoResponseDto;
 import scs.planus.domain.todo.service.calendar.TodoCalendarService;
 import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.common.response.BaseResponse;
@@ -29,12 +29,12 @@ public class MemberTodoCalendarController {
     private final TodoCalendarService todoCalendarService;
 
     @GetMapping("/todos/calendar")
-    @Operation(summary = "월별 Todo Calendar 상세 조회 API - Todo 내용 전체 출력")
-    public BaseResponse<List<TodoDetailsResponseDto>> getTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                               @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
-                                                               @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
+    @Operation(summary = "월별 Todo Calendar 상세 조회 API - MemberTodo/GroupTodo 전체 조회")
+    public BaseResponse<AllTodoResponseDto> getTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                     @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
+                                                     @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
         Long memberId = principalDetails.getId();
-        List<TodoDetailsResponseDto> responseDtos = todoCalendarService.getPeriodDetailTodos(memberId, from, to);
+        AllTodoResponseDto responseDtos = todoCalendarService.getPeriodDetailTodos(memberId, from, to);
         return new BaseResponse<>(responseDtos);
     }
 

--- a/src/main/java/scs/planus/domain/todo/controller/calendar/MemberTodoCalendarController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/calendar/MemberTodoCalendarController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import scs.planus.domain.group.dto.mygroup.GroupBelongInResponseDto;
 import scs.planus.domain.todo.dto.calendar.AllTodoResponseDto;
-import scs.planus.domain.todo.service.calendar.TodoCalendarService;
+import scs.planus.domain.todo.service.calendar.MemberTodoCalendarService;
 import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.common.response.BaseResponse;
 
@@ -26,7 +26,7 @@ import java.util.List;
 @Tag(name = "MemberTodo Calendar", description = "MemberTodo Calendar API Document")
 public class MemberTodoCalendarController {
 
-    private final TodoCalendarService todoCalendarService;
+    private final MemberTodoCalendarService todoCalendarService;
 
     @GetMapping("/todos/calendar")
     @Operation(summary = "월별 Todo Calendar 상세 조회 API - MemberTodo/GroupTodo 전체 조회")

--- a/src/main/java/scs/planus/domain/todo/dto/calendar/AllTodoResponseDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/calendar/AllTodoResponseDto.java
@@ -1,0 +1,22 @@
+package scs.planus.domain.todo.dto.calendar;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AllTodoResponseDto {
+
+    private List<TodoDetailsResponseDto> memberTodos;
+    private List<TodoDetailsResponseDto> groupTodos;
+
+    public static AllTodoResponseDto of(List<TodoDetailsResponseDto> memberTodos, List<TodoDetailsResponseDto> groupTodos) {
+        return AllTodoResponseDto.builder()
+                .memberTodos(memberTodos)
+                .groupTodos(groupTodos)
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -41,7 +41,7 @@ public class TodoQueryRepository {
                 .fetchOne());
     }
 
-    public List<MemberTodo> findPeriodMemberTodosByDate(Long memberId, LocalDate from, LocalDate to) {
+    public List<MemberTodo> findAllPeriodMemberTodosByDate(Long memberId, LocalDate from, LocalDate to) {
         return queryFactory
                 .selectFrom(memberTodo)
                 .join(memberTodo.member, member).fetchJoin()
@@ -108,7 +108,7 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
-    public List<GroupTodo> findAllPeriodGroupTodos(List<Group> groups, LocalDate from , LocalDate to) {
+    public List<GroupTodo> findAllPeriodGroupTodosByDate(List<Group> groups, LocalDate from , LocalDate to) {
         return queryFactory
                 .selectFrom(groupTodo)
                 .join(groupTodo.group, group).fetchJoin()

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import scs.planus.domain.Status;
+import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.todo.entity.GroupTodo;
 import scs.planus.domain.todo.entity.MemberTodo;
 
@@ -18,6 +19,7 @@ import static scs.planus.domain.group.entity.QGroup.group;
 import static scs.planus.domain.member.entity.QMember.member;
 import static scs.planus.domain.todo.entity.QGroupTodo.groupTodo;
 import static scs.planus.domain.todo.entity.QMemberTodo.memberTodo;
+import static scs.planus.domain.todo.entity.QTodo.todo;
 
 @Repository
 @RequiredArgsConstructor
@@ -106,12 +108,30 @@ public class TodoQueryRepository {
                 .fetch();
     }
 
+    public List<GroupTodo> findAllPeriodGroupTodos(List<Group> groups, LocalDate from , LocalDate to) {
+        return queryFactory
+                .selectFrom(groupTodo)
+                .join(groupTodo.group, group).fetchJoin()
+                .join(groupTodo.todoCategory, todoCategory).fetchJoin()
+                .where(groupsIn(groups), groupTodoPeriodBetween(from, to))
+                .orderBy(groupTodo.startDate.asc())
+                .fetch();
+    }
+
+    private BooleanExpression todoIdEq(Long todoId) {
+        return todo.id.eq(todoId);
+    }
+
     private BooleanExpression memberIdEq(Long memberId) {
         return member.id.eq(memberId);
     }
 
     private BooleanExpression groupIdEq(Long groupId) {
         return group.id.eq(groupId);
+    }
+
+    private BooleanExpression groupsIn(List<Group> groups) {
+        return group.in(groups);
     }
 
     private BooleanExpression isActiveGroup() {

--- a/src/main/java/scs/planus/domain/todo/service/MemberTodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/MemberTodoService.java
@@ -9,6 +9,7 @@ import scs.planus.domain.category.repository.TodoCategoryRepository;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
 import scs.planus.domain.group.repository.GroupMemberRepository;
+import scs.planus.domain.group.repository.GroupRepository;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
@@ -34,6 +35,7 @@ public class MemberTodoService {
     private final TodoRepository todoRepository;
     private final TodoQueryRepository todoQueryRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private final GroupRepository groupRepository;
 
     @Transactional
     public TodoResponseDto createMemberTodo(Long memberId, TodoRequestDto requestDto) {
@@ -110,7 +112,11 @@ public class MemberTodoService {
         }
 
         GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId)
-                .orElseThrow(() -> new PlanusException(NOT_JOINED_GROUP));
+                .orElseThrow(() -> {
+                    groupRepository.findById(groupId)
+                            .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
+                    return new PlanusException(NOT_JOINED_GROUP);
+                });
         return groupMember.getGroup();
     }
 }

--- a/src/main/java/scs/planus/domain/todo/service/MemberTodoService.java
+++ b/src/main/java/scs/planus/domain/todo/service/MemberTodoService.java
@@ -7,7 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 import scs.planus.domain.category.entity.TodoCategory;
 import scs.planus.domain.category.repository.TodoCategoryRepository;
 import scs.planus.domain.group.entity.Group;
-import scs.planus.domain.group.repository.GroupRepository;
+import scs.planus.domain.group.entity.GroupMember;
+import scs.planus.domain.group.repository.GroupMemberRepository;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
@@ -30,9 +31,9 @@ public class MemberTodoService {
 
     private final MemberRepository memberRepository;
     private final TodoCategoryRepository todoCategoryRepository;
-    private final GroupRepository groupRepository;
     private final TodoRepository todoRepository;
     private final TodoQueryRepository todoQueryRepository;
+    private final GroupMemberRepository groupMemberRepository;
 
     @Transactional
     public TodoResponseDto createMemberTodo(Long memberId, TodoRequestDto requestDto) {
@@ -42,7 +43,7 @@ public class MemberTodoService {
         TodoCategory todoCategory = todoCategoryRepository.findMemberTodoCategoryByIdAndMember(requestDto.getCategoryId(), member)
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
 
-        Group group = getGroup(requestDto.getGroupId());
+        Group group = checkAndGetGroup(memberId, requestDto.getGroupId());
         Validator.validateStartDateBeforeEndDate(requestDto.getStartDate(), requestDto.getEndDate());
         MemberTodo memberTodo = requestDto.toMemberTodoEntity(member, todoCategory, group);
         todoRepository.save(memberTodo);
@@ -70,7 +71,7 @@ public class MemberTodoService {
         TodoCategory todoCategory = todoCategoryRepository.findById(requestDto.getCategoryId())
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_CATEGORY));
 
-        Group group = getGroup(requestDto.getGroupId());
+        Group group = checkAndGetGroup(memberId, requestDto.getGroupId());
 
         Validator.validateStartDateBeforeEndDate(requestDto.getStartDate(), requestDto.getEndDate());
         todo.update(requestDto.getTitle(), requestDto.getDescription(), requestDto.getStartTime(),
@@ -103,12 +104,13 @@ public class MemberTodoService {
         return TodoResponseDto.of(todo);
     }
 
-    private Group getGroup(Long groupId) {
+    private Group checkAndGetGroup(Long memberId, Long groupId) {
         if (groupId == null) {
             return null;
         }
-        // TODO : 그룹 가입 이후, 현재 멤버가 해당 그룹에 가입했는지를 체크해야함. 아래 방식은 가입하지 않더라도 그룹 지정 가능한 방식
-        return groupRepository.findById(groupId)
-                    .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
+
+        GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId)
+                .orElseThrow(() -> new PlanusException(NOT_JOINED_GROUP));
+        return groupMember.getGroup();
     }
 }

--- a/src/main/java/scs/planus/domain/todo/service/calendar/MemberTodoCalendarService.java
+++ b/src/main/java/scs/planus/domain/todo/service/calendar/MemberTodoCalendarService.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Slf4j
-public class TodoCalendarService {
+public class MemberTodoCalendarService {
 
     private final MyGroupService myGroupService;
     private final MemberRepository memberRepository;
@@ -41,8 +41,8 @@ public class TodoCalendarService {
                 .map(GroupMember::getGroup)
                 .collect(Collectors.toList());
 
-        List<MemberTodo> todos = todoQueryRepository.findPeriodMemberTodosByDate(memberId, from, to);
-        List<GroupTodo> groupTodos = todoQueryRepository.findAllPeriodGroupTodos(groups, from, to);
+        List<MemberTodo> todos = todoQueryRepository.findAllPeriodMemberTodosByDate(memberId, from, to);
+        List<GroupTodo> groupTodos = todoQueryRepository.findAllPeriodGroupTodosByDate(groups, from, to);
 
         List<TodoDetailsResponseDto> memberTodos = todos.stream()
                 .map(TodoDetailsResponseDto::of)


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [X]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 홈 캘린더 화면에서 그룹 투두 조회 기능 구현
- 투두 생성 시, 가입하지 않은 그룹 지정 가능 오류 수정

### :: 특이사항
### 🔥  홈 캘린더 화면에서 그룹 투두 조회 기능 구현
- 본인이 속한 `GroupMember`를 가져온 후, `getGroup()`을 통해 가입한 모든 그룹을 불러옵니다.
- 이 후, `where in`절을 이용하여 속한 그룹에 존재하는 모든 `GroupTodo`를 가져옵니다.
- `AllReponseDto`를 통해, `MemberTodos`와 `GroupTodos`를 응답합니다.

### 🔥 투두 생성 시, 가입하지 않은 그룹 지정 가능 오류 수정
- Todo 생성시, `getGroup()`을 통해 가입하지 않던 모든 그룹을 지정할 수 있었던 버그를 수정하였습니다.
- `checkAndGetGroup()`으로 메서드 명을 변경하였습니다.
  - `GroupMember`를 통해, 현재 지정한 `groupId`가 본인이 속한 `Group`인지를 판단하는 기능을 추가하였습니다.