### PR TITLE
[Refactor] MyGroupOnlineStatusResponseDto 필드 변경 

### DIFF
--- a/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupOnlineStatusResponseDto.java
+++ b/src/main/java/scs/planus/domain/group/dto/mygroup/MyGroupOnlineStatusResponseDto.java
@@ -8,11 +8,11 @@ import scs.planus.domain.group.entity.GroupMember;
 @Builder
 public class MyGroupOnlineStatusResponseDto {
 
-    private Long groupMemberId;
+    private Long memberId;
 
     public static MyGroupOnlineStatusResponseDto of(GroupMember groupMember) {
         return MyGroupOnlineStatusResponseDto.builder()
-                .groupMemberId(groupMember.getId())
+                .memberId(groupMember.getMember().getId())
                 .build();
     }
 }

--- a/src/test/java/scs/planus/domain/group/controller/MyGroupControllerTest.java
+++ b/src/test/java/scs/planus/domain/group/controller/MyGroupControllerTest.java
@@ -109,7 +109,7 @@ class MyGroupControllerTest extends ControllerTest {
         Long groupId = 1L;
 
         given(myGroupService.changeOnlineStatus(anyLong(), anyLong()))
-                .willReturn(MyGroupOnlineStatusResponseDto.builder().groupMemberId(1L).build());
+                .willReturn(MyGroupOnlineStatusResponseDto.builder().memberId(1L).build());
 
         //when & then
         mockMvc

--- a/src/test/java/scs/planus/domain/group/service/MyGroupServiceTest.java
+++ b/src/test/java/scs/planus/domain/group/service/MyGroupServiceTest.java
@@ -167,7 +167,7 @@ class MyGroupServiceTest extends ServiceTest {
                 = myGroupService.changeOnlineStatus(member.getId(), group.getId());
 
         //then
-        assertThat(myGroupOnlineStatusResponseDto.getGroupMemberId()).isEqualTo(groupMember.getId());
+        assertThat(myGroupOnlineStatusResponseDto.getMemberId()).isEqualTo(member.getId());
         assertThat(groupMember.isOnlineStatus()).isTrue();
     }
 }


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [X]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- MyGroupOnlineStatusResponseDto 필드 변경

### :: 특이사항
- 프론트의 캐싱을 위하여 groupMemberId -> memberId로 변경하였습니다.
