### PR TITLE
[Test] AmazonS3Uploader 리팩토링 및 테스트코드 

### DIFF
--- a/src/main/java/scs/planus/infra/s3/AmazonS3Uploader.java
+++ b/src/main/java/scs/planus/infra/s3/AmazonS3Uploader.java
@@ -6,7 +6,6 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -24,14 +23,17 @@ import java.util.UUID;
 import static scs.planus.global.exception.CustomExceptionStatus.*;
 
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class AmazonS3Uploader {
 
     private final AmazonS3Client amazonS3Client;
+    public final String bucket;
 
-    @Value("${cloud.aws.s3.bucket}")
-    public String bucket;
+    public AmazonS3Uploader(AmazonS3Client amazonS3Client,
+                            @Value("${cloud.aws.s3.bucket}") String bucket) {
+        this.amazonS3Client = amazonS3Client;
+        this.bucket = bucket;
+    }
 
     public String upload(MultipartFile multipartFile, String dirName) {
         try {

--- a/src/test/java/scs/planus/infra/s3/AmazonS3UploaderTest.java
+++ b/src/test/java/scs/planus/infra/s3/AmazonS3UploaderTest.java
@@ -1,0 +1,109 @@
+package scs.planus.infra.s3;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockMultipartFile;
+import scs.planus.support.ServiceTest;
+
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class AmazonS3UploaderTest extends ServiceTest {
+
+    public static final String BASE_URL = "https://test-planus-bucket.s3.amazonaws.com/";
+    private static final String TEST_BUCKET = "test-planus-bucket";
+    private static final String TEST_DIRECTORY = "test-directory";
+
+    @MockBean
+    private AmazonS3Client amazonS3Client;
+    private AmazonS3Uploader amazonS3Uploader;
+
+    @BeforeEach
+    void init() {
+        amazonS3Uploader = new AmazonS3Uploader(amazonS3Client, TEST_BUCKET);
+    }
+
+    @DisplayName("S3에 이미지가 업로드되어야 한다.")
+    @Test
+    void upload() throws Exception {
+
+        //given
+        MockMultipartFile file = new MockMultipartFile("test-image", "test.png", "image/png", "test".getBytes());
+        String urlPath = BASE_URL + TEST_DIRECTORY + "/" + file.getOriginalFilename();
+
+        given(amazonS3Client.putObject(any(PutObjectRequest.class)))
+                .willReturn(new PutObjectResult());
+
+        given(amazonS3Client.getUrl(anyString(), anyString()))
+                .willReturn(new URL(urlPath));
+
+        //when
+        String upload = amazonS3Uploader.upload(file, TEST_DIRECTORY);
+
+        //then
+        assertThat(upload).isEqualTo(urlPath);
+    }
+
+    @DisplayName("이미지 변경 시, 기존의 이미지가 제거된 후, 새로운 이미지가 S3에 업로드되어야 한다.")
+    @Test
+    void updateImage() throws Exception {
+
+        //given
+        MockMultipartFile oldFile = new MockMultipartFile("oldImage", "old-image.png", "image/png", "test".getBytes());
+        String oldUrlPath = BASE_URL + TEST_DIRECTORY + "/" + oldFile.getOriginalFilename();
+
+        MockMultipartFile updatedFile = new MockMultipartFile("updatedImage", "new-image.png", "image/png", "test".getBytes());
+        String updatedUrlPath = BASE_URL + TEST_DIRECTORY + "/" + updatedFile.getOriginalFilename();
+
+        given(amazonS3Client.putObject(any(PutObjectRequest.class)))
+                .willReturn(new PutObjectResult());
+
+        given(amazonS3Client.getUrl(anyString(), anyString()))
+                .willReturn(new URL(oldUrlPath))
+                .willReturn(new URL(updatedUrlPath));
+
+        amazonS3Uploader.upload(oldFile, TEST_DIRECTORY);
+
+        //when
+        String updatedImage = amazonS3Uploader.updateImage(oldFile, oldUrlPath, TEST_DIRECTORY);
+
+        //then
+        verify(amazonS3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
+        assertThat(updatedImage).isEqualTo(updatedUrlPath);
+    }
+
+    @DisplayName("이미지가 변경되지 않았더라면 이전 이미지 URL을 반환한다.")
+    @Test
+    void updateImage_If_Not_Update_Image_Then_Return_Old_Image_Url() throws Exception {
+
+        //given
+        MockMultipartFile oldFile = new MockMultipartFile("oldImage", "old-image.png", "image/png", "test".getBytes());
+        String oldUrlPath = BASE_URL + TEST_DIRECTORY + "/" + oldFile.getOriginalFilename();
+
+        given(amazonS3Client.putObject(any(PutObjectRequest.class)))
+                .willReturn(new PutObjectResult());
+
+        given(amazonS3Client.getUrl(anyString(), anyString()))
+                .willReturn(new URL(oldUrlPath));
+
+        amazonS3Uploader.upload(oldFile, TEST_DIRECTORY);
+
+        //when
+        String updatedImage = amazonS3Uploader.updateImage(null, oldUrlPath, TEST_DIRECTORY);
+
+        //then
+        assertThat(updatedImage).isEqualTo(oldUrlPath);
+    }
+}

--- a/src/test/java/scs/planus/infra/s3/AmazonS3UploaderTest.java
+++ b/src/test/java/scs/planus/infra/s3/AmazonS3UploaderTest.java
@@ -38,14 +38,12 @@ class AmazonS3UploaderTest extends ServiceTest {
     @DisplayName("S3에 이미지가 업로드되어야 한다.")
     @Test
     void upload() throws Exception {
-
         //given
         MockMultipartFile file = new MockMultipartFile("test-image", "test.png", "image/png", "test".getBytes());
         String urlPath = BASE_URL + TEST_DIRECTORY + "/" + file.getOriginalFilename();
 
         given(amazonS3Client.putObject(any(PutObjectRequest.class)))
                 .willReturn(new PutObjectResult());
-
         given(amazonS3Client.getUrl(anyString(), anyString()))
                 .willReturn(new URL(urlPath));
 
@@ -59,7 +57,6 @@ class AmazonS3UploaderTest extends ServiceTest {
     @DisplayName("이미지 변경 시, 기존의 이미지가 제거된 후, 새로운 이미지가 S3에 업로드되어야 한다.")
     @Test
     void updateImage() throws Exception {
-
         //given
         MockMultipartFile oldFile = new MockMultipartFile("oldImage", "old-image.png", "image/png", "test".getBytes());
         String oldUrlPath = BASE_URL + TEST_DIRECTORY + "/" + oldFile.getOriginalFilename();
@@ -69,7 +66,6 @@ class AmazonS3UploaderTest extends ServiceTest {
 
         given(amazonS3Client.putObject(any(PutObjectRequest.class)))
                 .willReturn(new PutObjectResult());
-
         given(amazonS3Client.getUrl(anyString(), anyString()))
                 .willReturn(new URL(oldUrlPath))
                 .willReturn(new URL(updatedUrlPath));
@@ -94,7 +90,6 @@ class AmazonS3UploaderTest extends ServiceTest {
 
         given(amazonS3Client.putObject(any(PutObjectRequest.class)))
                 .willReturn(new PutObjectResult());
-
         given(amazonS3Client.getUrl(anyString(), anyString()))
                 .willReturn(new URL(oldUrlPath));
 


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [X]  테스트 🔍

### :: 구현
- AmazonS3Uploader 리팩토링
- AmazonS3Uploader 테스트코드 

### :: 특이사항
### AmazonS3Uploader 리팩토링
- JwtProvider과 유사하게, 생성자에서 필드를 초기화시켜 더욱 유연한 객체 생성이 가능하도록 리팩토링하였습니다.

### AmazonS3Uploader 테스트코드 
```java
given(amazonS3Client.getUrl(anyString(), anyString()))
        .willReturn(new URL(oldUrlPath))
        .willReturn(new URL(updatedUrlPath));
````
- `updateImage()`를 테스트하기 위해선 `getUrl()`이 2번 호출됩니다.
1. 초기 upload 시 호출
2. 이후 update 시 호출
- 따라서 1의 경우, `oldUrlPath`가 반환되고, 2의 경우 `updatedUrlPath`가 반환되도록 구현하였습니다.
