### PR TITLE
[Fix] MyGroup OnlineCount, GroupJoin 버그 수정

### DIFF
--- a/src/main/java/scs/planus/domain/group/service/MyGroupService.java
+++ b/src/main/java/scs/planus/domain/group/service/MyGroupService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import scs.planus.domain.Status;
 import scs.planus.domain.group.dto.GroupTagResponseDto;
 import scs.planus.domain.group.dto.mygroup.GroupBelongInResponseDto;
 import scs.planus.domain.group.dto.mygroup.MyGroupDetailResponseDto;
@@ -49,10 +50,7 @@ public class MyGroupService {
     }
 
     public List<MyGroupResponseDto> getMyAllGroups(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new PlanusException(NONE_USER));
-
-        List<GroupMember> myGroupMembers = groupMemberRepository.findAllByActiveGroupAndMemberId(member.getId());
+        List<GroupMember> myGroupMembers = groupMemberRepository.findAllByActiveGroupAndMemberId(memberId);
         List<Group> myGroups = myGroupMembers.stream()
                 .map(GroupMember::getGroup)
                 .collect(Collectors.toList());
@@ -141,7 +139,7 @@ public class MyGroupService {
 
     private int getOnlineCount(Group group, List<GroupMember> allGroupMembers) {
         return (int) allGroupMembers.stream()
-                .filter(groupMember -> groupMember.getGroup().equals(group))
+                .filter(groupMember -> groupMember.getGroup().equals(group) && groupMember.getStatus().equals(Status.ACTIVE))
                 .filter(GroupMember::isOnlineStatus)
                 .count();
     }


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [X]  버그 수정 🐞
- [ ]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
- MyGroup OnlineCount
- GroupJoin 버그 수정

### :: 특이사항
- MyGroup의 OnlineCount를 계산하는 getOnlineCount에 필터조건을 추가하였습니다.
- GroupJoin accept() 기능에서 인원수 제한 검증이 안되어있던 버그를 수정하였습니다.
   - group.getActiveGroupMembersSize를 사용하도록 변경
