### PR TITLE
[Test] GroupTag, GroupTagRepository, GroupTagService 단 테스트 코드 구현

### DIFF
--- a/src/test/java/scs/planus/domain/group/entity/GroupTagTest.java
+++ b/src/test/java/scs/planus/domain/group/entity/GroupTagTest.java
@@ -12,6 +12,8 @@ import java.util.stream.IntStream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class GroupTagTest {
+    private static final int TAG_COUNT = 10;
+
     private Group group;
     private List<Tag> tags;
 
@@ -20,7 +22,7 @@ class GroupTagTest {
         group = Group.builder()
                 .build();
 
-        tags = IntStream.range(0, 5)
+        tags = IntStream.range(0, TAG_COUNT)
                 .mapToObj(i -> Tag.builder()
                         .build()
                 )
@@ -35,7 +37,7 @@ class GroupTagTest {
         List<GroupTag> groupTags = GroupTag.create(group, tags);
 
         // then
-        assertThat(groupTags).hasSize(tags.size());
+        assertThat(groupTags).hasSize(TAG_COUNT);
         assertThat(groupTags.get(0).getGroup()).isEqualTo(group);
     }
 }

--- a/src/test/java/scs/planus/domain/group/entity/GroupTagTest.java
+++ b/src/test/java/scs/planus/domain/group/entity/GroupTagTest.java
@@ -1,0 +1,41 @@
+package scs.planus.domain.group.entity;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import scs.planus.domain.tag.entity.Tag;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GroupTagTest {
+    private Group group;
+    private List<Tag> tags;
+
+    @BeforeEach
+    void init() {
+        group = Group.builder()
+                .build();
+
+        tags = IntStream.range(0, 5)
+                .mapToObj(i -> Tag.builder()
+                        .build()
+                )
+                .collect(Collectors.toList());
+    }
+
+    @DisplayName("List<Tag> 로 GroupTag 를 생성할 수 있다.")
+    @Test
+    void create() {
+        // given
+        // when
+        List<GroupTag> groupTags = GroupTag.create(group, tags);
+
+        // then
+        assertThat(groupTags).hasSize(tags.size());
+        assertThat(groupTags.get(0).getGroup()).isEqualTo(group);
+    }
+}

--- a/src/test/java/scs/planus/domain/group/repository/GroupTagRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/group/repository/GroupTagRepositoryTest.java
@@ -1,0 +1,111 @@
+package scs.planus.domain.group.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.group.entity.GroupTag;
+import scs.planus.domain.tag.entity.Tag;
+import scs.planus.domain.tag.repository.TagRepository;
+import scs.planus.support.RepositoryTest;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RepositoryTest
+class GroupTagRepositoryTest {
+    private static final String TAG_NAME = "테스트 태그 이름";
+    private static final int TAG_COUNT = 10;
+    private static final int GROUP_TAG_COUNT = 5;
+
+    private final GroupRepository groupRepository;
+    private final GroupTagRepository groupTagRepository;
+    private final TagRepository tagRepository;
+
+    private Group group;
+    private List<Tag> tags;
+
+    @Autowired
+    public GroupTagRepositoryTest(GroupRepository groupRepository,
+                                  GroupTagRepository groupTagRepository,
+                                  TagRepository tagRepository) {
+        this.groupRepository = groupRepository;
+        this.groupTagRepository = groupTagRepository;
+        this.tagRepository = tagRepository;
+    }
+
+    @BeforeEach
+    void init() {
+        group = Group.builder()
+                .build();
+
+        groupRepository.save(group);
+
+        tags = IntStream.range(0, TAG_COUNT)
+                .mapToObj(i -> Tag.builder()
+                        .name(TAG_NAME + i)
+                        .build()
+                )
+                .collect(Collectors.toList());
+
+        tagRepository.saveAll(tags);
+
+        List<GroupTag> groupTags = IntStream.range(0, GROUP_TAG_COUNT)
+                .mapToObj(i -> GroupTag.builder()
+                        .group(group)
+                        .tag(tags.get(i))
+                        .build()
+                )
+                .collect(Collectors.toList());
+
+        groupTagRepository.saveAll(groupTags);
+    }
+
+    @DisplayName("Group 으로 GroupTag 들이 Tag 와 함께 조회돼야 한다.")
+    @Test
+    void findAllByGroup() {
+        // given
+        // when
+        List<GroupTag> findGroupTags = groupTagRepository.findAllByGroup(group);
+
+        List<Tag> findTags = findGroupTags.stream()
+                .map(GroupTag::getTag)
+                .collect(Collectors.toList());
+
+        // then
+        assertThat(findGroupTags).hasSize(GROUP_TAG_COUNT);
+        assertThat(findTags).hasSize(GROUP_TAG_COUNT);
+    }
+
+    @DisplayName("List<Group>으로 각 GroupTag 들이 Tag 와 함께 조회돼야 한다.")
+    @Test
+    void findAllTagInGroups() {
+        // given
+        Group group2 = Group.builder()
+                .build();
+
+        groupRepository.save(group2);
+
+        List<GroupTag> group2Tags = IntStream.range(0, 3)
+                .mapToObj(i -> GroupTag.builder()
+                        .group(group2)
+                        .tag(tags.get(i))
+                        .build()
+                )
+                .collect(Collectors.toList());
+
+        groupTagRepository.saveAll(group2Tags);
+
+        List<Group> groups = List.of(group, group2);
+
+        // when
+        List<GroupTag> findGroupTags = groupTagRepository.findAllTagInGroups(groups);
+
+        // then
+        assertThat(findGroupTags).hasSize(GROUP_TAG_COUNT + 3);
+    }
+}

--- a/src/test/java/scs/planus/domain/group/service/GroupTagServiceTest.java
+++ b/src/test/java/scs/planus/domain/group/service/GroupTagServiceTest.java
@@ -1,0 +1,92 @@
+package scs.planus.domain.group.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.group.entity.GroupTag;
+import scs.planus.domain.group.repository.GroupRepository;
+import scs.planus.domain.group.repository.GroupTagRepository;
+import scs.planus.domain.tag.dto.TagCreateRequestDto;
+import scs.planus.domain.tag.entity.Tag;
+import scs.planus.domain.tag.repository.TagRepository;
+import scs.planus.support.ServiceTest;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ServiceTest
+class GroupTagServiceTest {
+    private static final String TAG_NAME = "테스트 태그 이름";
+    private static final int TAG_COUNT = 5;
+
+    private final GroupTagRepository groupTagRepository;
+    private final TagRepository tagRepository;
+    private final GroupRepository groupRepository;
+
+    private final GroupTagService groupTagService;
+
+    private Group group;
+
+    @Autowired
+    public GroupTagServiceTest(GroupTagRepository groupTagRepository,
+                               TagRepository tagRepository,
+                               GroupRepository groupRepository) {
+        this.groupTagRepository = groupTagRepository;
+        this.tagRepository = tagRepository;
+        this.groupRepository = groupRepository;
+
+        groupTagService = new GroupTagService(groupTagRepository);
+    }
+
+    @BeforeEach
+    void init() {
+        group = groupRepository.findById(1L).orElseThrow();
+
+        List<Tag> tags = IntStream.range(0, TAG_COUNT)
+                .mapToObj(i -> Tag.builder()
+                        .name(TAG_NAME + i)
+                        .build()
+                )
+                .collect(Collectors.toList());
+
+        tagRepository.saveAll(tags);
+
+        List<GroupTag> groupTags = IntStream.range(0, TAG_COUNT)
+                .mapToObj(i -> GroupTag.builder()
+                        .group(group)
+                        .tag(tags.get(i))
+                        .build()
+                )
+                .collect(Collectors.toList());
+
+        groupTagRepository.saveAll(groupTags);
+    }
+
+    @DisplayName("수정하고자 하는 5개 태그인 List<TagCreateRequestDto> 중" +
+            "3개가 기존의 GroupTag 와 일치 할때, " +
+            "불필요한 태그 2개는 삭제되고," +
+            "새로 추가할 태그 2개가 반환되어야 한다.")
+    @Test
+    void update() {
+        // given
+        List<TagCreateRequestDto> tagCreateRequestDtos = IntStream.range(2, TAG_COUNT + 2)
+                .mapToObj(i -> TagCreateRequestDto.builder()
+                        .name(TAG_NAME + i)
+                        .build()
+                )
+                .collect(Collectors.toList());
+
+        // when
+        List<TagCreateRequestDto> updateTags = groupTagService.update(group, tagCreateRequestDtos);
+        List<GroupTag> findGroupTags = groupTagRepository.findAllByGroup(group);
+
+        // then
+        assertThat(updateTags).hasSize(2); // 0~4 가 존재하는데 2~6 을 추가했으므로, 5~6 만 추출되어야 한다.
+        assertThat(findGroupTags).hasSize(3); // 추가 태그는 아직 저장안된 상태이고, 5개중 불필요한 태그 2개는 삭제되어있어야 한다.
+    }
+}


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [x]  테스트 🔍

### :: 구현
### `GroupTagTest`
- 테스트 메소드는 하나이나, 확장성을 고려하여 공통이 될 수 있는 부분은 인스턴스 필드와 @BeforEach로 분리했습니다.

### `GroupTagRepositoryTest` & `GroupTagServiceTest`
- 조회 쿼리만 존재하고 최소 하나의 그룹에 대해서 조회 하므로, @BeforEach 를 통해 Group, GroupTag, Tag 한 세트를 생성해두었습니다.
- 추가 Group, GroupTag, Tag 세트가 필요한 경우 `// given` 을 통해 추가하도록 하여, @BeforEach에 너무 많은 객체 생성으로 인한 테스트 속도 저하를 방지하였습니다.

### :: 특이사항
- `TAG_NAME` : 임의의 Tag Name
- `TAG_COUNT` : 반복문을 통해 Tag를 생성할때, 갯수 제한.
- `GROUP_TAG_COUNT` : 반복문을 통해 GroupTag를 생성할때, 갯수 제한
