### PR TITLE
[Refactor] 역할 분담을 위해 기존의 GroupController 에 있던 그룹 가입 관련 API를 GroupJoinController 로 이전

### DIFF
--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -101,48 +101,6 @@ public class GroupController {
         return new BaseResponse<>( responseDto );
     }
 
-    @PostMapping("/groups/{groupId}/joins")
-    @Operation(summary = "그룹 가입 요청 API")
-    public BaseResponse<GroupJoinResponseDto> joinGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                        @PathVariable("groupId") Long groupId ) {
-        Long memberId = principalDetails.getId();
-        GroupJoinResponseDto responseDto = groupService.joinGroup( memberId, groupId );
-
-        return new BaseResponse<>( responseDto );
-    }
-
-    @GetMapping("/groups/joins")
-    @Operation(summary = "(리더용) 그룹의 모든 가입 요청 조회 API")
-    public BaseResponse<List<GroupJoinGetResponseDto>> getAllGroupJoin(@AuthenticationPrincipal PrincipalDetails principalDetails) {
-
-        Long memberId = principalDetails.getId();
-        List<GroupJoinGetResponseDto> responseDto = groupService.getAllGroupJoin( memberId );
-
-        return new BaseResponse<>( responseDto );
-    }
-
-    @PostMapping("/groups/joins/{groupJoinId}/accept")
-    @Operation(summary = "(리더용) 그룹 가입 요청 수락 API")
-    public BaseResponse<GroupMemberResponseDto> acceptGroupJoin(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                @PathVariable("groupJoinId") Long groupJoinId ){
-
-        Long memberId = principalDetails.getId();
-        GroupMemberResponseDto responseDto = groupService.acceptGroupJoin( memberId, groupJoinId );
-
-        return new BaseResponse<>( responseDto );
-    }
-
-    @PostMapping("/groups/joins/{groupJoinId}/reject")
-    @Operation(summary = "(리더용) 그룹 가입 요청 거절 API")
-    public BaseResponse<GroupJoinResponseDto> rejectGroupJoin(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                              @PathVariable("groupJoinId") Long groupJoinId ){
-
-        Long memberId = principalDetails.getId();
-        GroupJoinResponseDto responseDto = groupService.rejectGroupJoin( memberId, groupJoinId );
-
-        return new BaseResponse<>( responseDto );
-    }
-
     @DeleteMapping("/groups/{groupId}/members/{memberId}")
     @Operation(summary = "(리더용) 그룹 회원 강제 탈퇴 API")
     public BaseResponse<GroupMemberResponseDto> withdrawGroupMember(@AuthenticationPrincipal PrincipalDetails principalDetails,

--- a/src/main/java/scs/planus/domain/group/controller/GroupJoinController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupJoinController.java
@@ -1,0 +1,68 @@
+package scs.planus.domain.group.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import scs.planus.domain.group.dto.groupJoin.GroupJoinGetResponseDto;
+import scs.planus.domain.group.dto.groupJoin.GroupJoinResponseDto;
+import scs.planus.domain.group.dto.GroupMemberResponseDto;
+import scs.planus.domain.group.service.GroupJoinService;
+import scs.planus.global.auth.entity.PrincipalDetails;
+import scs.planus.global.common.response.BaseResponse;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/app")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Group Join", description = "Group Join API Document")
+public class GroupJoinController {
+
+    private final GroupJoinService groupJoinService;
+
+    @PostMapping("/group-joins/groups/{groupId}")
+    @Operation(summary = "그룹 가입 요청 API")
+    public BaseResponse<GroupJoinResponseDto> joinGroup(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                        @PathVariable("groupId") Long groupId ) {
+        Long memberId = principalDetails.getId();
+        GroupJoinResponseDto responseDto = groupJoinService.joinGroup( memberId, groupId );
+
+        return new BaseResponse<>( responseDto );
+    }
+
+    @GetMapping("/group-joins")
+    @Operation(summary = "(리더용) 그룹의 모든 가입 요청 조회 API")
+    public BaseResponse<List<GroupJoinGetResponseDto>> getAllGroupJoin(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+
+        Long memberId = principalDetails.getId();
+        List<GroupJoinGetResponseDto> responseDto = groupJoinService.getAllGroupJoin( memberId );
+
+        return new BaseResponse<>( responseDto );
+    }
+
+    @PostMapping("/group-joins/{groupJoinId}/accept")
+    @Operation(summary = "(리더용) 그룹 가입 요청 수락 API")
+    public BaseResponse<GroupMemberResponseDto> acceptGroupJoin(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                                @PathVariable("groupJoinId") Long groupJoinId ){
+
+        Long memberId = principalDetails.getId();
+        GroupMemberResponseDto responseDto = groupJoinService.acceptGroupJoin( memberId, groupJoinId );
+
+        return new BaseResponse<>( responseDto );
+    }
+
+    @PostMapping("/group-joins/{groupJoinId}/reject")
+    @Operation(summary = "(리더용) 그룹 가입 요청 거절 API")
+    public BaseResponse<GroupJoinResponseDto> rejectGroupJoin(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                              @PathVariable("groupJoinId") Long groupJoinId ){
+
+        Long memberId = principalDetails.getId();
+        GroupJoinResponseDto responseDto = groupJoinService.rejectGroupJoin( memberId, groupJoinId );
+
+        return new BaseResponse<>( responseDto );
+    }
+}

--- a/src/main/java/scs/planus/domain/group/dto/groupJoin/GroupJoinGetResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/groupJoin/GroupJoinGetResponseDto.java
@@ -1,4 +1,4 @@
-package scs.planus.domain.group.dto;
+package scs.planus.domain.group.dto.groupJoin;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/scs/planus/domain/group/dto/groupJoin/GroupJoinResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/groupJoin/GroupJoinResponseDto.java
@@ -1,4 +1,4 @@
-package scs.planus.domain.group.dto;
+package scs.planus.domain.group.dto.groupJoin;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/scs/planus/domain/group/service/GroupJoinService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupJoinService.java
@@ -1,0 +1,130 @@
+package scs.planus.domain.group.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import scs.planus.domain.group.dto.groupJoin.GroupJoinGetResponseDto;
+import scs.planus.domain.group.dto.groupJoin.GroupJoinResponseDto;
+import scs.planus.domain.group.dto.GroupMemberResponseDto;
+import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.group.entity.GroupJoin;
+import scs.planus.domain.group.entity.GroupMember;
+import scs.planus.domain.group.repository.GroupJoinRepository;
+import scs.planus.domain.group.repository.GroupMemberQueryRepository;
+import scs.planus.domain.group.repository.GroupMemberRepository;
+import scs.planus.domain.group.repository.GroupRepository;
+import scs.planus.domain.member.entity.Member;
+import scs.planus.domain.member.repository.MemberRepository;
+import scs.planus.global.exception.PlanusException;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static scs.planus.global.exception.CustomExceptionStatus.*;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class GroupJoinService {
+    private final MemberRepository memberRepository;
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupMemberQueryRepository groupMemberQueryRepository;
+    private final GroupJoinRepository groupJoinRepository;
+
+    @Transactional
+    public GroupJoinResponseDto joinGroup(Long memberId, Long groupId ) {
+        Group group = groupRepository.findByIdAndStatus(groupId)
+                .orElseThrow(() -> { throw new PlanusException( NOT_EXIST_GROUP ); });
+
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+
+        groupJoinRepository.findByMemberIdAndGroupId(memberId, groupId)
+                .ifPresent(groupJoin -> {
+                    throw new PlanusException(ALREADY_APPLY_JOINED_GROUP);});
+
+        List<GroupMember> allGroupMembers = groupMemberRepository.findAllWithMemberByGroupAndStatus( group );
+
+        // 제한 인원 초과 검증
+        validateExceedLimit( group, allGroupMembers );
+
+        // 가입 여부 검증
+        Boolean isJoined = groupMemberQueryRepository.existByMemberIdAndGroupId( member.getId(), groupId );
+        if (isJoined) {throw new PlanusException( ALREADY_JOINED_GROUP );}
+
+        GroupJoin groupJoin = GroupJoin.createGroupJoin( member, group );
+        GroupJoin saveGroupJoin = groupJoinRepository.save( groupJoin );
+
+        return GroupJoinResponseDto.of( saveGroupJoin );
+    }
+
+    public List<GroupJoinGetResponseDto> getAllGroupJoin(Long memberId ) {
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+
+        // 내가 리더인 그룹들 조회
+        List<GroupMember> groupMembers = groupMemberRepository.findWithGroupByLeaderMember(member);
+        List<Group> groups = groupMembers.stream()
+                .map(GroupMember::getGroup)
+                .collect(Collectors.toList());
+
+        // 내가 리더인 그룹에 들어온 가입 신청 조회
+        List<GroupJoin> allGroupJoinsOfGroups = groupJoinRepository.findAllByGroupIn(groups);
+
+        return allGroupJoinsOfGroups.stream()
+                .map(GroupJoinGetResponseDto::of)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public GroupMemberResponseDto acceptGroupJoin(Long memberId, Long groupJoinId ) {
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+
+        GroupJoin groupJoin = groupJoinRepository.findWithGroupById( groupJoinId )
+                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP_JOIN ));
+
+        validateLeaderPermission( member, groupJoin.getGroup() );
+
+        GroupMember groupMember = GroupMember.creatGroupMember( groupJoin.getMember(), groupJoin.getGroup() );
+        GroupMember saveGroupMember = groupMemberRepository.save( groupMember );
+
+        groupJoinRepository.delete( groupJoin );
+
+        return GroupMemberResponseDto.of( saveGroupMember );
+    }
+
+    @Transactional
+    public GroupJoinResponseDto rejectGroupJoin( Long memberId, Long groupJoinId ) {
+        Member member = memberRepository.findById( memberId )
+                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+
+        GroupJoin groupJoin = groupJoinRepository.findWithGroupById( groupJoinId )
+                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP_JOIN ));
+
+        validateLeaderPermission( member, groupJoin.getGroup() );
+
+        groupJoinRepository.delete( groupJoin );
+
+        return GroupJoinResponseDto.of( groupJoin );
+    }
+
+    private void validateExceedLimit( Group group, List<GroupMember> allGroupMembers ) {
+        // 제한 인원을 초과하지 않았는지
+        if ( allGroupMembers.size() >= group.getLimitCount() ) {
+            throw new PlanusException( EXCEED_GROUP_LIMIT_COUNT );
+        }
+    }
+
+    // TODO GroupJoinService 내 동일 메서드 존재 -> GroupValidate Class 로 빼는것 고려
+    private void validateLeaderPermission( Member member, Group group ) {
+        GroupMember groupLeader = groupMemberRepository.findWithGroupAndLeaderByGroup( group )
+                .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_LEADER ); });
+
+        if ( !member.equals( groupLeader.getMember() ) )
+            throw new PlanusException( NOT_GROUP_LEADER_PERMISSION );
+    }
+}


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
### 📚 그룹 관련 API 는 다음과 같습니다.
- [Post] 그룹 가입 요청
- [Get] (리더용) 그룹의 모든 가입 요청 조회
- [Post] (리더용) 그룹 가입 요청 수락
- [Post] (리더용) 그룹 가입 요청 거절

### 📚 그룹 관련 기능은 다음과 같습니다.
- public GroupJoinResponseDto **joinGroup**(Long memberId, Long groupId )
- public List<GroupJoinGetResponseDto> **getAllGroupJoin**(Long memberId )
- public GroupMemberResponseDto **acceptGroupJoin**(Long memberId, Long groupJoinId )
- public GroupJoinResponseDto **rejectGroupJoin**( Long memberId, Long groupJoinId )
- private void **validateExceedLimit**( Group group, List<GroupMember> allGroupMembers )

### :: 특이사항
### ⚠️  `validateLeaderPermission` 중복
- private void **validateLeaderPermission**( Member member, Group group )
- 위 메소드는 `GroupService` 와 중복됩니다.
- 추후에 GroupValidate Class 를 만들어 Group 에서 쓰이는 모든 validator 를 모아두는 것을 제안합니다!
