### PR TITLE
[Test] 의존성 주입 리팩토링

### DIFF
--- a/src/test/java/scs/planus/config/ExternalApiConfig.java
+++ b/src/test/java/scs/planus/config/ExternalApiConfig.java
@@ -1,0 +1,20 @@
+package scs.planus.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@TestConfiguration
+public class ExternalApiConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/scs/planus/domain/group/repository/GroupMemberQueryRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/group/repository/GroupMemberQueryRepositoryTest.java
@@ -1,36 +1,32 @@
 package scs.planus.domain.group.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 import scs.planus.domain.Status;
 import scs.planus.domain.group.entity.Group;
 import scs.planus.domain.group.entity.GroupMember;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
-import scs.planus.global.config.QueryDslConfig;
 import scs.planus.support.RepositoryTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RepositoryTest
-@Import(QueryDslConfig.class)
 class GroupMemberQueryRepositoryTest {
 
-    @Autowired
-    private MemberRepository memberRepository;
-    @Autowired
-    private GroupRepository groupRepository;
-    @Autowired
-    private JPAQueryFactory queryFactory;
+    private final MemberRepository memberRepository;
+    private final GroupRepository groupRepository;
 
-    private GroupMemberQueryRepository groupMemberQueryRepository;
+    private final GroupMemberQueryRepository groupMemberQueryRepository;
 
-    @BeforeEach
-    void init() {
+    @Autowired
+    public GroupMemberQueryRepositoryTest(MemberRepository memberRepository, GroupRepository groupRepository,
+                                          JPAQueryFactory queryFactory) {
+        this.memberRepository = memberRepository;
+        this.groupRepository = groupRepository;
+
         groupMemberQueryRepository = new GroupMemberQueryRepository(queryFactory);
     }
 

--- a/src/test/java/scs/planus/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/scs/planus/domain/member/service/MemberServiceTest.java
@@ -4,9 +4,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
 import scs.planus.domain.Status;
 import scs.planus.domain.member.dto.MemberResponseDto;
@@ -15,41 +15,32 @@ import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.infra.redis.RedisService;
 import scs.planus.infra.s3.AmazonS3Uploader;
-
-import java.util.Optional;
+import scs.planus.support.ServiceTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+@ServiceTest
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
 
-    @InjectMocks
-    private MemberService memberService;
-
-    @Mock
-    private MemberRepository memberRepository;
-
-    @Mock
+    @MockBean
     private AmazonS3Uploader s3Uploader;
-
-    @Mock
+    @MockBean
     private RedisService redisService;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private MemberService memberService;
     private Member member;
 
     @BeforeEach
     void init() {
-        member = Member.builder()
-                .nickname("testNick")
-                .description("testDesc")
-                .profileImageUrl("testImg")
-                .status(Status.ACTIVE)
-                .build();
-
-        given(memberRepository.findById(any())).willReturn(Optional.of(member));
+        memberService = new MemberService(redisService, s3Uploader, memberRepository);
+        member = memberRepository.findById(1L).orElseThrow();
     }
 
     @DisplayName("회원정보를 제대로 응답받아야 한다.")

--- a/src/test/java/scs/planus/domain/todo/repository/TodoQueryRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/todo/repository/TodoQueryRepositoryTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 import scs.planus.domain.Status;
 import scs.planus.domain.category.entity.GroupTodoCategory;
 import scs.planus.domain.category.entity.MemberTodoCategory;
@@ -18,7 +17,6 @@ import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.domain.todo.entity.GroupTodo;
 import scs.planus.domain.todo.entity.MemberTodo;
 import scs.planus.domain.todo.entity.Todo;
-import scs.planus.global.config.QueryDslConfig;
 import scs.planus.support.RepositoryTest;
 
 import java.time.LocalDate;
@@ -27,31 +25,31 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RepositoryTest
-@Import(QueryDslConfig.class)
 class TodoQueryRepositoryTest {
 
     private static final int COUNT = 7;
 
-    @Autowired
-    private MemberRepository memberRepository;
-    @Autowired
-    private GroupRepository groupRepository;
-    @Autowired
-    private TodoCategoryRepository todoCategoryRepository;
-    @Autowired
-    private TodoRepository todoRepository;
-    @Autowired
-    private JPAQueryFactory queryFactory;
+    private final MemberRepository memberRepository;
+    private final GroupRepository groupRepository;
+    private final TodoCategoryRepository todoCategoryRepository;
+    private final TodoRepository todoRepository;
 
-    private TodoQueryRepository todoQueryRepository;
+    private final TodoQueryRepository todoQueryRepository;
 
     private Member member;
     private Todo todo;
     private Group group;
     private GroupTodoCategory groupTodoCategory;
 
-    @BeforeEach
-    void initRepository() {
+    @Autowired
+    public TodoQueryRepositoryTest(MemberRepository memberRepository, GroupRepository groupRepository,
+                                   TodoCategoryRepository todoCategoryRepository, TodoRepository todoRepository,
+                                   JPAQueryFactory queryFactory) {
+        this.memberRepository = memberRepository;
+        this.groupRepository = groupRepository;
+        this.todoCategoryRepository = todoCategoryRepository;
+        this.todoRepository = todoRepository;
+
         todoQueryRepository = new TodoQueryRepository(queryFactory);
     }
 

--- a/src/test/java/scs/planus/domain/todo/service/GroupTodoServiceTest.java
+++ b/src/test/java/scs/planus/domain/todo/service/GroupTodoServiceTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 import scs.planus.domain.Status;
 import scs.planus.domain.category.entity.GroupTodoCategory;
 import scs.planus.domain.category.entity.MemberTodoCategory;
@@ -25,7 +24,6 @@ import scs.planus.domain.todo.entity.Todo;
 import scs.planus.domain.todo.repository.GroupTodoCompletionRepository;
 import scs.planus.domain.todo.repository.TodoQueryRepository;
 import scs.planus.domain.todo.repository.TodoRepository;
-import scs.planus.global.config.QueryDslConfig;
 import scs.planus.global.exception.PlanusException;
 import scs.planus.support.ServiceTest;
 
@@ -34,47 +32,49 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static scs.planus.global.exception.CustomExceptionStatus.*;
 
 @ServiceTest
-@Import(QueryDslConfig.class)
 class GroupTodoServiceTest {
 
     private static final Long NOT_EXIST_ID = 0L;
 
-    @Autowired
-    private MemberRepository memberRepository;
-    @Autowired
-    private GroupRepository groupRepository;
-    @Autowired
-    private GroupMemberRepository groupMemberRepository;
-    @Autowired
-    private GroupTodoCompletionRepository groupTodoCompletionRepository;
-    @Autowired
-    private TodoCategoryRepository todoCategoryRepository;
-    @Autowired
-    private TodoRepository todoRepository;
-    @Autowired
-    private JPAQueryFactory queryFactory;
+    private final MemberRepository memberRepository;
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupTodoCompletionRepository groupTodoCompletionRepository;
+    private final TodoCategoryRepository todoCategoryRepository;
+    private final TodoRepository todoRepository;
 
-    private TodoQueryRepository todoQueryRepository;
-    private GroupTodoService groupTodoService;
+    private final TodoQueryRepository todoQueryRepository;
+    private final GroupTodoService groupTodoService;
 
     private Member groupLeader;
     private Member groupMember;
     private Group group;
     private GroupTodoCategory groupTodoCategory;
 
-    @BeforeEach
-    void init() {
-        todoQueryRepository = new TodoQueryRepository(queryFactory);
+    @Autowired
+    public GroupTodoServiceTest(MemberRepository memberRepository, GroupRepository groupRepository,
+                                GroupMemberRepository groupMemberRepository, GroupTodoCompletionRepository groupTodoCompletionRepository,
+                                TodoCategoryRepository todoCategoryRepository, TodoRepository todoRepository,
+                                JPAQueryFactory queryFactory) {
+        this.memberRepository = memberRepository;
+        this.groupRepository = groupRepository;
+        this.groupMemberRepository = groupMemberRepository;
+        this.groupTodoCompletionRepository = groupTodoCompletionRepository;
+        this.todoCategoryRepository = todoCategoryRepository;
+        this.todoRepository = todoRepository;
 
+        todoQueryRepository = new TodoQueryRepository(queryFactory);
         groupTodoService = new GroupTodoService(
                 groupRepository,
                 groupMemberRepository,
                 groupTodoCompletionRepository,
                 todoCategoryRepository,
                 todoRepository,
-                todoQueryRepository
-        );
+                todoQueryRepository);
+    }
 
+    @BeforeEach
+    void init() {
         groupLeader = memberRepository.findById(1L).orElseThrow();
         groupMember = memberRepository.findById(2L).orElseThrow();
         group = groupRepository.findById(1L).orElseThrow();

--- a/src/test/java/scs/planus/domain/todo/service/MemberTodoServiceTest.java
+++ b/src/test/java/scs/planus/domain/todo/service/MemberTodoServiceTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 import scs.planus.domain.category.entity.MemberTodoCategory;
 import scs.planus.domain.category.repository.TodoCategoryRepository;
 import scs.planus.domain.group.entity.Group;
@@ -20,7 +19,6 @@ import scs.planus.domain.todo.entity.MemberTodo;
 import scs.planus.domain.todo.entity.Todo;
 import scs.planus.domain.todo.repository.TodoQueryRepository;
 import scs.planus.domain.todo.repository.TodoRepository;
-import scs.planus.global.config.QueryDslConfig;
 import scs.planus.global.exception.PlanusException;
 import scs.planus.support.ServiceTest;
 
@@ -31,43 +29,44 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static scs.planus.global.exception.CustomExceptionStatus.*;
 
 @ServiceTest
-@Import(QueryDslConfig.class)
 class MemberTodoServiceTest {
-    
+
     private static final Long NOT_EXISTED_ID = 0L;
 
-    @Autowired
-    private MemberRepository memberRepository;
-    @Autowired
-    private GroupRepository groupRepository;
-    @Autowired
-    private GroupMemberRepository groupMemberRepository;
-    @Autowired
-    private TodoCategoryRepository todoCategoryRepository;
-    @Autowired
-    private TodoRepository todoRepository;
-    @Autowired
-    private JPAQueryFactory queryFactory;
+    private final MemberRepository memberRepository;
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final TodoCategoryRepository todoCategoryRepository;
+    private final TodoRepository todoRepository;
 
-    private TodoQueryRepository todoQueryRepository;
-    private MemberTodoService memberTodoService;
+    private final TodoQueryRepository todoQueryRepository;
+    private final MemberTodoService memberTodoService;
 
     private Member member;
     private MemberTodoCategory memberTodoCategory;
 
-    @BeforeEach
-    void init() {
-        todoQueryRepository = new TodoQueryRepository(queryFactory);
+    @Autowired
+    public MemberTodoServiceTest(MemberRepository memberRepository, GroupRepository groupRepository,
+                                 GroupMemberRepository groupMemberRepository, TodoCategoryRepository todoCategoryRepository,
+                                 TodoRepository todoRepository, JPAQueryFactory queryFactory) {
+        this.memberRepository = memberRepository;
+        this.groupRepository = groupRepository;
+        this.groupMemberRepository = groupMemberRepository;
+        this.todoCategoryRepository = todoCategoryRepository;
+        this.todoRepository = todoRepository;
 
+        todoQueryRepository = new TodoQueryRepository(queryFactory);
         memberTodoService = new MemberTodoService(
                 memberRepository,
                 todoCategoryRepository,
                 todoRepository,
                 todoQueryRepository,
                 groupMemberRepository,
-                groupRepository
-        );
+                groupRepository);
+    }
 
+    @BeforeEach
+    void init() {
         member = memberRepository.findById(1L).orElseThrow();
         memberTodoCategory = (MemberTodoCategory) todoCategoryRepository.findById(1L).orElseThrow();
     }

--- a/src/test/java/scs/planus/domain/todo/service/calendar/GroupTodoCalendarServiceTest.java
+++ b/src/test/java/scs/planus/domain/todo/service/calendar/GroupTodoCalendarServiceTest.java
@@ -1,12 +1,10 @@
 package scs.planus.domain.todo.service.calendar;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 import scs.planus.domain.Status;
 import scs.planus.domain.category.entity.GroupTodoCategory;
 import scs.planus.domain.category.entity.MemberTodoCategory;
@@ -24,7 +22,6 @@ import scs.planus.domain.todo.entity.MemberTodo;
 import scs.planus.domain.todo.repository.GroupTodoCompletionRepository;
 import scs.planus.domain.todo.repository.TodoQueryRepository;
 import scs.planus.domain.todo.repository.TodoRepository;
-import scs.planus.global.config.QueryDslConfig;
 import scs.planus.global.exception.PlanusException;
 import scs.planus.support.ServiceTest;
 
@@ -39,45 +36,48 @@ import static scs.planus.global.exception.CustomExceptionStatus.NOT_JOINED_GROUP
 import static scs.planus.global.exception.CustomExceptionStatus.NOT_JOINED_MEMBER_IN_GROUP;
 
 @ServiceTest
-@Import(QueryDslConfig.class)
-@Slf4j
 class GroupTodoCalendarServiceTest {
 
     private static final int COUNT = 7;
 
-    @Autowired
-    private MemberRepository memberRepository;
-    @Autowired
-    private TodoRepository todoRepository;
-    @Autowired
-    private TodoCategoryRepository todoCategoryRepository;
-    @Autowired
-    private GroupRepository groupRepository;
-    @Autowired
-    private GroupMemberRepository groupMemberRepository;
-    @Autowired
-    private GroupTodoCompletionRepository groupTodoCompletionRepository;
-    @Autowired
-    private JPAQueryFactory queryFactory;
+    private final MemberRepository memberRepository;
+    private final TodoRepository todoRepository;
+    private final TodoCategoryRepository todoCategoryRepository;
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupTodoCompletionRepository groupTodoCompletionRepository;
 
-    private TodoQueryRepository todoQueryRepository;
-    private GroupTodoCalendarService groupTodoCalendarService;
+    private final TodoQueryRepository todoQueryRepository;
+    private final GroupTodoCalendarService groupTodoCalendarService;
 
     private Member groupLeader;
     private Member groupMember;
     private Group group;
     private GroupTodoCategory groupTodoCategory;
 
-    @BeforeEach
-    void init() {
-        todoQueryRepository = new TodoQueryRepository(queryFactory);
+    @Autowired
+    public GroupTodoCalendarServiceTest(MemberRepository memberRepository, TodoRepository todoRepository,
+                                        TodoCategoryRepository todoCategoryRepository, GroupRepository groupRepository,
+                                        GroupMemberRepository groupMemberRepository, GroupTodoCompletionRepository groupTodoCompletionRepository,
+                                        JPAQueryFactory queryFactory) {
+        this.memberRepository = memberRepository;
+        this.todoRepository = todoRepository;
+        this.todoCategoryRepository = todoCategoryRepository;
+        this.groupRepository = groupRepository;
+        this.groupMemberRepository = groupMemberRepository;
+        this.groupTodoCompletionRepository = groupTodoCompletionRepository;
 
+        todoQueryRepository = new TodoQueryRepository(queryFactory);
         groupTodoCalendarService = new GroupTodoCalendarService(
                 todoQueryRepository,
                 groupRepository,
                 groupMemberRepository,
-                groupTodoCompletionRepository
-        );
+                groupTodoCompletionRepository);
+    }
+
+    @BeforeEach
+    void init() {
+
 
         groupLeader = memberRepository.findById(1L).orElseThrow();
         groupMember = memberRepository.findById(2L).orElseThrow();

--- a/src/test/java/scs/planus/domain/todo/service/calendar/GroupTodoCalendarServiceTest.java
+++ b/src/test/java/scs/planus/domain/todo/service/calendar/GroupTodoCalendarServiceTest.java
@@ -77,8 +77,6 @@ class GroupTodoCalendarServiceTest {
 
     @BeforeEach
     void init() {
-
-
         groupLeader = memberRepository.findById(1L).orElseThrow();
         groupMember = memberRepository.findById(2L).orElseThrow();
         group = groupRepository.findById(1L).orElseThrow();

--- a/src/test/java/scs/planus/domain/todo/service/calendar/MemberTodoCalendarServiceTest.java
+++ b/src/test/java/scs/planus/domain/todo/service/calendar/MemberTodoCalendarServiceTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Import;
 import scs.planus.domain.category.entity.GroupTodoCategory;
 import scs.planus.domain.category.entity.MemberTodoCategory;
 import scs.planus.domain.category.repository.TodoCategoryRepository;
@@ -23,7 +22,6 @@ import scs.planus.domain.todo.entity.MemberTodo;
 import scs.planus.domain.todo.repository.GroupTodoCompletionRepository;
 import scs.planus.domain.todo.repository.TodoQueryRepository;
 import scs.planus.domain.todo.repository.TodoRepository;
-import scs.planus.global.config.QueryDslConfig;
 import scs.planus.support.ServiceTest;
 
 import java.time.LocalDate;
@@ -32,53 +30,55 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ServiceTest
-@Import(QueryDslConfig.class)
 class MemberTodoCalendarServiceTest {
 
     private static final int COUNT = 7;
 
-    @Autowired
-    private MemberRepository memberRepository;
-    @Autowired
-    private GroupRepository groupRepository;
-    @Autowired
-    private GroupTagRepository groupTagRepository;
-    @Autowired
-    private TodoRepository todoRepository;
-    @Autowired
-    private TodoCategoryRepository todoCategoryRepository;
-    @Autowired
-    private GroupMemberRepository groupMemberRepository;
-    @Autowired
-    private GroupTodoCompletionRepository groupTodoCompletionRepository;
-    @Autowired
-    private JPAQueryFactory queryFactory;
+    private final MemberRepository memberRepository;
+    private final GroupRepository groupRepository;
+    private final GroupTagRepository groupTagRepository;
+    private final TodoRepository todoRepository;
+    private final TodoCategoryRepository todoCategoryRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupTodoCompletionRepository groupTodoCompletionRepository;
 
-    private TodoQueryRepository todoQueryRepository;
-    private MyGroupService myGroupService;
-    private MemberTodoCalendarService memberTodoCalendarService;
+    private final TodoQueryRepository todoQueryRepository;
+    private final MyGroupService myGroupService;
+    private final MemberTodoCalendarService memberTodoCalendarService;
 
     private Member member;
     private MemberTodoCategory memberTodoCategory;
     private Group group;
     private GroupTodoCategory groupTodoCategory;
 
-    @BeforeEach
-    void init() {
-        todoQueryRepository = new TodoQueryRepository(queryFactory);
+    @Autowired
+    public MemberTodoCalendarServiceTest(MemberRepository memberRepository, GroupRepository groupRepository,
+                                         GroupTagRepository groupTagRepository, TodoRepository todoRepository,
+                                         TodoCategoryRepository todoCategoryRepository, GroupMemberRepository groupMemberRepository,
+                                         GroupTodoCompletionRepository groupTodoCompletionRepository, JPAQueryFactory queryFactory) {
+        this.memberRepository = memberRepository;
+        this.groupRepository = groupRepository;
+        this.groupTagRepository = groupTagRepository;
+        this.todoRepository = todoRepository;
+        this.todoCategoryRepository = todoCategoryRepository;
+        this.groupMemberRepository = groupMemberRepository;
+        this.groupTodoCompletionRepository = groupTodoCompletionRepository;
 
+        todoQueryRepository = new TodoQueryRepository(queryFactory);
         myGroupService = new MyGroupService(
                 memberRepository,
                 groupRepository,
                 groupMemberRepository,
                 groupTagRepository);
-
         memberTodoCalendarService = new MemberTodoCalendarService(
                 myGroupService,
                 todoQueryRepository,
                 groupMemberRepository,
                 groupTodoCompletionRepository);
+    }
 
+    @BeforeEach
+    void init() {
         member = memberRepository.findById(1L).orElseThrow();
         memberTodoCategory = (MemberTodoCategory) todoCategoryRepository.findById(1L).orElseThrow();
         group = groupRepository.findById(1L).orElseThrow();

--- a/src/test/java/scs/planus/support/RepositoryTest.java
+++ b/src/test/java/scs/planus/support/RepositoryTest.java
@@ -1,7 +1,9 @@
 package scs.planus.support;
 
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
+import scs.planus.config.ExternalApiConfig;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -11,6 +13,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @DataJpaTest
+@Import(ExternalApiConfig.class)
 @Sql(scripts = {"classpath:schema.sql", "classpath:data.sql"})
 public @interface RepositoryTest {
 }

--- a/src/test/java/scs/planus/support/ServiceTest.java
+++ b/src/test/java/scs/planus/support/ServiceTest.java
@@ -1,7 +1,9 @@
 package scs.planus.support;
 
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
+import scs.planus.config.ExternalApiConfig;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -11,6 +13,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @DataJpaTest
+@Import(ExternalApiConfig.class)
 @Sql(scripts = {"classpath:schema.sql", "classpath:data.sql"})
 public @interface ServiceTest {
 }


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [X]  테스트 🔍

### :: 구현
- 의존성 주입 리팩토링

### :: 특이사항
- 테스트코드에서 필요한 외부API 의존성을 관리하는 ExternalApiConfig 구현
   - @RespositoryTest, @ServiceTest에 메타어노테이션으로 추가하였습니다. 
   - 현재는 QueryDsl 관련만 추가된 상태입니다.
 - Service단 및 QueryDsl을 의존하는 Repository단의 의존성 주입을 생성자 주입으로 변경하였습니다.
