### PR TITLE
[Feat] 속한 모든 그룹 카테고리 조회 기능 구현

### DIFF
--- a/src/main/java/scs/planus/domain/category/controller/MemberTodoCategoryController.java
+++ b/src/main/java/scs/planus/domain/category/controller/MemberTodoCategoryController.java
@@ -32,6 +32,16 @@ public class MemberTodoCategoryController {
         return new BaseResponse<>(responseDto);
     }
 
+    @GetMapping("/categories/groups")
+    @Operation(summary = "속한 Group Todo Category 조회 API")
+    public BaseResponse<List<TodoCategoryGetResponseDto>> getAllGroupTodoCategory(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Long memberId = principalDetails.getId();
+        List<TodoCategoryGetResponseDto> responseDto = memberTodoCategoryService.findAllGroupTodoCategories(memberId);
+
+        return new BaseResponse<>(responseDto);
+    }
+
     @PostMapping("/categories")
     @Operation(summary = "Member Todo Category 생성 API")
     public BaseResponse<TodoCategoryResponseDto> createMemberTodoCategory(@AuthenticationPrincipal PrincipalDetails principalDetails,

--- a/src/main/java/scs/planus/domain/category/repository/TodoCategoryRepository.java
+++ b/src/main/java/scs/planus/domain/category/repository/TodoCategoryRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import scs.planus.domain.category.entity.GroupTodoCategory;
 import scs.planus.domain.category.entity.MemberTodoCategory;
 import scs.planus.domain.category.entity.TodoCategory;
+import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.member.entity.Member;
 
 import java.util.List;
@@ -37,4 +38,9 @@ public interface TodoCategoryRepository extends JpaRepository<TodoCategory, Long
             "where gc.id= :categoryId " +
             "and gc.status= 'ACTIVE' ")
     Optional<GroupTodoCategory> findGroupTodoCategoryByIdAndStatus(@Param("categoryId") Long categoryId);
+
+    @Query("select gc from GroupTodoCategory gc " +
+            "where gc.group in :groups " +
+            "order by gc.group.id ASC")
+    List<GroupTodoCategory> findAllGroupTodoCategoriesInGroups(@Param("groups") List<Group> groups);
 }

--- a/src/main/java/scs/planus/domain/category/service/MemberTodoCategoryService.java
+++ b/src/main/java/scs/planus/domain/category/service/MemberTodoCategoryService.java
@@ -8,9 +8,13 @@ import scs.planus.domain.category.dto.TodoCategoryGetResponseDto;
 import scs.planus.domain.category.dto.TodoCategoryRequestDto;
 import scs.planus.domain.category.dto.TodoCategoryResponseDto;
 import scs.planus.domain.category.entity.Color;
+import scs.planus.domain.category.entity.GroupTodoCategory;
 import scs.planus.domain.category.entity.MemberTodoCategory;
 import scs.planus.domain.category.entity.TodoCategory;
 import scs.planus.domain.category.repository.TodoCategoryRepository;
+import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.group.entity.GroupMember;
+import scs.planus.domain.group.repository.GroupMemberRepository;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.global.exception.CustomExceptionStatus;
@@ -26,6 +30,7 @@ import java.util.stream.Collectors;
 public class MemberTodoCategoryService {
     private final TodoCategoryRepository todoCategoryRepository;
     private final MemberRepository memberRepository;
+    private final GroupMemberRepository groupMemberRepository;
 
     /**
      * 카테고리 조회
@@ -41,6 +46,24 @@ public class MemberTodoCategoryService {
         return memberTodoCategories.stream()
                 .map(TodoCategoryGetResponseDto::of)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * 속한 그룹 카테고리 조회
+     */
+    public List<TodoCategoryGetResponseDto> findAllGroupTodoCategories(Long memberId) {
+
+        List<GroupMember> groupMembers = groupMemberRepository.findAllByActiveGroupAndMemberId(memberId);
+        List<Group> groups = groupMembers.stream()
+                .map(GroupMember::getGroup)
+                .collect(Collectors.toList());
+
+        List<GroupTodoCategory> groupTodoCategories = todoCategoryRepository.findAllGroupTodoCategoriesInGroups(groups);
+        List<TodoCategoryGetResponseDto> responseDtos = groupTodoCategories.stream()
+                .map(TodoCategoryGetResponseDto::of)
+                .collect(Collectors.toList());
+
+        return responseDtos;
     }
 
     /**


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 속한 모든 그룹 카테고리 조회 기능 구현

### :: 특이사항
- `/app/categories/groups`
- 앱단 캐싱을 위한 그룹 카테고리 조회 기능을 구현하였습니다.
- Todo처럼 한번에 개인카테고리/그룹카테고리를 응답하지 않은 이유는 다음과 같습니다.
  - 홈 캘린더에서 슬라이딩할 때, 개인 카테고리가 추가되거나 삭제되는 경우는 없습니다.
  - 따라서, 다음 윈도우의 투두들을 호출하기전, 변경 가능성이 존재하는 그룹 카테고리를 미리 캐싱한 뒤, 투두들을 받아오는 식으로 진행하게 되었습니다. (이상민은 천재야!)