### PR TITLE
[Oauth] Apple OAuth 로그인 기능 구현

### DIFF
--- a/src/main/java/scs/planus/global/auth/controller/OAuthController.java
+++ b/src/main/java/scs/planus/global/auth/controller/OAuthController.java
@@ -4,12 +4,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import scs.planus.global.auth.dto.apple.AppleAuthRequestDto;
 import scs.planus.global.auth.dto.OAuthLoginResponseDto;
+import scs.planus.global.auth.service.apple.AppleOAuthService;
 import scs.planus.global.auth.service.OAuthService;
 import scs.planus.global.common.response.BaseResponse;
 
@@ -21,12 +19,22 @@ import scs.planus.global.common.response.BaseResponse;
 public class OAuthController {
 
     private final OAuthService oAuthService;
+    private final AppleOAuthService appleOAuthService;
 
     @GetMapping("/oauth/{provider}")
     @Operation(summary = "OAuth API")
     public BaseResponse<OAuthLoginResponseDto> socialLogin(@PathVariable String provider,
                                                            @RequestParam String code) {
         OAuthLoginResponseDto loginResponseDto = oAuthService.login(provider, code);
+        return new BaseResponse<>(loginResponseDto);
+    }
+
+    @PostMapping("/oauth/apple/login")
+    @Operation(summary = "Apple OAuth API")
+    public BaseResponse<OAuthLoginResponseDto> appleLogin(@RequestBody AppleAuthRequestDto appleAuthRequestDto) {
+
+        OAuthLoginResponseDto loginResponseDto = appleOAuthService.login(appleAuthRequestDto);
+
         return new BaseResponse<>(loginResponseDto);
     }
 }

--- a/src/main/java/scs/planus/global/auth/dto/apple/AppleAuthRequestDto.java
+++ b/src/main/java/scs/planus/global/auth/dto/apple/AppleAuthRequestDto.java
@@ -1,0 +1,12 @@
+package scs.planus.global.auth.dto.apple;
+
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class AppleAuthRequestDto {
+    @NotBlank(message = "[request] identityToken 값을 입력해 주세요.")
+    private String identityToken;
+    private FullName fullName;
+}

--- a/src/main/java/scs/planus/global/auth/dto/apple/FullName.java
+++ b/src/main/java/scs/planus/global/auth/dto/apple/FullName.java
@@ -1,0 +1,9 @@
+package scs.planus.global.auth.dto.apple;
+
+import lombok.Getter;
+
+@Getter
+public class FullName {
+    private String givenName;
+    private String familyName;
+}

--- a/src/main/java/scs/planus/global/auth/entity/apple/ApplePublicKey.java
+++ b/src/main/java/scs/planus/global/auth/entity/apple/ApplePublicKey.java
@@ -1,0 +1,20 @@
+package scs.planus.global.auth.entity.apple;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ApplePublicKey {
+    private String kty; // key 유형 매개변수 설정. "RSA"로 설정해야함.
+    private String kid; // Apple developer account 에서 얻은 identity key
+    private String use; // public key 의 용도
+    private String alg; // 토큰을 암호화 하는데 사용된 암호화 알고리즘
+    private String n; // RSA public key 의 모듈러스 값
+    private String e; // RSA public key 의 지수 값
+}
+
+

--- a/src/main/java/scs/planus/global/auth/entity/apple/ApplePublicKeys.java
+++ b/src/main/java/scs/planus/global/auth/entity/apple/ApplePublicKeys.java
@@ -1,0 +1,26 @@
+package scs.planus.global.auth.entity.apple;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import scs.planus.global.exception.PlanusException;
+
+import java.util.List;
+
+import static scs.planus.global.exception.CustomExceptionStatus.INVALID_ALG_KID_INFO;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ApplePublicKeys {
+    private List<ApplePublicKey> keys;
+
+    public ApplePublicKey getMatchesKey(String alg, String kid) {
+        return this.keys
+                .stream()
+                .filter(k -> k.getAlg().equals(alg) && k.getKid().equals(kid))
+                .findFirst()
+                .orElseThrow(() -> new PlanusException(INVALID_ALG_KID_INFO));
+    }
+}

--- a/src/main/java/scs/planus/global/auth/service/OAuthService.java
+++ b/src/main/java/scs/planus/global/auth/service/OAuthService.java
@@ -11,19 +11,22 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
+import scs.planus.domain.Status;
+import scs.planus.domain.member.entity.Member;
+import scs.planus.domain.member.repository.MemberRepository;
 import scs.planus.global.auth.dto.OAuth2TokenResponseDto;
 import scs.planus.global.auth.dto.OAuthLoginResponseDto;
-import scs.planus.global.auth.entity.Token;
-import scs.planus.infra.redis.RedisService;
 import scs.planus.global.auth.entity.MemberProfile;
 import scs.planus.global.auth.entity.OAuthAttributes;
-import scs.planus.domain.member.entity.Member;
-import scs.planus.domain.Status;
-import scs.planus.domain.member.repository.MemberRepository;
+import scs.planus.global.auth.entity.Token;
+import scs.planus.global.exception.PlanusException;
+import scs.planus.infra.redis.RedisService;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
+
+import static scs.planus.global.exception.CustomExceptionStatus.ALREADY_EXIST_SOCIAL_ACCOUNT;
 
 @Service
 @RequiredArgsConstructor
@@ -96,6 +99,10 @@ public class OAuthService {
         if (member == null) {
             member = memberRepository.save(profile.toEntity());
             return member;
+        }
+
+        if (!member.getSocialType().equals(profile.getSocialType())) {
+            throw new PlanusException(ALREADY_EXIST_SOCIAL_ACCOUNT);
         }
 
         if (member.getStatus().equals(Status.INACTIVE)) {

--- a/src/main/java/scs/planus/global/auth/service/apple/AppleAuthClient.java
+++ b/src/main/java/scs/planus/global/auth/service/apple/AppleAuthClient.java
@@ -1,0 +1,25 @@
+package scs.planus.global.auth.service.apple;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import scs.planus.global.auth.entity.apple.ApplePublicKeys;
+
+@Component
+public class AppleAuthClient {
+
+    private final String publicKeyUrl;
+
+    public AppleAuthClient(@Value("${oauth.apple.public-key-url}") String publicKeyUrl) {
+        this.publicKeyUrl = publicKeyUrl;
+    }
+
+    public ApplePublicKeys getApplePublicKey() {
+        return WebClient.create()
+                .get()
+                .uri(publicKeyUrl)
+                .retrieve()
+                .bodyToMono(ApplePublicKeys.class)
+                .block();
+    }
+}

--- a/src/main/java/scs/planus/global/auth/service/apple/AppleClaimsValidator.java
+++ b/src/main/java/scs/planus/global/auth/service/apple/AppleClaimsValidator.java
@@ -1,0 +1,36 @@
+package scs.planus.global.auth.service.apple;
+
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import scs.planus.global.exception.PlanusException;
+import scs.planus.global.util.encryptor.Encryptor;
+
+import static scs.planus.global.exception.CustomExceptionStatus.INVALID_APPLE_IDENTITY_TOKEN;
+
+@Component
+public class AppleClaimsValidator {
+    private static final String NONCE_KEY = "nonce";
+
+    private final String iss;
+    private final String clientId;
+    private final String nonce;
+
+    public AppleClaimsValidator(@Value("${oauth.apple.iss}") String iss,
+                                @Value("${oauth.apple.client-id}") String clientId,
+                                @Value("${oauth.apple.nonce}") String nonce) {
+        this.iss = iss;
+        this.clientId = clientId;
+        this.nonce = Encryptor.encryptWithSHA256(nonce);
+    }
+
+    public void validation(Claims claims) {
+        boolean result = claims.getIssuer().contains(iss) &&
+                claims.getAudience().equals(clientId) &&
+                claims.get(NONCE_KEY, String.class).equals(nonce);
+
+        if (!result) {
+            throw new PlanusException(INVALID_APPLE_IDENTITY_TOKEN);
+        }
+    }
+}

--- a/src/main/java/scs/planus/global/auth/service/apple/AppleJwtParser.java
+++ b/src/main/java/scs/planus/global/auth/service/apple/AppleJwtParser.java
@@ -1,0 +1,50 @@
+package scs.planus.global.auth.service.apple;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Base64Utils;
+import scs.planus.global.exception.PlanusException;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+import static scs.planus.global.exception.CustomExceptionStatus.*;
+
+@Component
+public class AppleJwtParser {
+    private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";
+    private static final int HEADER_INDEX = 0;
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public Map<String, String> parseHeaders(String identityToken) {
+        try {
+            String encodedHeader = identityToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
+            String decodedHeader = new String(Base64Utils.decodeFromUrlSafeString(encodedHeader));
+
+            return OBJECT_MAPPER.readValue(decodedHeader, Map.class);
+        } catch (JsonProcessingException | ArrayIndexOutOfBoundsException e) {
+            throw new PlanusException(INVALID_APPLE_IDENTITY_TOKEN);
+        } catch (RuntimeException e) {
+            throw new PlanusException(INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public Claims parseClaimWithPublicKey(String identityToken, PublicKey publicKey) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(identityToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new PlanusException(UNAUTHORIZED_ACCESS_TOKEN);
+        } catch (UnsupportedJwtException | MalformedJwtException | IllegalArgumentException e) {
+            throw new PlanusException(INVALID_APPLE_IDENTITY_TOKEN);
+        } catch (RuntimeException e) {
+            throw new PlanusException(INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/scs/planus/global/auth/service/apple/AppleOAuthService.java
+++ b/src/main/java/scs/planus/global/auth/service/apple/AppleOAuthService.java
@@ -1,0 +1,102 @@
+package scs.planus.global.auth.service.apple;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import scs.planus.domain.Status;
+import scs.planus.domain.member.entity.Member;
+import scs.planus.domain.member.entity.Role;
+import scs.planus.domain.member.entity.SocialType;
+import scs.planus.domain.member.repository.MemberRepository;
+import scs.planus.global.auth.dto.apple.AppleAuthRequestDto;
+import scs.planus.global.auth.dto.apple.FullName;
+import scs.planus.global.auth.dto.OAuthLoginResponseDto;
+import scs.planus.global.auth.entity.apple.ApplePublicKeys;
+import scs.planus.global.auth.entity.Token;
+import scs.planus.global.auth.service.JwtProvider;
+import scs.planus.global.exception.PlanusException;
+import scs.planus.infra.redis.RedisService;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+import static scs.planus.global.exception.CustomExceptionStatus.ALREADY_EXIST_SOCIAL_ACCOUNT;
+import static scs.planus.global.exception.CustomExceptionStatus.INVALID_USER_NAME;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AppleOAuthService {
+    private static final String EMAIL_KEY = "email";
+
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
+    private final RedisService redisService;
+
+    private final AppleJwtParser appleJwtParser;
+    private final AppleAuthClient appleAuthClient;
+    private final ApplePublicKeyGenerator applePublicKeyGenerator;
+    private final AppleClaimsValidator appleClaimsValidator;
+
+    public OAuthLoginResponseDto login(AppleAuthRequestDto appleAuthRequestDto) {
+        String email = getAppleEmail(appleAuthRequestDto.getIdentityToken());
+
+        Member member  = memberRepository.findByEmail(email)
+                .map(this::validateMember)
+                .orElseGet(() -> saveNewMember(appleAuthRequestDto, email));
+
+        Token token = jwtProvider.generateToken(member.getEmail());
+        redisService.saveValue(member.getEmail(), token);
+
+        return OAuthLoginResponseDto.builder()
+                .memberId(member.getId())
+                .accessToken(token.getAccessToken())
+                .refreshToken(token.getRefreshToken())
+                .build();
+    }
+
+    public String getAppleEmail(String identityToken) {
+        Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
+
+        ApplePublicKeys applePublicKey = appleAuthClient.getApplePublicKey();
+
+        PublicKey publicKey = applePublicKeyGenerator.generatePublicKey(headers, applePublicKey);
+
+        Claims claims = appleJwtParser.parseClaimWithPublicKey(identityToken, publicKey);
+        appleClaimsValidator.validation(claims);
+
+        return claims.get(EMAIL_KEY, String.class);
+    }
+
+    public Member saveNewMember(AppleAuthRequestDto appleAuthRequestDto, String email) {
+        String nickName = getName(appleAuthRequestDto.getFullName());
+        return memberRepository.save(
+                Member.builder()
+                        .nickname(nickName)
+                        .email(email)
+                        .socialType(SocialType.APPLE)
+                        .status(Status.ACTIVE)
+                        .role(Role.USER)
+                        .build()
+        );
+    }
+
+    public String getName(FullName fullName) {
+        if (fullName == null) {
+            throw new PlanusException(INVALID_USER_NAME);
+        }
+        return fullName.getFamilyName() + fullName.getGivenName();
+    }
+
+    public Member validateMember(Member member) {
+        if (!member.getSocialType().equals(SocialType.APPLE)) {
+            throw new PlanusException(ALREADY_EXIST_SOCIAL_ACCOUNT);
+        }
+
+        if (member.getStatus().equals(Status.INACTIVE)) {
+            member.init(member.getNickname());
+        }
+        return member;
+    }
+}

--- a/src/main/java/scs/planus/global/auth/service/apple/ApplePublicKeyGenerator.java
+++ b/src/main/java/scs/planus/global/auth/service/apple/ApplePublicKeyGenerator.java
@@ -1,0 +1,48 @@
+package scs.planus.global.auth.service.apple;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.Base64Utils;
+import scs.planus.global.auth.entity.apple.ApplePublicKey;
+import scs.planus.global.auth.entity.apple.ApplePublicKeys;
+import scs.planus.global.exception.PlanusException;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Map;
+
+import static scs.planus.global.exception.CustomExceptionStatus.APPLE_PUBLIC_KEY_GENERATION_ERROR;
+
+@Component
+public class ApplePublicKeyGenerator {
+    private static final String SIGN_ALGORITHM_HEADER_KEY = "alg";
+    private static final String KEY_ID_HEADER_KEY = "kid";
+    private static final int POSITIVE_SIGN_NUMBER = 1;
+
+    public PublicKey generatePublicKey(Map<String, String> headers, ApplePublicKeys applePublicKeys) {
+        ApplePublicKey applePublicKey =
+                applePublicKeys.getMatchesKey(headers.get(SIGN_ALGORITHM_HEADER_KEY), headers.get(KEY_ID_HEADER_KEY));
+
+        return generatePublicKeyWithApplePublicKey(applePublicKey);
+    }
+
+    private PublicKey generatePublicKeyWithApplePublicKey(ApplePublicKey publicKey) throws PlanusException {
+        byte[] nBytes = Base64Utils.decodeFromUrlSafeString(publicKey.getN());
+        byte[] eBytes = Base64Utils.decodeFromUrlSafeString(publicKey.getE());
+
+        BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
+        BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
+
+        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
+
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance(publicKey.getKty());
+            return keyFactory.generatePublic(publicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            throw new PlanusException(APPLE_PUBLIC_KEY_GENERATION_ERROR);
+        }
+    }
+}

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -20,12 +20,20 @@ public enum CustomExceptionStatus implements ResponseStatus {
     DUPLICATED_EMAIL(CONFLICT, 2100, "중복된 이메일이 존재합니다."),
     NONE_USER(BAD_REQUEST, 2110, "존재하지 않는 회원입니다."),
     NONE_SOCIAL_TYPE(BAD_REQUEST, 2200, "존재하지 않는 소셜 로그인 타입입니다."),
+    ALREADY_EXIST_SOCIAL_ACCOUNT(BAD_REQUEST, 2201, "이미 가입된 소셜 계정이 존재합니다."),
 
     // jwt exception
     UNAUTHORIZED_ACCESS_TOKEN(UNAUTHORIZED, 2300, "인증되지 않거나 만료된 토큰입니다."),
     FORBIDDEN_ACCESS_TOKEN(FORBIDDEN, 2301, "권한이 없는 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(BAD_REQUEST, 2302, "Refresh Token 이 만료되어 재로그인이 필요합니다."),
     INVALID_REFRESH_TOKEN(BAD_REQUEST, 2303, "잘못된 Refresh Token 입니다."),
+
+    // apple identity token exception
+    INVALID_APPLE_IDENTITY_TOKEN(BAD_REQUEST, 2310, "Apple OAuth Identity Token 형식이 올바르지 않습니다."),
+    INVALID_ALG_KID_INFO(BAD_REQUEST, 2311, "Apple JWT 값의 alg, kid 정보가 올바르지 않습니다."),
+    INVALID_CLAIMS_VALUE(BAD_REQUEST, 2312, "Apple OAuth Claims 값이 올바르지 않습니다."),
+    APPLE_PUBLIC_KEY_GENERATION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 2313, "Apple OAuth 로그인 중 public key 생성에 문제가 발생했습니다."),
+    INVALID_USER_NAME(BAD_REQUEST, 2314, "Apple 사용자의 이름이 비어있습니다."),
 
     // category exception
     NOT_EXIST_CATEGORY(BAD_REQUEST, 2400, "존재하지 않는 카테고리 입니다."),

--- a/src/main/java/scs/planus/global/util/encryptor/Encryptor.java
+++ b/src/main/java/scs/planus/global/util/encryptor/Encryptor.java
@@ -1,0 +1,26 @@
+package scs.planus.global.util.encryptor;
+
+import scs.planus.global.exception.PlanusException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static scs.planus.global.exception.CustomExceptionStatus.INTERNAL_SERVER_ERROR;
+
+public class Encryptor {
+    public static String encryptWithSHA256(String value) throws PlanusException {
+        try {
+            MessageDigest sha256 = MessageDigest.getInstance("SHA-256");
+            byte[] digest = sha256.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : digest) {
+                hexString.append(String.format("%02x", b));
+            }
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new PlanusException(INTERNAL_SERVER_ERROR);
+        }
+    }
+
+}

--- a/src/test/java/scs/planus/global/auth/controller/OAuthControllerTest.java
+++ b/src/test/java/scs/planus/global/auth/controller/OAuthControllerTest.java
@@ -6,6 +6,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import scs.planus.global.auth.dto.OAuthLoginResponseDto;
+import scs.planus.global.auth.service.apple.AppleOAuthService;
 import scs.planus.global.auth.service.OAuthService;
 import scs.planus.support.ControllerTest;
 
@@ -20,6 +21,8 @@ class OAuthControllerTest extends ControllerTest {
 
     @MockBean
     private OAuthService oAuthService;
+    @MockBean
+    private AppleOAuthService appleOAuthService;
 
     @DisplayName("소셜로그인이 정상적으로 작동되어야 한다.")
     @Test


### PR DESCRIPTION
### :: PR 타입
- [X] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [X]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍


### :: 구현
### 🔥 `OAuthController` 🔥
### `AppleAuthRequestDto` & `FullName`
Apple OAuth 로그인 요청 Dto 입니다.
- Apple Server 로부터 프론트가 받는 Response 형식 그대로 구현하였습니다. 따라서 프론트는 Apple Server 로 부터 받은 Response 에서 `identityToken` 과 `fullName` 부분만 파싱하여 즉시 Planus 서버로 Apple login 요청을 할 수 있습니다.
<br/>

### 🔥 `AppleJwtParser` 🔥
AppleJwtParser 는 `parseHeaders(String identityToken)` 과 `parseClaimWithPublicKey(String identityToken, PublicKey publicKey)` 로 두가지 기능이 있습니다.
1. `parseHeaders(String identityToken)`
Apple 사용자의 식별 정보가 담긴 `identityToken`으로 부터 `headers` 를 파싱하는 기능입니다.

2. `parseClaimWithPublicKey(String identityToken, PublicKey publicKey)`
Apple 의 `PublicKey` 로 `identityToken` 를 복호화 하는 기능입니다.
<br/>

### 🔥 `AppleAuthClient` 🔥
Apple Server 에게 PublicKeys 요청을 위한 통신을 담당하는 클래스 입니다.
- API url 값 경로는 `application-oauth.yml` 의 `{oauth.apple.public-key-url}` 입니다.
<br/>

### 🔥 `ApplePublicKeyGenerator` 🔥
Apple PublicKeys 로 부터 `identityToken` 과 `alg` 과 `kid` 가 일치한 publicKey 를 파싱하는 클래스 입니다.
- `alg` : 토큰을 암호화하는 데 사용되는 암호화 알고리즘입니다.
- `kid` : 개발자 계정에서 얻은 10자리 식별자 키입니다.
- 최종적으로 String publicKey 를 `PublicKey` 인터페이스로 변환하여 반환합니다.
<br/>

### 🔥 `AppleClaimsValidator` 🔥
`identityToken` 으로 사용자 검증을 위해서 필수로 검증해야하는 5가지 중 2-4번을 담당하는 클래스 입니다.
- 검증에 필요한 필드 값은 각각 `application-oauth.yml` 로 부터 생성자에서 `@Value` 를 통해 주입 받습니다.
- 3가지 검중 중, 단 한가지라도 통과하지 못할 시, `INVALID_APPLE_IDENTITY_TOKEN` 예외를 발생 시킵니다.
<br/>

### 🔥 `AppleOAuthService` 🔥 
Apple OAuth 로그인을 담당하는 클래스 입니다.
- `identityToken` 으로부터 사용자의 `email` 을 파싱해내면 `memberRepository` 를 통해 사용자를 조회합니다.
- `email` 회원이 조회 되면 `validateMember(Member member)`로 부터 두가지 경우에 따라 다르게 처리됩니다.
1. 같은 이메일로 이미 가입된 계정이 존재할 시 -> `ALREADY_EXIST_SOCIAL_ACCOUNT` 예외 발생.
2. 조회된 `member` 가 `Status.Inactive` 상태 일 때 -> 상태값만 `Status.Active` 로 변경
3.  1~ 2 번 모두 아니면 `member` 그대로 반환
- 반환된 `member` 로 Planus 자체 `jwt` 를 발행한 뒤, `OAuthLoginResponseDto` 에 담아 클라이언트에게 반환합니다.
<br/>

### `util.Encryptor`
- String 값을 `SHA-256` 알고리즘으로 암호화 하는 클래스 입니다.
- `identityToken` 의 claim 중 `nonce` 값을 검증하기 위해 사용됩니다.
<br/>

##
### :: 특이사항
### `OAuthController`
- 기존의 OAuth API 인 `/oauth/{provider}` 과 파라미터가 달라, `/oauth/apple/login` 로 별도로 구분하여 구현하였습니다.
- `/oauth/apple` 로 해도되지만, 프론트측과 url 매핑의 혼동을 방지하고자 url 맨 뒤에 `/login` 을 추가하였습니다.
<br/>

### `OAuthService`
- 기존의 kakao, google 의 소셜 로그인 기능의 OAuthService 에서, 같은 이메일의 다른 SNS 계정으로 로그인을 시도하는 사용자에게 `ALREADY_EXIST_SOCIAL_ACCOUNT` 예외를 발생시키는 코드를 `saveOrGetMember(MemberProfile profile)`메소드에 추가하였습니다.
<br/>

### `identityToken` 으로부터 사용자 확인을 위한 5가지 필수 검증 목록
참고 : https://developer.apple.com/documentation/sign_in_with_apple/sign_in_with_apple_rest_api/verifying_a_user
- Verify the JWS E256 signature using the server’s public key
- Verify the nonce for the authentication
- Verify that the iss field contains https://appleid.apple.com
- Verify that the aud field is the developer’s client_id
- Verify that the time is earlier than the exp value of the token
<br/>