### PR TITLE
[Fix] 탈퇴한 기록이 있는 그룹회원이 재가입하는 경우, INACTIVE 상태인 GroupMember 가 쌓이는 버그 해결

### DIFF
--- a/src/main/java/scs/planus/domain/group/entity/GroupMember.java
+++ b/src/main/java/scs/planus/domain/group/entity/GroupMember.java
@@ -70,4 +70,8 @@ public class GroupMember extends BaseTimeEntity {
     public void changeStatusToInactive() {
         this.status = Status.INACTIVE;
     }
+
+    public void changeStatusToActive() {
+        this.status = Status.ACTIVE;
+    }
 }

--- a/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/scs/planus/domain/group/repository/GroupMemberRepository.java
@@ -26,6 +26,13 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
     Optional<GroupMember> findByMemberIdAndGroupId(@Param("memberId") Long memberId,
                                                    @Param("groupId") Long groupId);
 
+    @Query("select gm from GroupMember gm " +
+            "join fetch gm.group g " +
+            "join fetch gm.member m " +
+            "where m.id = :memberId and g.id = :groupId and gm.status = 'INACTIVE'")
+    Optional<GroupMember> findByMemberIdAndGroupIdAndInactive(@Param("memberId") Long memberId,
+                                                              @Param("groupId") Long groupId);
+
     @Query("select gm " +
             "from GroupMember gm " +
             "join fetch gm.group g " +


### PR DESCRIPTION
### :: PR 타입
- [x] 기능 추가 🔨
- [x]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 그룹에서 탈퇴한 GroupMember는 DB 상에서 삭제되지 않고, 상태만 변경되는(active -> inactive) soft deleting 을 합니다.
- 탈퇴한 기록이 있는 GroupMember 가 해당 그룹에 재가입신청 후, 승인을 받게 되면 `Status.INACTIVE` 인 GroupMember와 `Status.ACTIVE` 인 GroupMember 가 공존하게 되는 버그를 발견했습니다.
- 이를 해결하기 위해 그룹에 가입신청 시, 신청자의 `memberId` 와 `groupId` 로된 GroupMember 가 존재하면 상태만 변경, 존재하지 않으면 GroupMember 를 새로만들어주도록 수정하였습니다.

### 🔥  `GroupJoinService`
<img width="1034" alt="image" src="https://github.com/Planus-SCS/Planus-Backend/assets/54929830/ae2289fb-156f-48e1-873b-12eca3293aa7">
- Optional의 기능을 활용하여, GroupMember가 존재할 경우, map()을 통해 상태만 변경해준 뒤, 반환 해줍니다.
- 존재하지 않을 경우(null 인경우), orElseGet() 을 활용하여 람다식으로 새로운 GroupMember를 생성 후, 저장, 반환 해줍니다.

### 🔥  `GroupMemberRespository` 
- `Status.INACTIVE` 인 GroupMember 를 조회하는 `findByMemberIdAndGroupIdAndInactive()` 쿼리를 추가 구현하였습니다.
- 대부분의 쿼리에서는 `Status.ACTIVE` 가 디폴트 조건임으로, `Status.INACTIVE` 를 조건으로 거는 쿼리 메소드명에 `Inactive` 를 붙였습니다.

### 🔥  `GroupMember` 엔티티
- `Status.INACTIVE` -> `Status.ACTIVE` 로 변경하는 메소드를 추가하였습니다.

### :: 특이사항
- 
