### PR TITLE
[Test]  JwtProvider 리팩토링 및 auth 디렉토리 서비스단 테스트 코드 

### DIFF
--- a/src/main/java/scs/planus/global/auth/service/JwtProvider.java
+++ b/src/main/java/scs/planus/global/auth/service/JwtProvider.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +17,8 @@ import org.springframework.stereotype.Component;
 import scs.planus.global.auth.entity.Token;
 import scs.planus.global.exception.PlanusException;
 
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 import static scs.planus.global.exception.CustomExceptionStatus.UNAUTHORIZED_ACCESS_TOKEN;
@@ -25,14 +28,14 @@ import static scs.planus.global.exception.CustomExceptionStatus.UNAUTHORIZED_ACC
 @Slf4j
 public class JwtProvider {
 
-    private final String secretKey;
+    private final SecretKey secretKey;
     private final long accessTokenExpiredIn;
     private final long refreshTokenExpiredIn;
 
     public JwtProvider(@Value("${jwt.token.secret-key}") final String secretKey,
                        @Value("${jwt.access-token.expired-in}") final long accessTokenExpiredIn,
                        @Value("${jwt.refresh-token.expired-in}") final long refreshTokenExpiredIn) {
-        this.secretKey = secretKey;
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
         this.accessTokenExpiredIn = accessTokenExpiredIn;
         this.refreshTokenExpiredIn = refreshTokenExpiredIn;
     }
@@ -91,7 +94,7 @@ public class JwtProvider {
                 .setClaims(claims)
                 .setIssuedAt(now)
                 .setExpiration(expired)
-                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
 
@@ -101,7 +104,7 @@ public class JwtProvider {
         return Jwts.builder()
                 .setIssuedAt(now)
                 .setExpiration(expired)
-                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
 

--- a/src/main/java/scs/planus/global/config/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/scs/planus/global/config/filter/JwtAuthenticationFilter.java
@@ -2,11 +2,15 @@ package scs.planus.global.config.filter;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.auth.service.JwtProvider;
+import scs.planus.global.auth.service.PrincipalDetailsService;
 import scs.planus.global.exception.PlanusException;
 
 import javax.servlet.FilterChain;
@@ -22,20 +26,37 @@ import static scs.planus.global.exception.CustomExceptionStatus.INTERNAL_SERVER_
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private static final String HEADER_AUTHORIZATION = "Authorization";
+    private static final String TOKEN_TYPE = "Bearer ";
+
     private final JwtProvider jwtProvider;
+    private final PrincipalDetailsService principalDetailsService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
-            String token = jwtProvider.resolveToken(request);
+            String token = resolveToken(request);
             if (token != null && jwtProvider.isValidToken(token)) {
                 String email = jwtProvider.getPayload(token);
-                Authentication authentication = jwtProvider.getAuthentication(email);
+                Authentication authentication = getAuthentication(email);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (RuntimeException e) {
             throw new PlanusException(INTERNAL_SERVER_ERROR);
         }
         filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(HEADER_AUTHORIZATION);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(TOKEN_TYPE)) {
+            return bearerToken.substring(TOKEN_TYPE.length());
+        }
+        return null;
+    }
+
+    private Authentication getAuthentication(String email) {
+        PrincipalDetails principalDetails = principalDetailsService.loadUserByUsername(email);
+        return new UsernamePasswordAuthenticationToken(principalDetails, "", principalDetails.getAuthorities());
     }
 }

--- a/src/test/java/scs/planus/global/auth/service/AuthServiceTest.java
+++ b/src/test/java/scs/planus/global/auth/service/AuthServiceTest.java
@@ -1,0 +1,101 @@
+package scs.planus.global.auth.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import scs.planus.global.auth.dto.TokenReissueRequestDto;
+import scs.planus.global.auth.dto.TokenReissueResponseDto;
+import scs.planus.global.auth.entity.Token;
+import scs.planus.global.exception.PlanusException;
+import scs.planus.infra.redis.RedisService;
+import scs.planus.support.ServiceTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static scs.planus.global.exception.CustomExceptionStatus.EXPIRED_REFRESH_TOKEN;
+import static scs.planus.global.exception.CustomExceptionStatus.INVALID_REFRESH_TOKEN;
+
+@ServiceTest
+class AuthServiceTest {
+
+    private static final String TEST_EMAIL = "test@test";
+    private static final String ACCESS_TOKEN = "accessToken";
+    private static final String REFRESH_TOKEN = "refreshToken";
+
+    @MockBean
+    private RedisService redisService;
+    @MockBean
+    private JwtProvider jwtProvider;
+
+    private AuthService authService;
+
+    private TokenReissueRequestDto requestDto;
+    private Token reissuedToken;
+
+    @BeforeEach
+    void init() {
+        this.authService = new AuthService(redisService, jwtProvider);
+
+        requestDto = TokenReissueRequestDto.builder()
+                .accessToken(ACCESS_TOKEN)
+                .refreshToken(REFRESH_TOKEN)
+                .build();
+
+        reissuedToken = Token.builder()
+                .accessToken("newAccessToken")
+                .refreshToken("newRefreshToken")
+                .refreshTokenExpiredIn(0L)
+                .build();
+    }
+
+    @DisplayName("토큰이 재발급되어야 한다.")
+    @Test
+    void reissue(){
+        //given
+        given(jwtProvider.getPayload(ACCESS_TOKEN)).willReturn(TEST_EMAIL);
+        given(jwtProvider.generateToken(TEST_EMAIL)).willReturn(reissuedToken);
+        given(redisService.getValue(TEST_EMAIL)).willReturn(REFRESH_TOKEN);
+
+        //when
+        TokenReissueResponseDto reissue = authService.reissue(requestDto);
+
+        //then
+        assertThat(reissue.getAccessToken()).isEqualTo(reissuedToken.getAccessToken());
+        assertThat(reissue.getRefreshToken()).isEqualTo(reissuedToken.getRefreshToken());
+    }
+
+    @DisplayName("토큰이 만료되어 Redis에 없는 경우, 예외를 던진다.")
+    @Test
+    void reissue_Throw_Exception_If_Expired_Token(){
+        //given
+        given(jwtProvider.getPayload(ACCESS_TOKEN)).willReturn(TEST_EMAIL);
+        given(jwtProvider.generateToken(TEST_EMAIL)).willReturn(reissuedToken);
+        given(redisService.getValue(TEST_EMAIL)).willReturn(null);
+
+        //then
+        assertThatThrownBy(() ->
+                authService.reissue(requestDto))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(EXPIRED_REFRESH_TOKEN);
+    }
+
+    @DisplayName("토큰이 만료되어 Redis에 없는 경우, 예외를 던진다.")
+    @Test
+    void reissue_Throw_Exception_If_Invalid_Token(){
+        //given
+        String invalidRefreshToken = "invalidRefreshToken";
+        given(jwtProvider.getPayload(ACCESS_TOKEN)).willReturn(TEST_EMAIL);
+        given(jwtProvider.generateToken(TEST_EMAIL)).willReturn(reissuedToken);
+        given(redisService.getValue(TEST_EMAIL)).willReturn(invalidRefreshToken);
+
+        //then
+        assertThatThrownBy(() ->
+                authService.reissue(requestDto))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(INVALID_REFRESH_TOKEN);
+    }
+}

--- a/src/test/java/scs/planus/global/auth/service/JwtProviderTest.java
+++ b/src/test/java/scs/planus/global/auth/service/JwtProviderTest.java
@@ -4,9 +4,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import scs.planus.global.auth.entity.Token;
+import scs.planus.global.exception.PlanusException;
 import scs.planus.support.ServiceTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static scs.planus.global.exception.CustomExceptionStatus.UNAUTHORIZED_ACCESS_TOKEN;
 
 @ServiceTest
 class JwtProviderTest {
@@ -14,7 +17,7 @@ class JwtProviderTest {
     private static final String SECRET_KEY = "A".repeat(64);
     private static final int ACCESS_TOKEN_EXPIRED_IN = 3600;
     private static final int REFRESH_TOKEN_EXPIRED_IN = 7200;
-    private static final String PAYLOAD = "planus";
+    private static final String PAYLOAD = "test@test";
 
     private final JwtProvider jwtProvider;
 
@@ -73,6 +76,34 @@ class JwtProviderTest {
 
         //then
         assertThat(payload).isEqualTo(PAYLOAD);
+    }
+
+    @DisplayName("AccessToken이 만료되었더라도 이를 파싱한다.")
+    @Test
+    void getPayload_If_Expired_Token(){
+        //given
+        JwtProvider expiredJwtProvider = new JwtProvider(SECRET_KEY, 0L, 0L);
+        Token token = expiredJwtProvider.generateToken(PAYLOAD);
+
+        //when
+        String payload = expiredJwtProvider.getPayload(token.getAccessToken());
+
+        //then
+        assertThat(payload).isEqualTo(PAYLOAD);
+    }
+
+    @DisplayName("AccessToken 형식이 잘못된 경우, 예외를 던진다")
+    @Test
+    void getPayload_Throw_Exception_If_Invalid_Token(){
+        //given
+        String invalidToken = "invalidToken";
+
+        //when
+        assertThatThrownBy(() ->
+                jwtProvider.getPayload(invalidToken))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(UNAUTHORIZED_ACCESS_TOKEN);
     }
 
     @DisplayName("RefreshToken에는 payload가 존재하지 않는다.")

--- a/src/test/java/scs/planus/global/auth/service/JwtProviderTest.java
+++ b/src/test/java/scs/planus/global/auth/service/JwtProviderTest.java
@@ -1,0 +1,90 @@
+package scs.planus.global.auth.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import scs.planus.global.auth.entity.Token;
+import scs.planus.support.ServiceTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ServiceTest
+class JwtProviderTest {
+
+    private static final String SECRET_KEY = "A".repeat(64);
+    private static final int ACCESS_TOKEN_EXPIRED_IN = 3600;
+    private static final int REFRESH_TOKEN_EXPIRED_IN = 7200;
+    private static final String PAYLOAD = "planus";
+
+    private final JwtProvider jwtProvider;
+
+    @Autowired
+    public JwtProviderTest() {
+        this.jwtProvider = new JwtProvider(SECRET_KEY, ACCESS_TOKEN_EXPIRED_IN, REFRESH_TOKEN_EXPIRED_IN);
+    }
+
+    @DisplayName("토큰이 제대로 생성되어야 한다.")
+    @Test
+    void generateToken(){
+        //when
+        Token token = jwtProvider.generateToken(PAYLOAD);
+
+        //then
+        assertThat(token.getAccessToken().split("\\.")).hasSize(3);
+        assertThat(token.getRefreshToken().split("\\.")).hasSize(3);
+        assertThat(token.getRefreshTokenExpiredIn()).isEqualTo(REFRESH_TOKEN_EXPIRED_IN);
+    }
+
+    @DisplayName("토큰이 유효하다면, 검증 시 true를 반환한다.")
+    @Test
+    void isValidToken(){
+        //given
+        Token token = jwtProvider.generateToken(PAYLOAD);
+
+        //when
+        boolean isValid = jwtProvider.isValidToken(token.getAccessToken());
+
+        //then
+        assertThat(isValid).isTrue();
+    }
+
+    @DisplayName("토큰이 만료되었다면, 검증 시 false를 반환한다.")
+    @Test
+    void isValidToken_Return_False_If_Expired(){
+        //given
+        JwtProvider expiredJwtProvider = new JwtProvider(SECRET_KEY, 0, 0);
+        Token token = expiredJwtProvider.generateToken(PAYLOAD);
+
+        //when
+        boolean isValid = expiredJwtProvider.isValidToken(token.getAccessToken());
+
+        //then
+        assertThat(isValid).isFalse();
+    }
+
+    @DisplayName("AccessToken의 payload를 파싱한다.")
+    @Test
+    void getPayload(){
+        //given
+        Token token = jwtProvider.generateToken(PAYLOAD);
+
+        //when
+        String payload = jwtProvider.getPayload(token.getAccessToken());
+
+        //then
+        assertThat(payload).isEqualTo(PAYLOAD);
+    }
+
+    @DisplayName("RefreshToken에는 payload가 존재하지 않는다.")
+    @Test
+    void getPayload_Return_Null_If_Refresh_Token(){
+        //given
+        Token token = jwtProvider.generateToken(PAYLOAD);
+
+        //when
+        String payload = jwtProvider.getPayload(token.getRefreshToken());
+
+        //then
+        assertThat(payload).isNull();
+    }
+}

--- a/src/test/java/scs/planus/global/auth/service/PrincipalDetailsServiceTest.java
+++ b/src/test/java/scs/planus/global/auth/service/PrincipalDetailsServiceTest.java
@@ -1,0 +1,58 @@
+package scs.planus.global.auth.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import scs.planus.domain.member.entity.Member;
+import scs.planus.domain.member.repository.MemberRepository;
+import scs.planus.global.auth.entity.PrincipalDetails;
+import scs.planus.global.exception.PlanusException;
+import scs.planus.support.ServiceTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static scs.planus.global.exception.CustomExceptionStatus.NONE_USER;
+
+@ServiceTest
+class PrincipalDetailsServiceTest {
+
+    private final MemberRepository memberRepository;
+    private PrincipalDetailsService principalDetailsService;
+
+    @Autowired
+    public PrincipalDetailsServiceTest(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+        principalDetailsService = new PrincipalDetailsService(memberRepository);
+    }
+
+    @DisplayName("존재하는 이메일의 회원인 경우, 그 회원에 관한 PrincipalDetail을 반환한다.")
+    @Test
+    void loadUserByUsername(){
+        //given
+        Member member = Member.builder().email("test@test").build();
+        memberRepository.save(member);
+
+        //when
+        PrincipalDetails principalDetails
+                = principalDetailsService.loadUserByUsername("test@test");
+
+        //then
+        assertThat(principalDetails.getId()).isEqualTo(member.getId());
+        assertThat(principalDetails.getUsername()).isEqualTo(member.getEmail());
+    }
+
+    @DisplayName("존재하지 않는 이메일의 회원인 경우, 예외를 던진다.")
+    @Test
+    void loadUserByUsername_Throw_Exception_If_Not_Existed_Email(){
+        //given
+        Member member = Member.builder().email("test@test").build();
+        memberRepository.save(member);
+
+        //then
+        assertThatThrownBy(() ->
+                principalDetailsService.loadUserByUsername("wrong@test"))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(NONE_USER);
+    }
+}

--- a/src/test/java/scs/planus/global/auth/service/PrincipalDetailsServiceTest.java
+++ b/src/test/java/scs/planus/global/auth/service/PrincipalDetailsServiceTest.java
@@ -3,7 +3,9 @@ package scs.planus.global.auth.service;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
 import scs.planus.domain.member.entity.Member;
+import scs.planus.domain.member.entity.Role;
 import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.global.auth.entity.PrincipalDetails;
 import scs.planus.global.exception.PlanusException;
@@ -25,11 +27,14 @@ class PrincipalDetailsServiceTest {
         principalDetailsService = new PrincipalDetailsService(memberRepository);
     }
 
-    @DisplayName("존재하는 이메일의 회원인 경우, 그 회원에 관한 PrincipalDetail을 반환한다.")
+    @DisplayName("존재하는 이메일의 회원인 경우, 그 회원에 관한 PrincipalDetails을 반환한다.")
     @Test
     void loadUserByUsername(){
         //given
-        Member member = Member.builder().email("test@test").build();
+        Member member = Member.builder()
+                .email("test@test")
+                .role(Role.USER)
+                .build();
         memberRepository.save(member);
 
         //when
@@ -39,6 +44,9 @@ class PrincipalDetailsServiceTest {
         //then
         assertThat(principalDetails.getId()).isEqualTo(member.getId());
         assertThat(principalDetails.getUsername()).isEqualTo(member.getEmail());
+        assertThat(principalDetails.getAuthorities()).hasSize(1)
+                .extracting(GrantedAuthority::getAuthority)
+                .containsExactly(member.getRole().getRoleName());
     }
 
     @DisplayName("존재하지 않는 이메일의 회원인 경우, 예외를 던진다.")


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [X]  테스트 🔍

### :: 구현
- JwtProvider 리팩토링
- PrincipalDetailService / JwtProvider / AuthService 테스트 코드 작성

### :: 특이사항
### 🔥 JwtProvider 리팩토링 🔥
1. `@Value`를 이용하여 필드값을 초기화 -> `@Value + 생성자`를 이용하여 필드값 초기화
- 조금 더 유연한 객체 생성을 위해 생성자를 통해 필드값을 주입하도록 변경하였습니다.
2. secreteKey 타입 변경 : `String` -> `SecreteKey`
- Jwts 빌더를 통해 토큰을 만드는 과정에서 기존에 사용하던, `signWith(alg, secreteKey)` 메서드가 deprecated 됐었다는 사실을 알게되어, `signWith(Key secreteKey, alg)`를 사용하도록 secreteKey의 타입을 `SecreteKey`로 변경하였습니다.
3. 메서드 분리
- `resolveToken(), getAuthentication()` 두 메서드를 `JwtProvider`에서 분리하여 `JwtAuthenticationFilter`로 이동시켰습니다.