### PR TITLE
[Refactor] 어노테이션 대신 추상클래스 상속하도록 변경

### DIFF
--- a/src/main/java/scs/planus/domain/todo/controller/MemberTodoController.java
+++ b/src/main/java/scs/planus/domain/todo/controller/MemberTodoController.java
@@ -52,8 +52,8 @@ public class MemberTodoController {
     @PatchMapping("/todos/{todoId}")
     @Operation(summary = "MemberTodo 변경 API")
     public BaseResponse<TodoResponseDto> updateTodoDetail(@AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                                 @PathVariable Long todoId,
-                                                                 @Valid @RequestBody TodoRequestDto todoRequestDto) {
+                                                          @PathVariable Long todoId,
+                                                          @Valid @RequestBody TodoRequestDto todoRequestDto) {
         Long memberId = principalDetails.getId();
         TodoResponseDto responseDto = memberTodoService.updateTodo(memberId, todoId, todoRequestDto);
         return new BaseResponse<>(responseDto);

--- a/src/test/java/scs/planus/PlanusApplicationTests.java
+++ b/src/test/java/scs/planus/PlanusApplicationTests.java
@@ -1,9 +1,8 @@
 package scs.planus;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+//@SpringBootTest
 class PlanusApplicationTests {
 
 	@Test

--- a/src/test/java/scs/planus/domain/category/repository/TodoCategoryRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/category/repository/TodoCategoryRepositoryTest.java
@@ -21,8 +21,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
-@RepositoryTest
-class TodoCategoryRepositoryTest {
+class TodoCategoryRepositoryTest extends RepositoryTest {
     private static final Long NOT_EXIST_ID = 0L;
 
     @Autowired

--- a/src/test/java/scs/planus/domain/category/service/GroupTodoCategoryServiceTest.java
+++ b/src/test/java/scs/planus/domain/category/service/GroupTodoCategoryServiceTest.java
@@ -28,8 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static scs.planus.global.exception.CustomExceptionStatus.*;
 
 @Slf4j
-@ServiceTest
-class GroupTodoCategoryServiceTest {
+class GroupTodoCategoryServiceTest extends ServiceTest {
     private static final long NOT_EXIST_ID = 0L;
     private static final String INVALID_COLOR = "invalid color";
 

--- a/src/test/java/scs/planus/domain/category/service/MemberTodoCategoryServiceTest.java
+++ b/src/test/java/scs/planus/domain/category/service/MemberTodoCategoryServiceTest.java
@@ -29,8 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static scs.planus.global.exception.CustomExceptionStatus.*;
 
 @Slf4j
-@ServiceTest
-class MemberTodoCategoryServiceTest {
+class MemberTodoCategoryServiceTest extends ServiceTest {
     private static final long NOT_EXIST_ID = 0L;
     private static final String INVALID_COLOR = "invalid color";
 

--- a/src/test/java/scs/planus/domain/group/repository/GroupJoinRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/group/repository/GroupJoinRepositoryTest.java
@@ -14,8 +14,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RepositoryTest
-class GroupJoinRepositoryTest {
+class GroupJoinRepositoryTest extends RepositoryTest {
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
     private final GroupJoinRepository groupJoinRepository;

--- a/src/test/java/scs/planus/domain/group/repository/GroupMemberQueryRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/group/repository/GroupMemberQueryRepositoryTest.java
@@ -13,8 +13,7 @@ import scs.planus.support.RepositoryTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RepositoryTest
-class GroupMemberQueryRepositoryTest {
+class GroupMemberQueryRepositoryTest extends RepositoryTest {
 
     private final MemberRepository memberRepository;
     private final GroupRepository groupRepository;
@@ -32,7 +31,7 @@ class GroupMemberQueryRepositoryTest {
 
     @DisplayName("GroupMember가 존재하면 true를 반환한다.")
     @Test
-    void existByMemberIdAndGroupId_Return_True_If_GroupMember(){
+    void existByMemberIdAndGroupId_Return_True_If_GroupMember() {
         //given
         Member member = Member.builder().status(Status.ACTIVE).build();
         Group group = Group.builder().status(Status.ACTIVE).build();
@@ -52,7 +51,7 @@ class GroupMemberQueryRepositoryTest {
 
     @DisplayName("GroupMember가 존재하지 않다면 false를 반환한다.")
     @Test
-    void existByMemberIdAndGroupId_Return_False_If_Not_GroupMember(){
+    void existByMemberIdAndGroupId_Return_False_If_Not_GroupMember() {
         //given
         Member member = Member.builder().status(Status.ACTIVE).build();
         Group group = Group.builder().status(Status.ACTIVE).build();
@@ -70,7 +69,7 @@ class GroupMemberQueryRepositoryTest {
 
     @DisplayName("GroupMember의 status가 inactive라면 false를 반환한다.")
     @Test
-    void existByMemberIdAndGroupId_Return_False_If_GroupMember_Status_Inactive(){
+    void existByMemberIdAndGroupId_Return_False_If_GroupMember_Status_Inactive() {
         //given
         Member member = Member.builder().status(Status.ACTIVE).build();
         Group group = Group.builder().status(Status.ACTIVE).build();

--- a/src/test/java/scs/planus/domain/group/repository/GroupMemberRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/group/repository/GroupMemberRepositoryTest.java
@@ -15,8 +15,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RepositoryTest
-class GroupMemberRepositoryTest {
+class GroupMemberRepositoryTest extends RepositoryTest {
 
     private static final int COUNT = 7;
 
@@ -60,7 +59,7 @@ class GroupMemberRepositoryTest {
 
     @DisplayName("createGroupMember 호출시, GroupMember가 저장되어야 한다.")
     @Test
-    void createGroupMember_Then_Save_GroupMember(){
+    void createGroupMember_Then_Save_GroupMember() {
         //given
         GroupMember groupMember = GroupMember.createGroupMember(member, group);
 
@@ -77,7 +76,7 @@ class GroupMemberRepositoryTest {
 
     @DisplayName("createGroupLeader 호출시, GroupMember(leader)가 저장되어야 한다.")
     @Test
-    void createGroupLeader_Then_Save_GroupLeader(){
+    void createGroupLeader_Then_Save_GroupLeader() {
         //given
         GroupMember groupMember = GroupMember.createGroupLeader(member, group);
 

--- a/src/test/java/scs/planus/domain/group/repository/GroupRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/group/repository/GroupRepositoryTest.java
@@ -14,8 +14,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RepositoryTest
-class GroupRepositoryTest {
+class GroupRepositoryTest extends RepositoryTest {
 
     private final static int PAGE = 0;
     private final static int PAGE_SIZE = 5;

--- a/src/test/java/scs/planus/domain/group/repository/GroupTagRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/group/repository/GroupTagRepositoryTest.java
@@ -16,8 +16,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RepositoryTest
-class GroupTagRepositoryTest {
+class GroupTagRepositoryTest extends RepositoryTest {
     private static final String TAG_NAME = "테스트 태그 이름";
     private static final int TAG_COUNT = 10;
     private static final int GROUP_TAG_COUNT = 5;

--- a/src/test/java/scs/planus/domain/group/service/GroupJoinServiceTest.java
+++ b/src/test/java/scs/planus/domain/group/service/GroupJoinServiceTest.java
@@ -28,8 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static scs.planus.global.exception.CustomExceptionStatus.*;
 
-@ServiceTest
-class GroupJoinServiceTest {
+class GroupJoinServiceTest extends ServiceTest {
     private static final long NOT_EXIST_ID = 0L;
 
     private final MemberRepository memberRepository;

--- a/src/test/java/scs/planus/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/scs/planus/domain/group/service/GroupServiceTest.java
@@ -46,8 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static scs.planus.global.exception.CustomExceptionStatus.*;
 
-@ServiceTest
-class GroupServiceTest {
+class GroupServiceTest extends ServiceTest {
 
     private final static Long NOT_EXISTED_ID = 0L;
     private final static int COUNT = 7;
@@ -212,7 +211,7 @@ class GroupServiceTest {
         //then
         assertThat(groupMembers).hasSize(2);
     }
-    
+
     @DisplayName("Group 상세 정보가 변경되어야 한다.")
     @Test
     void updateGroupDetail() {

--- a/src/test/java/scs/planus/domain/group/service/GroupTagServiceTest.java
+++ b/src/test/java/scs/planus/domain/group/service/GroupTagServiceTest.java
@@ -19,8 +19,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ServiceTest
-class GroupTagServiceTest {
+class GroupTagServiceTest extends ServiceTest {
     private static final String TAG_NAME = "테스트 태그 이름";
     private static final int TAG_COUNT = 5;
 

--- a/src/test/java/scs/planus/domain/group/service/MyGroupServiceTest.java
+++ b/src/test/java/scs/planus/domain/group/service/MyGroupServiceTest.java
@@ -23,8 +23,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ServiceTest
-class MyGroupServiceTest {
+class MyGroupServiceTest extends ServiceTest {
 
     private static final int COUNT = 7;
 

--- a/src/test/java/scs/planus/domain/member/repository/MemberRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/member/repository/MemberRepositoryTest.java
@@ -11,8 +11,7 @@ import scs.planus.support.RepositoryTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RepositoryTest
-class MemberRepositoryTest {
+class MemberRepositoryTest extends RepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;

--- a/src/test/java/scs/planus/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/scs/planus/domain/member/service/MemberServiceTest.java
@@ -22,9 +22,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-@ServiceTest
 @ExtendWith(MockitoExtension.class)
-class MemberServiceTest {
+class MemberServiceTest extends ServiceTest {
 
     @MockBean
     private AmazonS3Uploader s3Uploader;

--- a/src/test/java/scs/planus/domain/tag/repository/TagRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/tag/repository/TagRepositoryTest.java
@@ -8,8 +8,7 @@ import scs.planus.support.RepositoryTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RepositoryTest
-class TagRepositoryTest {
+class TagRepositoryTest extends RepositoryTest {
 
     private static final String TAG_NAME = "테스트 태그 이름";
     private final TagRepository tagRepository;

--- a/src/test/java/scs/planus/domain/tag/service/TagServiceTest.java
+++ b/src/test/java/scs/planus/domain/tag/service/TagServiceTest.java
@@ -14,8 +14,7 @@ import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ServiceTest
-class TagServiceTest {
+class TagServiceTest extends ServiceTest {
     private static final String TAG_NAME = "테스트 태그 이름";
 
     private final TagRepository tagRepository;

--- a/src/test/java/scs/planus/domain/todo/repository/GroupTodoCompletionRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/todo/repository/GroupTodoCompletionRepositoryTest.java
@@ -16,8 +16,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RepositoryTest
-class GroupTodoCompletionRepositoryTest {
+class GroupTodoCompletionRepositoryTest extends RepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;

--- a/src/test/java/scs/planus/domain/todo/repository/TodoQueryRepositoryTest.java
+++ b/src/test/java/scs/planus/domain/todo/repository/TodoQueryRepositoryTest.java
@@ -24,8 +24,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RepositoryTest
-class TodoQueryRepositoryTest {
+class TodoQueryRepositoryTest extends RepositoryTest {
 
     private static final int COUNT = 7;
 
@@ -84,7 +83,7 @@ class TodoQueryRepositoryTest {
 
         @DisplayName("기간 내의 멤버 투두가 리스트 형식으로 조회되어야 한다.")
         @Test
-        void findAllPeriodMemberTodosByDate(){
+        void findAllPeriodMemberTodosByDate() {
             //given
             LocalDate date = LocalDate.of(2023, 1, 1);
 
@@ -140,7 +139,7 @@ class TodoQueryRepositoryTest {
 
         @DisplayName("기간 내의 그룹 투두가 리스트 형식으로 조회되어야 한다.")
         @Test
-        void findPeriodGroupTodosByDate(){
+        void findPeriodGroupTodosByDate() {
             //given
             LocalDate date = LocalDate.of(2023, 1, 1);
 
@@ -166,7 +165,7 @@ class TodoQueryRepositoryTest {
 
         @DisplayName("일별 그룹 투두가 존재한다면 리스트 형식으로 조회되어야 한다.")
         @Test
-        void findDailyGroupTodosByDate(){
+        void findDailyGroupTodosByDate() {
             //given
             LocalDate date = LocalDate.of(2023, 1, 1);
 
@@ -187,7 +186,7 @@ class TodoQueryRepositoryTest {
 
         @DisplayName("일별 조회시, 기간 투두의 경우 기간내에 조회하고자하는 일이 포함된다면 조회되어야 한다.")
         @Test
-        void findDailyGroupTodosByDate_Period_Todo(){
+        void findDailyGroupTodosByDate_Period_Todo() {
             //given
             LocalDate date = LocalDate.of(2022, 12, 31);
 
@@ -209,7 +208,7 @@ class TodoQueryRepositoryTest {
 
         @DisplayName("기간 내의 여러 그룹의 그룹 투두들이 반환되어야 한다.")
         @Test
-        void findAllPeriodGroupTodosByDate(){
+        void findAllPeriodGroupTodosByDate() {
             //given
             LocalDate date = LocalDate.of(2023, 1, 1);
 
@@ -259,7 +258,7 @@ class TodoQueryRepositoryTest {
 
         @DisplayName("같은 그룹 멤버의 해당 그룹 투두가 조회되어야 한다.")
         @Test
-        void findOneGroupMemberTodoById_GroupTodo(){
+        void findOneGroupMemberTodoById_GroupTodo() {
             //given
             groupTodoCategory = GroupTodoCategory.builder()
                     .group(group)
@@ -283,7 +282,7 @@ class TodoQueryRepositoryTest {
 
         @DisplayName("같은 그룹 멤버가 해당 그룹을 지정한 개인 투두가 조회되어야 한다.")
         @Test
-        void findOneGroupMemberTodoById_MemberTodo(){
+        void findOneGroupMemberTodoById_MemberTodo() {
             //given
             MemberTodoCategory memberTodoCategory = (MemberTodoCategory) todoCategoryRepository.findById(1L).orElseThrow();
 
@@ -305,7 +304,7 @@ class TodoQueryRepositoryTest {
 
         @DisplayName("같은 그룹 멤버가 해당 그룹을 지정하지 않은 개인 투두는 조회되서는 안된다.")
         @Test
-        void findOneGroupMemberTodoById_MemberTodo_Fail_If_Not_Assign_Group(){
+        void findOneGroupMemberTodoById_MemberTodo_Fail_If_Not_Assign_Group() {
             //given
             MemberTodoCategory memberTodoCategory = (MemberTodoCategory) todoCategoryRepository.findById(1L).orElseThrow();
 
@@ -325,7 +324,7 @@ class TodoQueryRepositoryTest {
 
         @DisplayName("기간 내의 그룹 멤버 투두가 리스트 형식으로 조회되어야 한다.")
         @Test
-        void findPeriodGroupTodosByDate(){
+        void findPeriodGroupTodosByDate() {
             //given
             LocalDate date = LocalDate.of(2023, 1, 1);
             MemberTodoCategory memberTodoCategory = (MemberTodoCategory) todoCategoryRepository.findById(1L).orElseThrow();
@@ -353,7 +352,7 @@ class TodoQueryRepositoryTest {
 
         @DisplayName("일별 그룹 멤버 투두가 존재한다면 리스트 형식으로 조회되어야 한다.")
         @Test
-        void findGroupMemberDailyTodosByDate(){
+        void findGroupMemberDailyTodosByDate() {
             //given
             LocalDate date = LocalDate.of(2023, 1, 1);
             MemberTodoCategory memberTodoCategory = (MemberTodoCategory) todoCategoryRepository.findById(1L).orElseThrow();

--- a/src/test/java/scs/planus/domain/todo/service/GroupTodoServiceTest.java
+++ b/src/test/java/scs/planus/domain/todo/service/GroupTodoServiceTest.java
@@ -31,8 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static scs.planus.global.exception.CustomExceptionStatus.*;
 
-@ServiceTest
-class GroupTodoServiceTest {
+class GroupTodoServiceTest extends ServiceTest {
 
     private static final Long NOT_EXIST_ID = 0L;
 

--- a/src/test/java/scs/planus/domain/todo/service/MemberTodoServiceTest.java
+++ b/src/test/java/scs/planus/domain/todo/service/MemberTodoServiceTest.java
@@ -28,8 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static scs.planus.global.exception.CustomExceptionStatus.*;
 
-@ServiceTest
-class MemberTodoServiceTest {
+class MemberTodoServiceTest extends ServiceTest {
 
     private static final Long NOT_EXISTED_ID = 0L;
 

--- a/src/test/java/scs/planus/domain/todo/service/calendar/GroupTodoCalendarServiceTest.java
+++ b/src/test/java/scs/planus/domain/todo/service/calendar/GroupTodoCalendarServiceTest.java
@@ -35,8 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static scs.planus.global.exception.CustomExceptionStatus.NOT_JOINED_GROUP;
 import static scs.planus.global.exception.CustomExceptionStatus.NOT_JOINED_MEMBER_IN_GROUP;
 
-@ServiceTest
-class GroupTodoCalendarServiceTest {
+class GroupTodoCalendarServiceTest extends ServiceTest {
 
     private static final int COUNT = 7;
 

--- a/src/test/java/scs/planus/domain/todo/service/calendar/MemberTodoCalendarServiceTest.java
+++ b/src/test/java/scs/planus/domain/todo/service/calendar/MemberTodoCalendarServiceTest.java
@@ -29,8 +29,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ServiceTest
-class MemberTodoCalendarServiceTest {
+class MemberTodoCalendarServiceTest extends ServiceTest {
 
     private static final int COUNT = 7;
 

--- a/src/test/java/scs/planus/global/auth/service/AuthServiceTest.java
+++ b/src/test/java/scs/planus/global/auth/service/AuthServiceTest.java
@@ -17,8 +17,7 @@ import static org.mockito.BDDMockito.given;
 import static scs.planus.global.exception.CustomExceptionStatus.EXPIRED_REFRESH_TOKEN;
 import static scs.planus.global.exception.CustomExceptionStatus.INVALID_REFRESH_TOKEN;
 
-@ServiceTest
-class AuthServiceTest {
+class AuthServiceTest extends ServiceTest {
 
     private static final String TEST_EMAIL = "test@test";
     private static final String ACCESS_TOKEN = "accessToken";

--- a/src/test/java/scs/planus/global/auth/service/JwtProviderTest.java
+++ b/src/test/java/scs/planus/global/auth/service/JwtProviderTest.java
@@ -11,8 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static scs.planus.global.exception.CustomExceptionStatus.UNAUTHORIZED_ACCESS_TOKEN;
 
-@ServiceTest
-class JwtProviderTest {
+class JwtProviderTest extends ServiceTest {
 
     private static final String SECRET_KEY = "A".repeat(64);
     private static final int ACCESS_TOKEN_EXPIRED_IN = 3600;

--- a/src/test/java/scs/planus/global/auth/service/PrincipalDetailsServiceTest.java
+++ b/src/test/java/scs/planus/global/auth/service/PrincipalDetailsServiceTest.java
@@ -15,8 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static scs.planus.global.exception.CustomExceptionStatus.NONE_USER;
 
-@ServiceTest
-class PrincipalDetailsServiceTest {
+class PrincipalDetailsServiceTest extends ServiceTest {
 
     private final MemberRepository memberRepository;
     private PrincipalDetailsService principalDetailsService;

--- a/src/test/java/scs/planus/support/RepositoryTest.java
+++ b/src/test/java/scs/planus/support/RepositoryTest.java
@@ -5,15 +5,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
 import scs.planus.config.ExternalApiConfig;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
 @DataJpaTest
 @Import(ExternalApiConfig.class)
 @Sql(scripts = {"classpath:schema.sql", "classpath:data.sql"})
-public @interface RepositoryTest {
+public abstract class RepositoryTest {
 }

--- a/src/test/java/scs/planus/support/ServiceTest.java
+++ b/src/test/java/scs/planus/support/ServiceTest.java
@@ -5,15 +5,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.jdbc.Sql;
 import scs.planus.config.ExternalApiConfig;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE)
 @DataJpaTest
 @Import(ExternalApiConfig.class)
 @Sql(scripts = {"classpath:schema.sql", "classpath:data.sql"})
-public @interface ServiceTest {
+public abstract class ServiceTest {
 }


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- 어노테이션 대신 추상클래스 상속하도록 변경

### :: 특이사항
- `@ServiceTest` / `@RepositoryTest` 대신, 추상클래스를 구현하였으며, 테스트코드들이 이를 상속하도록 변경하였습니다.
