### PR TITLE
[Feat] 그룹 검색 홈 초기화면을 위한 그룹 회원수, 최근 생성 순으로 조회하는 API 구현

### DIFF
--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -2,6 +2,7 @@ package scs.planus.domain.group.controller;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,6 +20,15 @@ import java.util.List;
 @Slf4j
 public class GroupController {
     private final GroupService groupService;
+
+    @GetMapping("/groups/search-home")
+    public BaseResponse<List<GroupsGetResponseDto>> getGroupsSearchHome(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                        Pageable pageable) {
+
+        List<GroupsGetResponseDto> responseDtos = groupService.getGroupsOrderByNumOfMembers(pageable);
+
+        return new BaseResponse<>(responseDtos);
+    }
 
     @PostMapping("/groups")
     public BaseResponse<GroupResponseDto> createGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -29,7 +29,7 @@ public class GroupController {
     public BaseResponse<List<GroupsGetResponseDto>> getGroupsSearchHome(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                         Pageable pageable) {
 
-        List<GroupsGetResponseDto> responseDtos = groupService.getGroupsOrderByNumOfMembers(pageable);
+        List<GroupsGetResponseDto> responseDtos = groupService.getGroupsSearchHome(pageable);
 
         return new BaseResponse<>(responseDtos);
     }

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -31,11 +31,11 @@ public class GroupController {
     }
 
     @GetMapping("/groups/{groupId}")
-    public BaseResponse<GroupGetResponseDto> getGroupDetailForNonMember(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                        @PathVariable("groupId") Long groupId) {
+    public BaseResponse<GroupGetDetailResponseDto> getGroupDetailForNonMember(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                              @PathVariable("groupId") Long groupId) {
 
         Long memberId = principalDetails.getId();
-        GroupGetResponseDto responseDto = groupService.getGroupDetailForNonMember(memberId, groupId);
+        GroupGetDetailResponseDto responseDto = groupService.getGroupDetailForNonMember(memberId, groupId);
 
         return new BaseResponse<>(responseDto);
     }

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class GroupController {
     private final GroupService groupService;
 
-    @GetMapping("/groups/search-home")
+    @GetMapping("/groups")
     @Operation(summary = "검색 홈에서 초기화면을 위한 Groups 조회 API")
     public BaseResponse<List<GroupsGetResponseDto>> getGroupsSearchHome(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                         Pageable pageable) {

--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -1,5 +1,7 @@
 package scs.planus.domain.group.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -18,10 +20,12 @@ import java.util.List;
 @RequestMapping("/app")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "Group", description = "Group API Document")
 public class GroupController {
     private final GroupService groupService;
 
     @GetMapping("/groups/search-home")
+    @Operation(summary = "검색 홈에서 초기화면을 위한 Groups 조회 API")
     public BaseResponse<List<GroupsGetResponseDto>> getGroupsSearchHome(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                         Pageable pageable) {
 
@@ -31,6 +35,7 @@ public class GroupController {
     }
 
     @PostMapping("/groups")
+    @Operation(summary = "그룹 생성 API")
     public BaseResponse<GroupResponseDto> createGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                       @RequestPart(value = "image") MultipartFile multipartFile,
                                                       @Valid @RequestPart(value = "groupCreateRequestDto") GroupCreateRequestDto requestDto) {
@@ -41,6 +46,7 @@ public class GroupController {
     }
 
     @GetMapping("/groups/{groupId}")
+    @Operation(summary = "(비회원용) 그룹 상세 정보 조회 API")
     public BaseResponse<GroupGetDetailResponseDto> getGroupDetailForNonMember(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                               @PathVariable("groupId") Long groupId) {
 
@@ -51,6 +57,7 @@ public class GroupController {
     }
 
     @GetMapping("/groups/{groupId}/members")
+    @Operation(summary = "(비회원용) 그룹 회원 정보 조회 API")
     public BaseResponse<List<GroupGetMemberResponseDto>> getGroupMemberForNonMember(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                                     @PathVariable("groupId") Long groupId) {
 
@@ -60,6 +67,7 @@ public class GroupController {
     }
 
     @PatchMapping("/groups/{groupId}")
+    @Operation(summary = "(리더용) 그룹 상세 정보 수정 API")
     public BaseResponse<GroupResponseDto> updateGroupDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                             @PathVariable("groupId") Long groupId,
                                                             @RequestPart(value = "image", required = false) MultipartFile multipartFile,
@@ -71,6 +79,7 @@ public class GroupController {
     }
 
     @PatchMapping("/groups/{groupId}/notice")
+    @Operation(summary = "(리더용) 그룹 공지 수정 API")
     public BaseResponse<GroupResponseDto> updateGroupNotice(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                             @PathVariable("groupId") Long groupId,
                                                             @Valid @RequestBody GroupNoticeUpdateRequestDto requestDto ) {
@@ -82,6 +91,7 @@ public class GroupController {
     }
 
     @DeleteMapping("/groups/{groupId}")
+    @Operation(summary = "(리더용) 그룹 삭제 API")
     public BaseResponse<GroupResponseDto> softDeleteGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                           @PathVariable("groupId") Long groupId ){
 
@@ -92,6 +102,7 @@ public class GroupController {
     }
 
     @PostMapping("/groups/{groupId}/joins")
+    @Operation(summary = "그룹 가입 요청 API")
     public BaseResponse<GroupJoinResponseDto> joinGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                         @PathVariable("groupId") Long groupId ) {
         Long memberId = principalDetails.getId();
@@ -101,6 +112,7 @@ public class GroupController {
     }
 
     @GetMapping("/groups/joins")
+    @Operation(summary = "(리더용) 그룹의 모든 가입 요청 조회 API")
     public BaseResponse<List<GroupJoinGetResponseDto>> getAllGroupJoin(@AuthenticationPrincipal PrincipalDetails principalDetails) {
 
         Long memberId = principalDetails.getId();
@@ -110,6 +122,7 @@ public class GroupController {
     }
 
     @PostMapping("/groups/joins/{groupJoinId}/accept")
+    @Operation(summary = "(리더용) 그룹 가입 요청 수락 API")
     public BaseResponse<GroupMemberResponseDto> acceptGroupJoin(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                 @PathVariable("groupJoinId") Long groupJoinId ){
 
@@ -120,6 +133,7 @@ public class GroupController {
     }
 
     @PostMapping("/groups/joins/{groupJoinId}/reject")
+    @Operation(summary = "(리더용) 그룹 가입 요청 거절 API")
     public BaseResponse<GroupJoinResponseDto> rejectGroupJoin(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                               @PathVariable("groupJoinId") Long groupJoinId ){
 
@@ -130,6 +144,7 @@ public class GroupController {
     }
 
     @DeleteMapping("/groups/{groupId}/members/{memberId}")
+    @Operation(summary = "(리더용) 그룹 회원 강제 탈퇴 API")
     public BaseResponse<GroupMemberResponseDto> withdrawGroupMember(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                                     @PathVariable("groupId") Long groupId,
                                                                     @PathVariable("memberId") Long memberId) {

--- a/src/main/java/scs/planus/domain/group/dto/GroupGetDetailResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupGetDetailResponseDto.java
@@ -31,7 +31,7 @@ public class GroupGetDetailResponseDto {
                 .groupImageUrl( group.getGroupImageUrl() )
                 .memberCount( group.getGroupMembers().size() )
                 .limitCount( group.getLimitCount() )
-                .leaderName( group.getLeaderName() )
+                .leaderName( group.getLeader().getNickname() )
                 .groupTags( groupTagNameList )
                 .build();
     }

--- a/src/main/java/scs/planus/domain/group/dto/GroupGetDetailResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupGetDetailResponseDto.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 @Builder
 @Slf4j
-public class GroupGetResponseDto {
+public class GroupGetDetailResponseDto {
     private Long id;
     private String name;
     private Boolean isJoined;
@@ -22,8 +22,8 @@ public class GroupGetResponseDto {
     private List<GroupTagResponseDto> groupTags;
 
 
-    public static GroupGetResponseDto of( Group group, List<GroupTagResponseDto> groupTagNameList, Boolean isJoined ) {
-        return GroupGetResponseDto.builder()
+    public static GroupGetDetailResponseDto of(Group group, List<GroupTagResponseDto> groupTagNameList, Boolean isJoined ) {
+        return GroupGetDetailResponseDto.builder()
                 .id( group.getId() )
                 .name( group.getName() )
                 .isJoined( isJoined )

--- a/src/main/java/scs/planus/domain/group/dto/GroupMembersCountDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupMembersCountDto.java
@@ -1,0 +1,6 @@
+package scs.planus.domain.group.dto;
+
+public interface GroupMembersCountDto {
+    Long getGroupId();
+    Integer getCount();
+}

--- a/src/main/java/scs/planus/domain/group/dto/GroupMembersCountDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupMembersCountDto.java
@@ -1,6 +1,0 @@
-package scs.planus.domain.group.dto;
-
-public interface GroupMembersCountDto {
-    Long getGroupId();
-    Integer getCount();
-}

--- a/src/main/java/scs/planus/domain/group/dto/GroupsGetResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupsGetResponseDto.java
@@ -3,7 +3,6 @@ package scs.planus.domain.group.dto;
 import lombok.Builder;
 import lombok.Getter;
 import scs.planus.domain.group.entity.Group;
-import scs.planus.domain.member.entity.Member;
 
 import java.util.List;
 
@@ -19,12 +18,12 @@ public class GroupsGetResponseDto {
     private String leaderName;
     private List<GroupTagResponseDto> groupTags;
 
-    public static GroupsGetResponseDto of( Group group, int memberCount, Member groupLeader, List<GroupTagResponseDto> groupTagNameList ) {
+    public static GroupsGetResponseDto of( Group group, List<GroupTagResponseDto> groupTagNameList ) {
         return GroupsGetResponseDto.builder()
                 .groupId( group.getId() )
                 .name( group.getName() )
                 .groupImageUrl( group.getGroupImageUrl() )
-                .memberCount( memberCount )
+                .memberCount( group.getGroupMembers().size() )
                 .limitCount( group.getLimitCount() )
                 .leaderId( group.getLeader().getId() )
                 .leaderName( group.getLeader().getNickname() )

--- a/src/main/java/scs/planus/domain/group/dto/GroupsGetResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupsGetResponseDto.java
@@ -1,0 +1,34 @@
+package scs.planus.domain.group.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.member.entity.Member;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class GroupsGetResponseDto {
+    private Long groupId;
+    private String name;
+    private String groupImageUrl;
+    private int memberCount;
+    private int limitCount;
+    private Long leaderId;
+    private String leaderName;
+    private List<GroupTagResponseDto> groupTags;
+
+    public static GroupsGetResponseDto of( Group group, int memberCount, Member groupLeader, List<GroupTagResponseDto> groupTagNameList ) {
+        return GroupsGetResponseDto.builder()
+                .groupId( group.getId() )
+                .name( group.getName() )
+                .groupImageUrl( group.getGroupImageUrl() )
+                .memberCount( memberCount )
+                .limitCount( group.getLimitCount() )
+                .leaderId( groupLeader.getId() )
+                .leaderName( groupLeader.getNickname() )
+                .groupTags( groupTagNameList )
+                .build();
+    }
+}

--- a/src/main/java/scs/planus/domain/group/dto/GroupsGetResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupsGetResponseDto.java
@@ -26,8 +26,8 @@ public class GroupsGetResponseDto {
                 .groupImageUrl( group.getGroupImageUrl() )
                 .memberCount( memberCount )
                 .limitCount( group.getLimitCount() )
-                .leaderId( groupLeader.getId() )
-                .leaderName( groupLeader.getNickname() )
+                .leaderId( group.getLeader().getId() )
+                .leaderName( group.getLeader().getNickname() )
                 .groupTags( groupTagNameList )
                 .build();
     }

--- a/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupDetailResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupDetailResponseDto.java
@@ -34,7 +34,7 @@ public class MyGroupDetailResponseDto {
                 .onlineCount(onlineCount)
                 .memberCount(group.getGroupMembers().size()) // 추가쿼리 발생
                 .limitCount(group.getLimitCount())
-                .leaderName(group.getLeaderName()) // 추가쿼리 발생
+                .leaderName(group.getLeader().getNickname()) // 추가쿼리 발생
                 .notice(group.getNotice())
                 .groupTags(eachGroupTagDtos)
                 .build();

--- a/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupResponseDto.java
@@ -30,7 +30,7 @@ public class MyGroupResponseDto {
                 .onlineCount(onlineCount)
                 .memberCount(group.getGroupMembers().size()) // 추가쿼리 발생
                 .limitCount(group.getLimitCount())
-                .leaderName(group.getLeaderName()) // 추가쿼리 발생
+                .leaderName(group.getLeader().getNickname()) // 추가쿼리 발생
                 .groupTags(eachGroupTagDtos)
                 .build();
     }

--- a/src/main/java/scs/planus/domain/group/entity/Group.java
+++ b/src/main/java/scs/planus/domain/group/entity/Group.java
@@ -3,6 +3,7 @@ package scs.planus.domain.group.entity;
 import lombok.*;
 import scs.planus.domain.BaseTimeEntity;
 import scs.planus.domain.Status;
+import scs.planus.domain.member.entity.Member;
 import scs.planus.global.exception.PlanusException;
 
 import javax.persistence.*;
@@ -67,12 +68,12 @@ public class Group extends BaseTimeEntity {
                 .build();
     }
 
-    public String getLeaderName() {
+    public Member getLeader() {
         return this.getGroupMembers().stream()
                 .filter( GroupMember::isLeader )
                 .findFirst()
                 .orElseThrow(() -> new PlanusException(NOT_EXIST_LEADER))
-                .getMember().getNickname();
+                .getMember();
     }
 
     public void updateDetail(int limitCount, String groupImageUrl ) {

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -3,6 +3,7 @@ package scs.planus.domain.group.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import scs.planus.domain.group.dto.GroupMembersCountDto;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
 import scs.planus.domain.member.entity.Member;
@@ -53,4 +54,18 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             "where gm.member= :member " +
             "and gm.leader= true")
     List<GroupMember> findWithGroupByLeaderMember(@Param("member") Member member);
+
+    @Query("select gm from GroupMember gm " +
+            "join gm.group g " +
+            "join fetch gm.member m " +
+            "where gm.leader= true " +
+            "and g in :groups")
+    List<GroupMember> findAllGroupLeaderInGroups(@Param("groups") List<Group> groups);
+
+    @Query("select g.id as groupId, COUNT(*) as count from GroupMember gm " +
+            "join gm.group g " +
+            "where g in :groups " +
+            "group by g.id ")
+    List<GroupMembersCountDto> findAllGroupMembersCount(@Param("groups") List<Group> groups);
+
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -3,7 +3,6 @@ package scs.planus.domain.group.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import scs.planus.domain.group.dto.GroupMembersCountDto;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
 import scs.planus.domain.member.entity.Member;
@@ -54,18 +53,5 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             "where gm.member= :member " +
             "and gm.leader= true")
     List<GroupMember> findWithGroupByLeaderMember(@Param("member") Member member);
-
-    @Query("select gm from GroupMember gm " +
-            "join gm.group g " +
-            "join fetch gm.member m " +
-            "where gm.leader= true " +
-            "and g in :groups")
-    List<GroupMember> findAllGroupLeaderInGroups(@Param("groups") List<Group> groups);
-
-    @Query("select g.id as groupId, COUNT(*) as count from GroupMember gm " +
-            "join gm.group g " +
-            "where g in :groups " +
-            "group by g.id ")
-    List<GroupMembersCountDto> findAllGroupMembersCount(@Param("groups") List<Group> groups);
 
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupRepository.java
@@ -1,13 +1,21 @@
 package scs.planus.domain.group.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import scs.planus.domain.group.entity.Group;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
+
+    @Query("select g from Group g " +
+            "where g.status= 'ACTIVE' " +
+            "order by g.groupMembers.size desc, g.id desc ")
+    List<Group> findAllByActiveOrderByNumOfMembersAndId(Pageable pageable);
+
     @Query("select distinct g " +
             "from Group g " +
             "join fetch g.groupMembers gm " +

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -41,7 +41,7 @@ public class GroupService {
     private final GroupTagService groupTagService;
     private final TagService tagService;
 
-    public List<GroupsGetResponseDto> getGroupsOrderByNumOfMembers(Pageable pageable) {
+    public List<GroupsGetResponseDto> getGroupsSearchHome(Pageable pageable) {
 
         List<Group> groups = groupRepository.findAllByActiveOrderByNumOfMembersAndId(pageable);
 

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -268,6 +268,7 @@ public class GroupService {
         return GroupMemberResponseDto.of( withdrawGroupMember );
     }
 
+    // TODO MyGroupService 내 동일 메서드 존재 -> 추후 통합 리펙토링 고려
     private List<GroupTagResponseDto> getEachGroupTags(Group group, List<GroupTag> allGroupTags) {
         return allGroupTags.stream()
                 .filter(groupTag -> groupTag.getGroup().getId().equals(group.getId()))

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -5,25 +5,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import scs.planus.domain.group.dto.GroupCreateRequestDto;
-import scs.planus.domain.group.dto.GroupDetailUpdateRequestDto;
-import scs.planus.domain.group.dto.GroupGetMemberResponseDto;
-import scs.planus.domain.group.dto.GroupGetResponseDto;
-import scs.planus.domain.group.dto.GroupJoinGetResponseDto;
-import scs.planus.domain.group.dto.GroupJoinResponseDto;
-import scs.planus.domain.group.dto.GroupMemberResponseDto;
-import scs.planus.domain.group.dto.GroupNoticeUpdateRequestDto;
-import scs.planus.domain.group.dto.GroupResponseDto;
-import scs.planus.domain.group.dto.GroupTagResponseDto;
+import scs.planus.domain.group.dto.*;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupJoin;
 import scs.planus.domain.group.entity.GroupMember;
 import scs.planus.domain.group.entity.GroupTag;
-import scs.planus.domain.group.repository.GroupJoinRepository;
-import scs.planus.domain.group.repository.GroupMemberQueryRepository;
-import scs.planus.domain.group.repository.GroupMemberRepository;
-import scs.planus.domain.group.repository.GroupRepository;
-import scs.planus.domain.group.repository.GroupTagRepository;
+import scs.planus.domain.group.repository.*;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.domain.tag.dto.TagCreateRequestDto;
@@ -74,7 +61,7 @@ public class GroupService {
         return GroupResponseDto.of( saveGroup );
     }
 
-    public GroupGetResponseDto getGroupDetailForNonMember( Long memberId, Long groupId ) {
+    public GroupGetDetailResponseDto getGroupDetailForNonMember(Long memberId, Long groupId ) {
         Group group = groupRepository.findWithGroupMemberById( groupId )
                 .orElseThrow(() ->  new PlanusException( NOT_EXIST_GROUP ));
 
@@ -91,7 +78,7 @@ public class GroupService {
                         .map( GroupTagResponseDto::of )
                         .collect( Collectors.toList() );
 
-        return GroupGetResponseDto.of( group, groupTagResponseDtos, isJoined );
+        return GroupGetDetailResponseDto.of( group, groupTagResponseDtos, isJoined );
     }
 
     public List<GroupGetMemberResponseDto> getGroupMemberForNonMember(Long groupId) {

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -47,17 +47,11 @@ public class GroupService {
 
         List<GroupTag> allGroupTags = groupTagRepository.findAllTagInGroups(groups);
 
-        List<GroupMember> allGroupLeaders = groupMemberRepository.findAllGroupLeaderInGroups(groups);
-
-        List<GroupMembersCountDto> allGroupMembersCount = groupMemberRepository.findAllGroupMembersCount(groups);
-
         List<GroupsGetResponseDto> groupsGetResponseDtos = groups.stream()
                 .map(group -> {
                     List<GroupTagResponseDto> eachGroupTags = getEachGroupTags(group, allGroupTags);
-                    Member eachGroupLeader = getEachGroupLeader(group, allGroupLeaders);
-                    int eachGroupMembersCount = getEachGroupMembersCount(group, allGroupMembersCount);
 
-                    return GroupsGetResponseDto.of(group, eachGroupMembersCount, eachGroupLeader, eachGroupTags);
+                    return GroupsGetResponseDto.of(group, eachGroupTags);
                 })
                 .collect(Collectors.toList());
 
@@ -279,24 +273,6 @@ public class GroupService {
                 .filter(groupTag -> groupTag.getGroup().getId().equals(group.getId()))
                 .map(GroupTagResponseDto::of)
                 .collect(Collectors.toList());
-    }
-
-    private Member getEachGroupLeader(Group group, List<GroupMember> allGroupLeaders) {
-        GroupMember groupLeader = allGroupLeaders.stream()
-                .filter(gm -> gm.getGroup().getId().equals(group.getId()))
-                .findFirst()
-                .orElseThrow(() -> new PlanusException(NOT_EXIST_LEADER));
-
-        return groupLeader.getMember();
-    }
-
-    private int getEachGroupMembersCount(Group group, List<GroupMembersCountDto> allGroupMembersCount) {
-        GroupMembersCountDto groupMembersCountDto = allGroupMembersCount.stream()
-                .filter(c -> c.getGroupId().equals(group.getId()))
-                .findFirst()
-                .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
-
-        return groupMembersCountDto.getCount();
     }
 
     private void validateLeaderPermission( Member member, Group group ) {


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
### 🔥 getGroupSearchHome() API 구현
- 페이징을 위해 `Pageable` 인터페이스를 적용하였습니다.
- 클라이언트가 요청한 `page` 와 `size` 에 따라 Active 상태의 그룹들 중, 회원 수와 최근 생성 순으로 Group 들을 조회하는 쿼리를 구현하였습니다.
- 😢 기존에 fetch join 을 통해 가져오던 그룹 리더 쿼리 및 메소드를 삭제 하고, batch fetch 를 적용하여 `group` 객체를 통해 조회하도록 변경함으로써, N + 1 문제를 해결하고 성능을 개선하였습니다.
- 😢 이 또한 `COUNT`  통해 각 그룹의 회원수를 직접 가져오는 쿼리 및 메소드를 삭제 하고, batch fetch 를 적용하여 `group` 객체를 통해 조회하도록 변경함으로써, N + 1 문제를 해결하고 성능을 개선하였습니다.


### :: 특이사항
### 🔥 Group 엔티티 내부 메소드 `String getLeaderName()` -> `Member getLeader()` 로 변경
- 추후 확장성을 위해 리더의 이름만 반환하던 `String getLeaderName()` 를 리더 `Member` 자체를 반환하는 `Member getLeader()` 로 변경하였습니다.
- 이전에 `group.getLeaderName()` 으로 사용하던 코드는  `group.getLeader().getNickName()` 으로 수정하였습니다.
