### PR TITLE
[Refactor] Group 회원 수 조회 버그 수정

### DIFF
--- a/src/main/java/scs/planus/domain/group/dto/GroupGetDetailResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupGetDetailResponseDto.java
@@ -29,7 +29,7 @@ public class GroupGetDetailResponseDto {
                 .isJoined( isJoined )
                 .notice( group.getNotice() )
                 .groupImageUrl( group.getGroupImageUrl() )
-                .memberCount( group.getGroupMembers().size() )
+                .memberCount( group.getActiveGroupMembersSize() )
                 .limitCount( group.getLimitCount() )
                 .leaderName( group.getLeader().getNickname() )
                 .groupTags( groupTagNameList )

--- a/src/main/java/scs/planus/domain/group/dto/GroupsGetResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/GroupsGetResponseDto.java
@@ -2,7 +2,6 @@ package scs.planus.domain.group.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import scs.planus.domain.Status;
 import scs.planus.domain.group.entity.Group;
 
 import java.util.List;
@@ -24,9 +23,7 @@ public class GroupsGetResponseDto {
                 .groupId( group.getId() )
                 .name( group.getName() )
                 .groupImageUrl( group.getGroupImageUrl() )
-                .memberCount( (int) group.getGroupMembers().stream()
-                        .filter(gm -> gm.getStatus().equals(Status.ACTIVE))
-                        .count() )
+                .memberCount( group.getActiveGroupMembersSize() )
                 .limitCount( group.getLimitCount() )
                 .leaderId( group.getLeader().getId() )
                 .leaderName( group.getLeader().getNickname() )

--- a/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupDetailResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupDetailResponseDto.java
@@ -35,7 +35,7 @@ public class MyGroupDetailResponseDto {
                 .hasTodoAuthority(groupMember.isTodoAuthority())
                 .isOnline(groupMember.isOnlineStatus())
                 .onlineCount(onlineCount)
-                .memberCount(group.getGroupMembers().size()) // 추가쿼리 발생
+                .memberCount(group.getActiveGroupMembersSize()) // 추가쿼리 발생
                 .limitCount(group.getLimitCount())
                 .leaderName(group.getLeader().getNickname()) // 추가쿼리 발생
                 .notice(group.getNotice())

--- a/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupResponseDto.java
@@ -28,7 +28,7 @@ public class MyGroupResponseDto {
                 .groupName(group.getName())
                 .isOnline(onlineStatus)
                 .onlineCount(onlineCount)
-                .memberCount(group.getGroupMembers().size()) // 추가쿼리 발생
+                .memberCount(group.getActiveGroupMembersSize()) // 추가쿼리 발생
                 .limitCount(group.getLimitCount())
                 .leaderName(group.getLeader().getNickname()) // 추가쿼리 발생
                 .groupTags(eachGroupTagDtos)

--- a/src/main/java/scs/planus/domain/group/entity/Group.java
+++ b/src/main/java/scs/planus/domain/group/entity/Group.java
@@ -92,4 +92,10 @@ public class Group extends BaseTimeEntity {
     public void removeGroupTag(GroupTag groupTag) {
         this.getGroupTags().remove(groupTag);
     }
+
+    public int getActiveGroupMembersSize() {
+        return (int) this.getGroupMembers().stream()
+                .filter(gm -> gm.getStatus().equals(Status.ACTIVE))
+                .count();
+    }
 }

--- a/src/test/java/scs/planus/domain/group/entity/GroupTest.java
+++ b/src/test/java/scs/planus/domain/group/entity/GroupTest.java
@@ -138,4 +138,25 @@ class GroupTest {
         //then
         assertThat(group.getGroupTags()).isEmpty();
     }
+
+    @DisplayName("Group의 활성상태인 회원수가 조회되어야 한다.")
+    @Test
+    void getActiveGroupMembersSize(){
+        // given
+        Group group = Group.builder()
+                .status(Status.ACTIVE)
+                .build();
+
+        GroupMember.builder()
+                .group(group)
+                .build();
+
+        GroupMember.builder()
+                .group(group)
+                .build()
+                .changeStatusToInactive();
+
+        // when & then
+        assertThat(group.getActiveGroupMembersSize()).isEqualTo(1);
+    }
 }


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [X]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [X]  테스트 🔍

### :: 구현
### Group 회원 수 조회 시 발생하는 버그를 수정하였습니다.
1. 문제 사항
- Group 회원 수 조회 시, 활성 상태가 아닌, 탈퇴한 Inactive 상태의 회원들 까지 조회되는 문제 발생

2.  해결
- Group 도메인단에 Active 상태인 회원들 수만 반환하는 메소드 구현

3. 적용 대상
- GroupsGetResponseDto
- GroupGetDetailResponseDto
- MyGroupResponseDto
- MyGroupDetailResponseDto

4. GroupTest 에 테스트 코드 구현

### :: 특이사항
- 
