### PR TITLE
[Fix] 그룹투두 생성 이후 가입한 멤버 캘린더 조회할 때의 오류 수정

### DIFF
--- a/src/main/java/scs/planus/domain/todo/dto/TodoDetailsResponseDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/TodoDetailsResponseDto.java
@@ -1,6 +1,7 @@
 package scs.planus.domain.todo.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Getter;
 import scs.planus.domain.todo.entity.GroupTodo;
@@ -28,6 +29,7 @@ public class TodoDetailsResponseDto {
     private LocalTime startTime;
     private String description;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Boolean isCompleted;
 
     public static TodoDetailsResponseDto of(Todo todo) {
@@ -54,7 +56,7 @@ public class TodoDetailsResponseDto {
                 .endDate(todo.getEndDate())
                 .startTime(todo.getStartTime())
                 .description(todo.getDescription())
-                .isCompleted(completion.isCompletion())
+                .isCompleted(completion == null ? null : completion.isCompletion())
                 .build();
     }
 }

--- a/src/main/java/scs/planus/domain/todo/dto/calendar/TodoDailyDto.java
+++ b/src/main/java/scs/planus/domain/todo/dto/calendar/TodoDailyDto.java
@@ -65,7 +65,7 @@ public class TodoDailyDto {
                 .isGroupTodo(todo.isGroupTodo())
                 .isPeriodTodo(todo.getEndDate().isAfter(todo.getStartDate()))
                 .hasDescription(todo.getDescription() != null)
-                .isCompleted(completion.isCompletion())
+                .isCompleted(completion == null ? null : completion.isCompletion())
                 .build();
     }
 }

--- a/src/main/java/scs/planus/domain/todo/service/calendar/GroupTodoCalendarService.java
+++ b/src/main/java/scs/planus/domain/todo/service/calendar/GroupTodoCalendarService.java
@@ -101,6 +101,10 @@ public class GroupTodoCalendarService {
                 .orElseThrow(() -> new PlanusException(NOT_JOINED_MEMBER_IN_GROUP));
 
         List<Todo> todos = todoQueryRepository.findGroupMemberDailyTodosByDate(memberId, groupId, date);
+
+        for (Todo todo : todos) {
+            log.info("todo={}", todo.getTitle());
+        }
         List<GroupTodoCompletion> groupTodoCompletions = groupTodoCompletionRepository.findAllByMemberIdOnGroupId(memberId, groupId);
 
         List<TodoDailyDto> allTodos = getAllGroupMemberTodos(todos, groupTodoCompletions);
@@ -140,7 +144,7 @@ public class GroupTodoCalendarService {
                     }
                     GroupTodoCompletion todoCompletion = groupTodoCompletions.stream()
                             .filter(groupTodoCompletion -> groupTodoCompletion.getGroupTodo().equals(todo))
-                            .findFirst().orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP_TODO_COMPLETION));
+                            .findFirst().orElse(null);
                     return TodoDailyDto.ofGroupTodo((GroupTodo) todo, todoCompletion);
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/scs/planus/domain/todo/service/calendar/GroupTodoCalendarService.java
+++ b/src/main/java/scs/planus/domain/todo/service/calendar/GroupTodoCalendarService.java
@@ -102,9 +102,6 @@ public class GroupTodoCalendarService {
 
         List<Todo> todos = todoQueryRepository.findGroupMemberDailyTodosByDate(memberId, groupId, date);
 
-        for (Todo todo : todos) {
-            log.info("todo={}", todo.getTitle());
-        }
         List<GroupTodoCompletion> groupTodoCompletions = groupTodoCompletionRepository.findAllByMemberIdOnGroupId(memberId, groupId);
 
         List<TodoDailyDto> allTodos = getAllGroupMemberTodos(todos, groupTodoCompletions);

--- a/src/main/java/scs/planus/domain/todo/service/calendar/MemberTodoCalendarService.java
+++ b/src/main/java/scs/planus/domain/todo/service/calendar/MemberTodoCalendarService.java
@@ -16,14 +16,11 @@ import scs.planus.domain.todo.entity.GroupTodoCompletion;
 import scs.planus.domain.todo.entity.MemberTodo;
 import scs.planus.domain.todo.repository.GroupTodoCompletionRepository;
 import scs.planus.domain.todo.repository.TodoQueryRepository;
-import scs.planus.global.exception.PlanusException;
 import scs.planus.global.util.validator.Validator;
 
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static scs.planus.global.exception.CustomExceptionStatus.NOT_EXIST_GROUP_TODO_COMPLETION;
 
 @Service
 @Transactional(readOnly = true)
@@ -56,8 +53,7 @@ public class MemberTodoCalendarService {
                 .map(todo -> {
                     GroupTodoCompletion todoCompletion = groupTodoCompletions.stream()
                             .filter(groupTodoCompletion -> groupTodoCompletion.getGroupTodo().equals(todo))
-                            .findFirst()
-                            .orElseThrow(() -> new PlanusException(NOT_EXIST_GROUP_TODO_COMPLETION));
+                            .findFirst().orElse(null);
                     return TodoDetailsResponseDto.ofGroupTodo(todo, todoCompletion);
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [X]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 그룹투두 생성 이후 가입한 멤버 캘린더 조회할 때의 오류 수정

### :: 특이사항
- 현재 로직 상, 그룹투두가 생성된 이후 가입한 멤버라도, 이전에 그룹투두들을 개인캘린더, 혹은 그룹멤버캘린더에서 확인할 수 있습니다.
- 이로 인해, 이전에 생성된 그룹투두에 대해 GroupTodoCompletion이 null값이여서 GroupTodoCompletion Exception이 발생하던 점을 해결하였습니다.
   - `orElseThrow()` 대신, `orElse(null)`을 호출하고, responseDTO에 null 확인 조건을 추가하여 이를 해결하였습니다.