### PR TITLE
[Test] GroupJoin 도메인, Repository, Service 단 Test 코드 구현

### DIFF
--- a/src/main/java/scs/planus/domain/group/service/GroupJoinService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupJoinService.java
@@ -37,10 +37,10 @@ public class GroupJoinService {
     @Transactional
     public GroupJoinResponseDto joinGroup(Long memberId, Long groupId ) {
         Group group = groupRepository.findByIdAndStatus(groupId)
-                .orElseThrow(() -> { throw new PlanusException( NOT_EXIST_GROUP ); });
+                .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP ));
 
         Member member = memberRepository.findById( memberId )
-                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+                .orElseThrow(() -> new PlanusException( NONE_USER ));
 
         groupJoinRepository.findByMemberIdAndGroupId(memberId, groupId)
                 .ifPresent(groupJoin -> {
@@ -61,9 +61,9 @@ public class GroupJoinService {
         return GroupJoinResponseDto.of( saveGroupJoin );
     }
 
-    public List<GroupJoinGetResponseDto> getAllGroupJoin(Long memberId ) {
+    public List<GroupJoinGetResponseDto> getAllGroupJoin(Long memberId) {
         Member member = memberRepository.findById( memberId )
-                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+                .orElseThrow(() -> new PlanusException( NONE_USER ));
 
         // 내가 리더인 그룹들 조회
         List<GroupMember> groupMembers = groupMemberRepository.findWithGroupByLeaderMember(member);
@@ -82,7 +82,7 @@ public class GroupJoinService {
     @Transactional
     public GroupMemberResponseDto acceptGroupJoin( Long leaderId, Long groupJoinId ) {
         Member leader = memberRepository.findById( leaderId )
-                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+                .orElseThrow(() -> new PlanusException(NONE_USER));
 
         GroupJoin groupJoin = groupJoinRepository.findWithGroupById( groupJoinId )
                 .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP_JOIN ));
@@ -108,7 +108,7 @@ public class GroupJoinService {
     @Transactional
     public GroupJoinResponseDto rejectGroupJoin( Long leaderId, Long groupJoinId ) {
         Member leader = memberRepository.findById( leaderId )
-                .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
+                .orElseThrow(() -> new PlanusException(NONE_USER));
 
         GroupJoin groupJoin = groupJoinRepository.findWithGroupById( groupJoinId )
                 .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP_JOIN ));
@@ -130,7 +130,7 @@ public class GroupJoinService {
     // TODO GroupJoinService 내 동일 메서드 존재 -> GroupValidate Class 로 빼는것 고려
     private void validateLeaderPermission( Member member, Group group ) {
         GroupMember groupLeader = groupMemberRepository.findWithGroupAndLeaderByGroup( group )
-                .orElseThrow( () -> { throw new PlanusException( NOT_EXIST_LEADER ); });
+                .orElseThrow( () -> new PlanusException(NOT_EXIST_LEADER));
 
         if ( !member.equals( groupLeader.getMember() ) )
             throw new PlanusException( NOT_GROUP_LEADER_PERMISSION );

--- a/src/main/java/scs/planus/domain/group/service/GroupJoinService.java
+++ b/src/main/java/scs/planus/domain/group/service/GroupJoinService.java
@@ -106,14 +106,14 @@ public class GroupJoinService {
     }
 
     @Transactional
-    public GroupJoinResponseDto rejectGroupJoin( Long memberId, Long groupJoinId ) {
-        Member member = memberRepository.findById( memberId )
+    public GroupJoinResponseDto rejectGroupJoin( Long leaderId, Long groupJoinId ) {
+        Member leader = memberRepository.findById( leaderId )
                 .orElseThrow(() -> { throw new PlanusException( NONE_USER ); });
 
         GroupJoin groupJoin = groupJoinRepository.findWithGroupById( groupJoinId )
                 .orElseThrow(() -> new PlanusException( NOT_EXIST_GROUP_JOIN ));
 
-        validateLeaderPermission( member, groupJoin.getGroup() );
+        validateLeaderPermission( leader, groupJoin.getGroup() );
 
         groupJoinRepository.delete( groupJoin );
 

--- a/src/test/java/scs/planus/domain/group/entity/GroupJoinTest.java
+++ b/src/test/java/scs/planus/domain/group/entity/GroupJoinTest.java
@@ -1,0 +1,33 @@
+package scs.planus.domain.group.entity;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import scs.planus.domain.Status;
+import scs.planus.domain.member.entity.Member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GroupJoinTest {
+    private Member member;
+    private Group group;
+
+    @BeforeEach
+    void init() {
+        member = Member.builder()
+                .build();
+
+        group = Group.builder()
+                .build();
+    }
+
+    @Test
+    void createGroupJoin() {
+        // when
+        GroupJoin groupJoin = GroupJoin.createGroupJoin(member, group);
+
+        // then
+        assertThat(groupJoin.getMember()).isEqualTo(member);
+        assertThat(groupJoin.getGroup()).isEqualTo(group);
+        assertThat(groupJoin.getStatus()).isEqualTo(Status.INACTIVE);
+    }
+}

--- a/src/test/java/scs/planus/domain/group/entity/GroupJoinTest.java
+++ b/src/test/java/scs/planus/domain/group/entity/GroupJoinTest.java
@@ -1,6 +1,7 @@
 package scs.planus.domain.group.entity;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import scs.planus.domain.Status;
 import scs.planus.domain.member.entity.Member;
@@ -20,6 +21,7 @@ class GroupJoinTest {
                 .build();
     }
 
+    @DisplayName("GroupJoin 이 제대로 생성되어야 한다.")
     @Test
     void createGroupJoin() {
         // when

--- a/src/test/java/scs/planus/domain/group/repository/GroupJoinRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/group/repository/GroupJoinRepositoryTest.java
@@ -1,0 +1,98 @@
+package scs.planus.domain.group.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.group.entity.GroupJoin;
+import scs.planus.domain.member.entity.Member;
+import scs.planus.domain.member.repository.MemberRepository;
+import scs.planus.support.RepositoryTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RepositoryTest
+class GroupJoinRepositoryTest {
+    private final MemberRepository memberRepository;
+    private final GroupRepository groupRepository;
+    private final GroupJoinRepository groupJoinRepository;
+
+    private Member member;
+    private Group group;
+    private GroupJoin groupJoin;
+
+    @Autowired
+    public GroupJoinRepositoryTest(MemberRepository memberRepository,
+                                   GroupRepository groupRepository,
+                                   GroupJoinRepository groupJoinRepository) {
+        this.memberRepository = memberRepository;
+        this.groupRepository = groupRepository;
+        this.groupJoinRepository = groupJoinRepository;
+    }
+
+    @BeforeEach
+    void init() {
+        member = Member.builder()
+                .build();
+        memberRepository.save(member);
+
+        group = Group.builder()
+                .build();
+        groupRepository.save(group);
+
+        groupJoin = GroupJoin.createGroupJoin(member, group);
+        groupJoinRepository.save(groupJoin);
+    }
+
+    @DisplayName("List<Group> 으로 각 그룹의 모든 GroupJoin 을 조회할 수 있다.")
+    @Test
+    void findAllByGroupIn() {
+        // given
+        Member member2 = Member.builder()
+                .build();
+        memberRepository.save(member2);
+
+        Group group2 = Group.builder()
+                .build();
+        groupRepository.save(group2);
+
+        GroupJoin groupJoin2 = GroupJoin.createGroupJoin(member2, group2);
+        groupJoinRepository.save(groupJoin2);
+
+        // when
+        List<Group> groups = List.of(group, group2);
+        List<GroupJoin> findGroupJoins = groupJoinRepository.findAllByGroupIn(groups);
+
+        // then
+        assertThat(findGroupJoins).hasSize(2);
+    }
+
+    @DisplayName("groupJoinId 로 GroupJoin 을 조회할 수 있다.")
+    @Test
+    void findWithGroupById() {
+        // when
+        GroupJoin findGroupJoin = groupJoinRepository.findWithGroupById(groupJoin.getId())
+                .orElseThrow();
+
+        // then
+        assertThat(findGroupJoin.getId()).isEqualTo(groupJoin.getId());
+        assertThat(findGroupJoin.getMember()).isEqualTo(groupJoin.getMember());
+        assertThat(findGroupJoin.getGroup()).isEqualTo(groupJoin.getGroup());
+    }
+
+    @DisplayName("memberId, groupId 로 GroupJoin 을 조회할 수 있다.")
+    @Test
+    void findByMemberIdAndGroupId() {
+        // when
+        GroupJoin findGroupJoin = groupJoinRepository.findByMemberIdAndGroupId(member.getId(), group.getId())
+                .orElseThrow();
+
+        // then
+        assertThat(findGroupJoin.getId()).isEqualTo(groupJoin.getId());
+        assertThat(findGroupJoin.getMember()).isEqualTo(groupJoin.getMember());
+        assertThat(findGroupJoin.getGroup()).isEqualTo(groupJoin.getGroup());
+    }
+}

--- a/src/test/java/scs/planus/domain/group/service/GroupJoinServiceTest.java
+++ b/src/test/java/scs/planus/domain/group/service/GroupJoinServiceTest.java
@@ -1,0 +1,354 @@
+package scs.planus.domain.group.service;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import scs.planus.domain.Status;
+import scs.planus.domain.group.dto.GroupMemberResponseDto;
+import scs.planus.domain.group.dto.groupJoin.GroupJoinGetResponseDto;
+import scs.planus.domain.group.dto.groupJoin.GroupJoinResponseDto;
+import scs.planus.domain.group.entity.Group;
+import scs.planus.domain.group.entity.GroupJoin;
+import scs.planus.domain.group.entity.GroupMember;
+import scs.planus.domain.group.repository.GroupJoinRepository;
+import scs.planus.domain.group.repository.GroupMemberQueryRepository;
+import scs.planus.domain.group.repository.GroupMemberRepository;
+import scs.planus.domain.group.repository.GroupRepository;
+import scs.planus.domain.member.entity.Member;
+import scs.planus.domain.member.repository.MemberRepository;
+import scs.planus.global.exception.PlanusException;
+import scs.planus.support.ServiceTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static scs.planus.global.exception.CustomExceptionStatus.*;
+
+@ServiceTest
+class GroupJoinServiceTest {
+    private static final long NOT_EXIST_ID = 0L;
+
+    private final MemberRepository memberRepository;
+    private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GroupJoinRepository groupJoinRepository;
+
+    private final GroupJoinService groupJoinService;
+
+    private Member leader;
+    private Member member;
+    private Group group;
+
+    @Autowired
+    public GroupJoinServiceTest(MemberRepository memberRepository,
+                                GroupRepository groupRepository,
+                                GroupMemberRepository groupMemberRepository,
+                                GroupJoinRepository groupJoinRepository,
+                                JPAQueryFactory queryFactory) {
+        this.memberRepository = memberRepository;
+        this.groupRepository = groupRepository;
+        this.groupMemberRepository = groupMemberRepository;
+        this.groupJoinRepository = groupJoinRepository;
+
+        GroupMemberQueryRepository groupMemberQueryRepository = new GroupMemberQueryRepository(queryFactory);
+        groupJoinService = new GroupJoinService(memberRepository,
+                groupRepository,
+                groupMemberRepository,
+                groupMemberQueryRepository,
+                groupJoinRepository
+        );
+    }
+
+    @BeforeEach
+    void init() {
+        leader = memberRepository.findById(1L).orElseThrow();
+        group = groupRepository.findById(1L).orElseThrow();
+
+        member = Member.builder()
+                .nickname("미가입 회원")
+                .description("미가입 그룹에 대한 테스트를 위한 회원입니다.")
+                .profileImageUrl("image_url")
+                .build();
+        memberRepository.save(member);
+    }
+
+    @DisplayName("new Member 는 미가입 Group 에 그룹신청을 할 수 있다." +
+            "생성된 GroupJoin 의 Status 는 INACTIVE 여야 한다.")
+    @Test
+    void joinGroup_Success() {
+        // when
+        GroupJoinResponseDto groupJoinResponseDto
+                = groupJoinService.joinGroup(member.getId(), group.getId());
+
+        GroupJoin groupJoin
+                = groupJoinRepository.findById(groupJoinResponseDto.getGroupJoinId()).orElseThrow();
+
+        // then
+        assertThat(groupJoinResponseDto.getGroupJoinId()).isNotNull();
+        assertThat(groupJoin.getId()).isEqualTo(groupJoinResponseDto.getGroupJoinId());
+        assertThat(groupJoin.getMember()).isEqualTo(member);
+        assertThat(groupJoin.getGroup()).isEqualTo(group);
+        assertThat(groupJoin.getStatus()).isEqualTo(Status.INACTIVE);
+    }
+
+    @DisplayName("존재하지 Group 일 경우 NOT_EXIST_GROUP 예외가 발생해야 한다.")
+    @Test
+    void joinGroup_Fail_Not_Exist_Group() {
+        // when & then
+        assertThatThrownBy(() -> groupJoinService.joinGroup(member.getId(), NOT_EXIST_ID))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(NOT_EXIST_GROUP);
+    }
+
+    @DisplayName("존재하지 Member 일 경우 NONE_USER 예외가 발생해야 한다.")
+    @Test
+    void joinGroup_Fail_Not_Exist_Member() {
+        // when & then
+        assertThatThrownBy(() -> groupJoinService.joinGroup(NOT_EXIST_ID, group.getId()))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(NONE_USER);
+    }
+
+    @DisplayName("이미 신청서를 보낸 경우 ALREADY_APPLY_JOINED_GROUP 예외가 발생해야 한다.")
+    @Test
+    void joinGroup_Fail_Already_Apply_Joined_Group() {
+        // given
+        groupJoinService.joinGroup(member.getId(), group.getId());
+
+        // when & then
+        assertThatThrownBy(() -> groupJoinService.joinGroup(member.getId(), group.getId()))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(ALREADY_APPLY_JOINED_GROUP);
+    }
+
+    @DisplayName("그룹 최대인원을 초과한 경우 EXCEED_GROUP_LIMIT_COUNT 예외가 발생해야 한다.")
+    @Test
+    void joinGroup_Fail_Exceed_Group_Limit_Count() {
+        // given
+        Group limitExceededGroup = Group.builder()
+                .limitCount(0)
+                .status(Status.ACTIVE)
+                .build();
+        groupRepository.save(limitExceededGroup);
+
+        // when & then
+        assertThatThrownBy(() -> groupJoinService.joinGroup(member.getId(), limitExceededGroup.getId()))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(EXCEED_GROUP_LIMIT_COUNT);
+    }
+
+    @DisplayName("이미 가입 되어 있는 경우 ALREADY_JOINED_GROUP 예외가 발생해야 한다.")
+    @Test
+    void joinGroup_Fail_Already_Joined_Group() {
+        // given
+        GroupMember groupMember = GroupMember.builder()
+                .member(member)
+                .group(group)
+                .build();
+        groupMemberRepository.save(groupMember);
+
+        // when & then
+        assertThatThrownBy(() -> groupJoinService.joinGroup(member.getId(), group.getId()))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(ALREADY_JOINED_GROUP);
+    }
+
+    @DisplayName("로그인 유저가 리더인 그룹의 모든 가입 신청서를 조회할 수 있다.")
+    @Test
+    void getAllGroupJoin_Success() {
+        // given
+        Group group2 = Group.builder()
+                .status(Status.ACTIVE)
+                .build();
+        groupRepository.save(group2);
+
+        GroupMember groupMember = GroupMember.builder()
+                .group(group2)
+                .member(leader)
+                .leader(true)
+                .build();
+        groupMemberRepository.save(groupMember);
+
+        GroupJoin groupJoin1 = GroupJoin.builder()
+                .group(group)
+                .member(member)
+                .build();
+
+        GroupJoin groupJoin2 = GroupJoin.builder()
+                .group(group2)
+                .member(member)
+                .build();
+
+        List<GroupJoin> groupJoins = List.of(groupJoin1, groupJoin2);
+        groupJoinRepository.saveAll(groupJoins);
+
+        // when
+        List<GroupJoinGetResponseDto> groupJoinGetResponseDtos = groupJoinService.getAllGroupJoin(leader.getId());
+
+        // then
+        assertThat(groupJoinGetResponseDtos).hasSize(2);
+        assertThat(groupJoinGetResponseDtos)
+                .filteredOn(dto -> dto.getGroupJoinId().equals(groupJoin1.getId()))
+                .first()
+                .satisfies(groupJoinDto1 -> {
+                    assertThat(groupJoinDto1.getGroupId()).isEqualTo(group.getId());
+                    assertThat(groupJoinDto1.getGroupName()).isEqualTo(group.getName());
+                    assertThat(groupJoinDto1.getMemberId()).isEqualTo(member.getId());
+                    assertThat(groupJoinDto1.getMemberName()).isEqualTo(member.getNickname());
+                    assertThat(groupJoinDto1.getMemberDescription()).isEqualTo(member.getDescription());
+                    assertThat(groupJoinDto1.getMemberProfileImageUrl()).isEqualTo(member.getProfileImageUrl());
+                });
+    }
+
+    @DisplayName("그룹의 리더는 그룹 가입 신청을 수락할 수 있다." +
+            "이후 해당 GroupJoin 은 삭제되어야 한다.")
+    @Nested
+    class acceptGroupJoin_Success{
+
+        @DisplayName("탈퇴 이력이 있는 회원의 경우 상태만 변경한다." +
+                "기존 GroupMember 의 Id 를 반환한다.")
+        @Test
+        void acceptGroupJoin_Success_Withdraw_Member() {
+            // given
+            GroupMember groupMember = GroupMember.builder()
+                    .member(member)
+                    .group(group)
+                    .build();
+            groupMember.changeStatusToInactive();
+
+            GroupJoin groupJoin = GroupJoin.builder()
+                    .member(member)
+                    .group(group)
+                    .build();
+            groupJoinRepository.save(groupJoin);
+
+            // when
+            GroupMemberResponseDto groupMemberResponseDto
+                    = groupJoinService.acceptGroupJoin(leader.getId(), groupJoin.getId());
+
+            GroupJoin findGroupJoin = groupJoinRepository.findById(groupJoin.getId())
+                    .orElse(null);
+
+            // then
+            assertThat(groupMemberResponseDto.getGroupMemberId()).isEqualTo(groupMember.getId());
+            assertThat(groupMember.getStatus()).isEqualTo(Status.ACTIVE);
+            assertThat(findGroupJoin).isNull();
+        }
+
+        @DisplayName("이력이 없는 회원의 경우 GroupMember 를 새로 생성한다." +
+                "생성된 GroupMember 의 Id 를 반환한다.")
+        @Test
+        void acceptGroupJoin_Success_New_Member() {
+            // given
+            GroupJoin groupJoin = GroupJoin.builder()
+                    .member(member)
+                    .group(group)
+                    .build();
+            groupJoinRepository.save(groupJoin);
+
+            // when
+            GroupMemberResponseDto groupMemberResponseDto
+                    = groupJoinService.acceptGroupJoin(leader.getId(), groupJoin.getId());
+
+            GroupJoin findGroupJoin = groupJoinRepository.findById(groupJoin.getId())
+                    .orElse(null);
+
+            GroupMember findGroupMember
+                    = groupMemberRepository.findByMemberIdAndGroupId(member.getId(), group.getId())
+                    .orElse(null);
+
+            // then
+            assertThat(findGroupMember).isNotNull();
+            assertThat(groupMemberResponseDto.getGroupMemberId()).isEqualTo(findGroupMember.getId());
+            assertThat(findGroupJoin).isNull();
+        }
+
+    }
+
+    @DisplayName("존재하지 않는 GroupJoin 일 경우 NOT_EXIST_GROUP_JOIN 예외가 발생해야 한다.")
+    @Test
+    void acceptGroupJoin_Fail_Not_Exist_Group_Join() {
+        // when & then
+        assertThatThrownBy(() -> groupJoinService.acceptGroupJoin(leader.getId(), NOT_EXIST_ID))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(NOT_EXIST_GROUP_JOIN);
+    }
+
+    @DisplayName("그룹의 리더가 없는 경우 NOT_EXIST_LEADER 예외가 발생해야 한다.")
+    @Test
+    void acceptGroupJoin_Fail_Not_Exist_Leader() {
+        // given
+        Group nonLeaderGroup = Group.builder()
+                .build();
+        groupRepository.save(nonLeaderGroup);
+
+        Member notLeader = Member.builder()
+                .build();
+        memberRepository.save(notLeader);
+
+        GroupJoin groupJoin = GroupJoin.builder()
+                .group(nonLeaderGroup)
+                .member(member)
+                .build();
+        groupJoinRepository.save(groupJoin);
+
+        // when & then
+        assertThatThrownBy(() -> groupJoinService.acceptGroupJoin(notLeader.getId(), group.getId()))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(NOT_EXIST_LEADER);
+    }
+
+    @DisplayName("로그인 유저가 그룹의 리더가 아닌 경우 NOT_GROUP_LEADER_PERMISSION 예외가 발생해야 한다.")
+    @Test
+    void acceptGroupJoin_Fail_Not_Group_Leader_Permission() {
+        // given
+        Member notLeader = Member.builder()
+                .build();
+        memberRepository.save(notLeader);
+
+        GroupJoin groupJoin = GroupJoin.builder()
+                .group(group)
+                .member(member)
+                .build();
+        groupJoinRepository.save(groupJoin);
+
+        // when & then
+        assertThatThrownBy(() -> groupJoinService.acceptGroupJoin(notLeader.getId(), groupJoin.getId()))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(NOT_GROUP_LEADER_PERMISSION);
+    }
+
+    @DisplayName("그룹의 리더는 그룹 가입 신청을 거절할 수 있다." +
+            "이후 해당 GroupJoin 은 삭제되어야 한다.")
+    @Test
+    void rejectGroupJoin_Success() {
+        // given
+        GroupJoin groupJoin = GroupJoin.builder()
+                .group(group)
+                .member(member)
+                .build();
+        groupJoinRepository.save(groupJoin);
+
+        // when
+        GroupJoinResponseDto groupJoinResponseDto
+                = groupJoinService.rejectGroupJoin(leader.getId(), group.getId());
+
+        GroupJoin findGroupJoin = groupJoinRepository.findById(groupJoin.getId()).orElse(null);
+
+        // then
+        assertThat(groupJoinResponseDto.getGroupJoinId()).isEqualTo(groupJoin.getId());
+        assertThat(findGroupJoin).isNull();
+    }
+}


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [x]  테스트 🔍

### :: 구현
### GroupJoinService Test
- `orElseThrow()` 의 람다식을 수정하였습니다.

### GroupJoinService Test
`Assertions.assertThat.filteredOn()`
- List<Dto> 형태로 반환되는 리스트에서 하나의 특정 객체의 필드값들을 검증하기 위해서 `Assertions.assertThat` 의 `.filteredOn()` 를 활용하였습니다.
- `.first()` 를 사용하여 `.filteredOn()`에 인자로 넘긴 `Predicate<>` 를 만족하는 첫번째 객체를 반환합니다.
- `.satisfies()`에 람다식을 이용하여, 해당 객체의 각 필드값들이 정상적으로 담겨있는지 모두 검증할 수 있습니다.

### :: 특이사항
- 
