### PR TITLE
[Feat] 그룹 자발적 탈퇴 API 구현

### DIFF
--- a/src/main/java/scs/planus/domain/group/controller/GroupController.java
+++ b/src/main/java/scs/planus/domain/group/controller/GroupController.java
@@ -123,4 +123,14 @@ public class GroupController {
         return new BaseResponse<>(responseDto);
     }
 
+    @DeleteMapping("/groups/{groupId}/withdraw")
+    @Operation(summary = "(회원용) 그룹 자발적 탈퇴 API")
+    public BaseResponse<GroupMemberResponseDto> withdraw(@AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                         @PathVariable("groupId") Long groupId) {
+        Long memberId = principalDetails.getId();
+        GroupMemberResponseDto responseDto = groupService.softWithdraw(memberId, groupId);
+
+        return new BaseResponse<>(responseDto);
+    }
+
 }

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -204,6 +204,20 @@ public class GroupService {
         return GroupMemberResponseDto.of( withdrawGroupMember );
     }
 
+    @Transactional
+    public GroupMemberResponseDto softWithdraw( Long memberId, Long groupId ) {
+        GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId)
+                .orElseThrow(() -> {
+                    groupRepository.findByIdAndStatus(groupId)
+                            .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
+                    return new PlanusException(NOT_JOINED_GROUP);
+                });
+
+        groupMember.changeStatusToInactive();
+
+        return GroupMemberResponseDto.of( groupMember );
+    }
+
     // TODO MyGroupService 내 동일 메서드 존재 -> 추후 통합 리펙토링 고려
     private List<GroupTagResponseDto> getEachGroupTags(Group group, List<GroupTag> allGroupTags) {
         return allGroupTags.stream()

--- a/src/main/java/scs/planus/domain/group/service/GroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupService.java
@@ -206,12 +206,14 @@ public class GroupService {
 
     @Transactional
     public GroupMemberResponseDto softWithdraw( Long memberId, Long groupId ) {
-        GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId(memberId, groupId)
+        GroupMember groupMember = groupMemberRepository.findByMemberIdAndGroupId( memberId, groupId )
                 .orElseThrow(() -> {
-                    groupRepository.findByIdAndStatus(groupId)
-                            .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP));
-                    return new PlanusException(NOT_JOINED_GROUP);
+                    groupRepository.findByIdAndStatus( groupId )
+                            .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
+                    return new PlanusException( NOT_JOINED_GROUP );
                 });
+
+        if ( groupMember.isLeader() ) {throw new PlanusException( CANNOT_WITHDRAW );}
 
         groupMember.changeStatusToInactive();
 

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -44,6 +44,7 @@ public enum CustomExceptionStatus implements ResponseStatus {
     NOT_EXIST_GROUP_JOIN(BAD_REQUEST, 2605, "존재 하지 않는 그룹 가입 신청서 입니다."),
     DO_NOT_HAVE_TODO_AUTHORITY(BAD_REQUEST, 2606, "그룹 투두 권한이 없습니다."),
     ALREADY_APPLY_JOINED_GROUP(BAD_REQUEST, 2607, "이미 가입 신청한 그룹입니다."),
+    CANNOT_WITHDRAW(BAD_REQUEST, 2608, "탈퇴가 불가능합니다."),
 
     // groupMember excepion
     NOT_JOINED_GROUP(BAD_REQUEST, 2700, "가입하지 않은 그룹 입니다."),


### PR DESCRIPTION
### :: PR 타입
- [x] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 회원용 그룹 자발적 탈퇴 API 를 구현하였습니다.
- 기존에 구현해놨던 GroupMember 엔티티 내장 메소드 `changeStatusToInactive()` 를 그대로 사용하였습니다.

### :: 특이사항
- 
