### PR TITLE
[Feat] GroupMember Calendar 구현 및 Group Calendar 리팩토링

### DIFF
--- a/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
@@ -4,21 +4,21 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import scs.planus.domain.category.dto.TodoCategoryGetResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupDetailResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupGetMemberResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
 import scs.planus.domain.group.service.MyGroupService;
-import scs.planus.domain.todo.dto.calendar.TodoDailyResponseDto;
-import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
 import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.common.response.BaseResponse;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -54,29 +54,6 @@ public class MyGroupController {
         Long memberId = principalDetails.getId();
         List<MyGroupGetMemberResponseDto> responseDto = myGroupService.getGroupMembersForMember(memberId, groupId);
         return new BaseResponse<>(responseDto);
-    }
-
-    @GetMapping("/my-groups/{groupId}/members/{memberId}/calendar")
-    @Operation(summary = "MyGroup에 속한 그룹원 캘린더 조회 API")
-    public BaseResponse<List<TodoDetailsResponseDto>> getGroupMemberPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                                @PathVariable Long groupId,
-                                                                                @PathVariable Long memberId,
-                                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
-                                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
-        Long loginId = principalDetails.getId();
-        List<TodoDetailsResponseDto> responseDtos = myGroupService.getGroupMemberPeriodTodos(loginId, groupId, memberId, from, to);
-        return new BaseResponse<>(responseDtos);
-    }
-
-    @GetMapping("/my-groups/{groupId}/members/{memberId}/calendar/daily")
-    @Operation(summary = "MyGroup에 속한 그룹원 일별 Todo/Schedule 조회 API")
-    public BaseResponse<TodoDailyResponseDto> getGroupMemberPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                                @PathVariable Long groupId,
-                                                                                @PathVariable Long memberId,
-                                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
-        Long loginId = principalDetails.getId();
-        TodoDailyResponseDto responseDtos = myGroupService.getGroupMemberDailyTodos(loginId, groupId, memberId, date);
-        return new BaseResponse<>(responseDtos);
     }
 
     @PatchMapping("/my-groups/{groupId}/online-status")

--- a/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/MyGroupController.java
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import scs.planus.domain.category.dto.TodoCategoryGetResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupDetailResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupGetMemberResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
@@ -64,17 +63,4 @@ public class MyGroupController {
         MyGroupOnlineStatusResponseDto responseDto = myGroupService.changeOnlineStatus(memberId, groupId);
         return new BaseResponse<>(responseDto);
     }
-
-    @GetMapping("/my-groups/{groupId}/members/{memberId}/categories")
-    @Operation(summary = "Group의 대상 회원의 전체 Member Todo Category 조회 API")
-    public BaseResponse<List<TodoCategoryGetResponseDto>> getAllTargetMemberTodoCategories(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                                           @PathVariable("groupId") Long groupId,
-                                                                                           @PathVariable("memberId") Long memberId) {
-
-        Long loginMemberId = principalDetails.getId();
-        List<TodoCategoryGetResponseDto> responseDto = myGroupService.findAllTargetMemberTodoCategories( loginMemberId, groupId, memberId );
-
-        return new BaseResponse<>(responseDto);
-    }
-
 }

--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -8,7 +8,11 @@ import scs.planus.domain.category.dto.TodoCategoryGetResponseDto;
 import scs.planus.domain.category.entity.MemberTodoCategory;
 import scs.planus.domain.category.repository.TodoCategoryRepository;
 import scs.planus.domain.group.dto.GroupTagResponseDto;
-import scs.planus.domain.group.dto.mygroup.*;
+import scs.planus.domain.group.dto.mygroup.GroupBelongInResponseDto;
+import scs.planus.domain.group.dto.mygroup.MyGroupDetailResponseDto;
+import scs.planus.domain.group.dto.mygroup.MyGroupGetMemberResponseDto;
+import scs.planus.domain.group.dto.mygroup.MyGroupOnlineStatusResponseDto;
+import scs.planus.domain.group.dto.mygroup.MyGroupResponseDto;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
 import scs.planus.domain.group.entity.GroupTag;
@@ -19,16 +23,9 @@ import scs.planus.domain.group.repository.GroupTagRepository;
 import scs.planus.domain.member.dto.MemberResponseDto;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
-import scs.planus.domain.todo.dto.calendar.TodoDailyDto;
-import scs.planus.domain.todo.dto.calendar.TodoDailyResponseDto;
-import scs.planus.domain.todo.dto.calendar.TodoDailyScheduleDto;
-import scs.planus.domain.todo.dto.TodoDetailsResponseDto;
-import scs.planus.domain.todo.entity.MemberTodo;
 import scs.planus.domain.todo.repository.TodoQueryRepository;
 import scs.planus.global.exception.PlanusException;
-import scs.planus.global.util.validator.Validator;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -143,47 +140,6 @@ public class MyGroupService {
         }
 
         return MemberResponseDto.of(member);
-    }
-
-    public List<TodoDetailsResponseDto> getGroupMemberPeriodTodos(Long loginId, Long groupId, Long memberId,
-                                                                 LocalDate from, LocalDate to) {
-        Boolean isLoginMemberJoined = groupMemberQueryRepository.existByMemberIdAndGroupId(loginId, groupId);
-        Boolean isMemberJoined = groupMemberQueryRepository.existByMemberIdAndGroupId(memberId, groupId);
-
-        if (!isLoginMemberJoined || !isMemberJoined) {
-            throw new PlanusException(NOT_JOINED_GROUP);
-        }
-
-        Validator.validateStartDateBeforeEndDate(from, to);
-        List<MemberTodo> todos = todoQueryRepository.findPeriodGroupMemberTodosByDate(memberId, groupId, from, to);
-        List<TodoDetailsResponseDto> responseDtos = todos.stream()
-                .map(TodoDetailsResponseDto::of)
-                .collect(Collectors.toList());
-        return responseDtos;
-    }
-
-    public TodoDailyResponseDto getGroupMemberDailyTodos(Long loginId, Long groupId, Long memberId, LocalDate date) {
-        Boolean isLoginMemberJoined = groupMemberQueryRepository.existByMemberIdAndGroupId(loginId, groupId);
-        Boolean isMemberJoined = groupMemberQueryRepository.existByMemberIdAndGroupId(memberId, groupId);
-
-        if (!isLoginMemberJoined || !isMemberJoined) {
-            throw new PlanusException(NOT_JOINED_GROUP);
-        }
-
-        List<MemberTodo> todos = todoQueryRepository.findDailyGroupMemberTodosByDate(memberId, groupId, date);
-
-        // TODO -> 리팩토링 필요. TodoCalendarService에서 구현된 메서드
-        List<TodoDailyScheduleDto> dailySchedules = todos.stream()
-                .filter(todo -> todo.getStartTime() != null)
-                .map(TodoDailyScheduleDto::of)
-                .collect(Collectors.toList());
-
-        List<TodoDailyDto> dailyTodos = todos.stream()
-                .filter(todo -> todo.getStartTime() == null)
-                .map(TodoDailyDto::of)
-                .collect(Collectors.toList());
-
-        return TodoDailyResponseDto.of(dailySchedules, dailyTodos);
     }
 
     @Transactional

--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -4,8 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import scs.planus.domain.category.dto.TodoCategoryGetResponseDto;
-import scs.planus.domain.category.entity.MemberTodoCategory;
 import scs.planus.domain.category.repository.TodoCategoryRepository;
 import scs.planus.domain.group.dto.GroupTagResponseDto;
 import scs.planus.domain.group.dto.mygroup.GroupBelongInResponseDto;
@@ -181,35 +179,5 @@ public class MyGroupService {
                 .filter(groupMember -> groupMember.getGroup().getId().equals(group.getId()))
                 .filter(GroupMember::isOnlineStatus)
                 .count();
-    }
-
-    public List<TodoCategoryGetResponseDto> findAllTargetMemberTodoCategories(Long loginMemberId, Long groupId, Long memberId ) {
-        Member loginMember = memberRepository.findById( loginMemberId )
-                .orElseThrow(() -> new PlanusException( NONE_USER ));
-
-        Group group = groupRepository.findByIdAndStatus( groupId )
-                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
-
-        Member targetMember = memberRepository.findById( memberId )
-                .orElseThrow(() -> new PlanusException( NONE_USER ));
-
-        // Member 가 그룹 회원인지 확인
-        Boolean isMemberJoined = groupMemberQueryRepository.existByMemberIdAndGroupId( loginMember.getId(), group.getId() );
-        if (!isMemberJoined) {
-            throw new PlanusException( NOT_JOINED_GROUP );
-        }
-
-        // TargetMember 가 그룹 회원인지 확인
-        Boolean isTargetMemberJoined = groupMemberQueryRepository.existByMemberIdAndGroupId( targetMember.getId(), group.getId() );
-        if (!isTargetMemberJoined) {
-            throw new PlanusException( NOT_JOINED_MEMBER_IN_GROUP );
-        }
-
-        List<MemberTodoCategory> targetMemberTodoCategories = todoCategoryRepository.findMemberTodoCategoryAllByMember( targetMember );
-
-        // TODO : 그룹 개인 투두 용으로만 쓴 카테고리 뿐 만 아니라 모두 응답으로 주는 것에 대한 보안 문제
-        return targetMemberTodoCategories.stream()
-                .map( TodoCategoryGetResponseDto::of )
-                .collect( Collectors.toList() );
     }
 }

--- a/src/main/java/scs/planus/domain/todo/controller/calendar/GroupTodoCalendarController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/calendar/GroupTodoCalendarController.java
@@ -53,12 +53,23 @@ public class GroupTodoCalendarController {
     @GetMapping("/my-groups/{groupId}/members/{memberId}/calendar")
     @Operation(summary = "월별 GroupMemberTodo Calendar 조회 API")
     public BaseResponse<List<TodoPeriodResponseDto>> getGroupMemberPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                                @PathVariable Long groupId,
-                                                                                @PathVariable Long memberId,
-                                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
-                                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
+                                                                               @PathVariable Long groupId,
+                                                                               @PathVariable Long memberId,
+                                                                               @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
+                                                                               @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
         Long loginId = principalDetails.getId();
         List<TodoPeriodResponseDto> responseDtos = groupTodoCalendarService.getGroupMemberPeriodTodos(loginId, groupId, memberId, from, to);
+        return new BaseResponse<>(responseDtos);
+    }
+
+    @GetMapping("/my-groups/{groupId}/members/{memberId}/calendar/daily")
+    @Operation(summary = "일별 GroupMemberTodo/GroupMemberSchedule 조회 API")
+    public BaseResponse<TodoDailyResponseDto> getGroupMemberPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                        @PathVariable Long groupId,
+                                                                        @PathVariable Long memberId,
+                                                                        @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+        Long loginId = principalDetails.getId();
+        TodoDailyResponseDto responseDtos = groupTodoCalendarService.getGroupMemberDailyTodos(loginId, groupId, memberId, date);
         return new BaseResponse<>(responseDtos);
     }
 }

--- a/src/main/java/scs/planus/domain/todo/controller/calendar/GroupTodoCalendarController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/calendar/GroupTodoCalendarController.java
@@ -49,4 +49,16 @@ public class GroupTodoCalendarController {
         TodoDailyResponseDto responseDtos = groupTodoCalendarService.getDailyGroupTodos(memberId, groupId, date);
         return new BaseResponse<>(responseDtos);
     }
+
+    @GetMapping("/my-groups/{groupId}/members/{memberId}/calendar")
+    @Operation(summary = "월별 GroupMemberTodo Calendar 조회 API")
+    public BaseResponse<List<TodoPeriodResponseDto>> getGroupMemberPeriodTodos(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                                @PathVariable Long groupId,
+                                                                                @PathVariable Long memberId,
+                                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
+                                                                                @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
+        Long loginId = principalDetails.getId();
+        List<TodoPeriodResponseDto> responseDtos = groupTodoCalendarService.getGroupMemberPeriodTodos(loginId, groupId, memberId, from, to);
+        return new BaseResponse<>(responseDtos);
+    }
 }

--- a/src/main/java/scs/planus/domain/todo/controller/calendar/GroupTodoCalendarController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/calendar/GroupTodoCalendarController.java
@@ -27,7 +27,7 @@ import java.util.List;
 @Tag(name = "GroupTodo Calendar", description = "GroupTodo Calendar API Document")
 public class GroupTodoCalendarController {
 
-    private final GroupTodoCalendarService GroupTodoCalendarService;
+    private final GroupTodoCalendarService groupTodoCalendarService;
 
     @GetMapping("my-groups/{groupId}/todos/calendar")
     @Operation(summary = "월별 GroupTodo Calendar 조회 API")
@@ -36,7 +36,7 @@ public class GroupTodoCalendarController {
                                                                     @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate from,
                                                                     @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate to) {
         Long memberId = principalDetails.getId();
-        List<TodoPeriodResponseDto> responseDtos = GroupTodoCalendarService.getPeriodGroupTodos(memberId, groupId, from, to);
+        List<TodoPeriodResponseDto> responseDtos = groupTodoCalendarService.getPeriodGroupTodos(memberId, groupId, from, to);
         return new BaseResponse<>(responseDtos);
     }
 
@@ -46,7 +46,7 @@ public class GroupTodoCalendarController {
                                                             @PathVariable Long groupId,
                                                             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         Long memberId = principalDetails.getId();
-        TodoDailyResponseDto responseDtos = GroupTodoCalendarService.getDailyGroupTodos(memberId, groupId, date);
+        TodoDailyResponseDto responseDtos = groupTodoCalendarService.getDailyGroupTodos(memberId, groupId, date);
         return new BaseResponse<>(responseDtos);
     }
 }

--- a/src/main/java/scs/planus/domain/todo/dto/calendar/TodoDailyDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/calendar/TodoDailyDto.java
@@ -9,7 +9,7 @@ import scs.planus.domain.todo.entity.Todo;
 public class TodoDailyDto {
 
     private Long todoId;
-    private Long categoryId;
+    private String categoryColor;
     private String title;
 
     private Boolean hasGroup;
@@ -20,7 +20,7 @@ public class TodoDailyDto {
     public static TodoDailyDto of(Todo todo) {
         return TodoDailyDto.builder()
                 .todoId(todo.getId())
-                .categoryId(todo.getTodoCategory().getId())
+                .categoryColor(todo.getTodoCategory().getColor().toString())
                 .title(todo.getTitle())
                 .hasGroup(todo.getGroup() != null)
                 .isPeriodTodo(todo.getEndDate().isAfter(todo.getStartDate()))

--- a/src/main/java/scs/planus/domain/todo/dto/calendar/TodoDailyScheduleDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/calendar/TodoDailyScheduleDto.java
@@ -12,7 +12,7 @@ import java.time.LocalTime;
 public class TodoDailyScheduleDto {
 
     private Long todoId;
-    private Long categoryId;
+    private String categoryColor;
     private String title;
     @JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING)
     private LocalTime startTime;
@@ -25,7 +25,7 @@ public class TodoDailyScheduleDto {
     public static TodoDailyScheduleDto of(Todo todo) {
         return TodoDailyScheduleDto.builder()
                 .todoId(todo.getId())
-                .categoryId(todo.getTodoCategory().getId())
+                .categoryColor(todo.getTodoCategory().getColor().toString())
                 .title(todo.getTitle())
                 .startTime(todo.getStartTime())
                 .hasGroup(todo.getGroup() != null)

--- a/src/main/java/scs/planus/domain/todo/dto/calendar/TodoPeriodResponseDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/calendar/TodoPeriodResponseDto.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 public class TodoPeriodResponseDto {
 
     private Long todoId;
-    private Long categoryId;
+    private String categoryColor;
     private String title;
     @JsonFormat(pattern = "yyyy-MM-dd", shape = JsonFormat.Shape.STRING)
     private LocalDate startDate;
@@ -22,7 +22,7 @@ public class TodoPeriodResponseDto {
     public static TodoPeriodResponseDto of(Todo todo) {
         return TodoPeriodResponseDto.builder()
                 .todoId(todo.getId())
-                .categoryId(todo.getTodoCategory().getId())
+                .categoryColor(todo.getTodoCategory().getColor().toString())
                 .title(todo.getTitle())
                 .startDate(todo.getStartDate())
                 .endDate(todo.getEndDate())

--- a/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
+++ b/src/main/java/scs/planus/domain/todo/repository/TodoQueryRepository.java
@@ -91,7 +91,7 @@ public class TodoQueryRepository {
     public List<GroupTodo> findPeriodGroupTodosByDate(Long groupId, LocalDate from, LocalDate to) {
         return queryFactory
                 .selectFrom(groupTodo)
-                .join(groupTodo.group, group).fetchJoin()
+                .join(groupTodo.group, group)
                 .join(groupTodo.todoCategory, todoCategory).fetchJoin()
                 .where(groupIdEq(groupId), groupTodoPeriodBetween(from, to))
                 .orderBy(groupTodo.startDate.asc(), groupTodo.endDate.desc())
@@ -101,7 +101,7 @@ public class TodoQueryRepository {
     public List<GroupTodo> findDailyGroupTodosByDate(Long groupId, LocalDate date) {
         return queryFactory
                 .selectFrom(groupTodo)
-                .join(groupTodo.group, group).fetchJoin()
+                .join(groupTodo.group, group)
                 .join(groupTodo.todoCategory, todoCategory).fetchJoin()
                 .where(groupIdEq(groupId), groupTodoDateBetween(date))
                 .orderBy(groupTodo.startTime.asc())

--- a/src/main/java/scs/planus/domain/todo/service/calendar/GroupTodoCalendarService.java
+++ b/src/main/java/scs/planus/domain/todo/service/calendar/GroupTodoCalendarService.java
@@ -21,8 +21,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static scs.planus.global.exception.CustomExceptionStatus.NOT_EXIST_GROUP;
-import static scs.planus.global.exception.CustomExceptionStatus.NOT_JOINED_GROUP;
+import static scs.planus.global.exception.CustomExceptionStatus.*;
 
 @Service
 @Transactional(readOnly = true)
@@ -76,7 +75,7 @@ public class GroupTodoCalendarService {
                 });
 
         GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId)
-                .orElseThrow(() -> new PlanusException(NOT_JOINED_GROUP));
+                .orElseThrow(() -> new PlanusException(NOT_JOINED_MEMBER_IN_GROUP));
 
         Validator.validateStartDateBeforeEndDate(from, to);
         List<Todo> todos = todoQueryRepository.findGroupMemberPeriodTodosByDate(memberId, groupId, from, to);
@@ -96,7 +95,7 @@ public class GroupTodoCalendarService {
                 });
 
         GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId)
-                .orElseThrow(() -> new PlanusException(NOT_JOINED_GROUP));
+                .orElseThrow(() -> new PlanusException(NOT_JOINED_MEMBER_IN_GROUP));
 
         List<Todo> todos = todoQueryRepository.findGroupMemberDailyTodosByDate(memberId, groupId, date);
 


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- GroupMember Calendar 구현
- Group Calendar 리팩토링

### :: 특이사항
### 🔥 Group Calendar 리팩토링
- 월별 / 일별 투두들을 응답할 시, categoryId가 아닌, categoryColor를 response하도록 수정하였습니다.
  - 상세 조회에서만 categoryName을 응답하도록 구현할 예정입니다.
  - 이는 GroupMember Calendar에서와 동일합니다.
 
### 🔥 GroupMember Calendar 구현
- 기존에 MyGroupController에 있던 것을 GroupCalendarController로 이동시켰습니다.
- 월별 캘린더 구현
  - 모든 투두들, 즉, 그룹투두 / 개인투두를 모두 가져오기 위한 쿼리를 작성하였습니다.
```java

public List<Todo> findGroupMemberPeriodTodosByDate(Long memberId, Long groupId, LocalDate from, LocalDate to) {
        return queryFactory
                .selectFrom(todo)
                .join(memberTodo).on(memberTodo.eq(todo))
                .join(todo.group, group).on(groupIdEq(groupId))
                .join(todo.todoCategory, todoCategory).fetchJoin()
                .leftJoin(memberTodo.member, member)
                .where((memberIdEq(memberId).and(groupIdEq(groupId)))
                                .or(groupIdEq(groupId).and(member.isNull())),
                        todoPeriodBetween(from, to))
                .orderBy(todo.startDate.asc(), todo.endDate.desc())
                .fetch();
    }

/** 
*    where 절 설명 !
*   (memberIdEq(memberId).and(groupIdEq(groupId)) : 개인투두
*   (groupIdEq(groupId).and(member.isNull()) : 그룹투두
/*

```
- 일별 투두/일정 조회 구현
  - 위와 동일하되, where 조건을 달리하여 이를 구현하였습니다.

### 🔥 제네릭 사용
- GroupTodo 조회 : List<GroupTodo> 반환
- GroupMemberTodo 조회 : List<Todo> 반환
- 일별 투두/일정을 불러오기 위해, 공통으로 사용하는 `getDailySchedule()`, `getDailyTodo()` 메서드의 내부 파라미터를 다음과 같이 제네릭으로 구현하였습니다.
  - `getDailySchedules(List<? extends Todo> todos)`
- 임시로 제네릭을 사용하여 해결했지만, TodoQueryRepository단에서 아래의 사진과 같이 중복되는 메서드들이 너무 많습니다.
- 이를 이 후, 해결하고자 합니다.
<img width="888" alt="스크린샷 2023-05-24 오전 2 51 24" src="https://github.com/Planus-SCS/Planus-Backend/assets/97597051/74887053-ec5d-42f2-a1e0-af01ffceeb7d">

