### PR TITLE
[Feat] Apple OAuth 2.0 테스트 코드 작성

### DIFF
--- a/src/main/java/scs/planus/global/auth/dto/apple/AppleAuthRequestDto.java
+++ b/src/main/java/scs/planus/global/auth/dto/apple/AppleAuthRequestDto.java
@@ -1,10 +1,13 @@
 package scs.planus.global.auth.dto.apple;
 
-import lombok.Getter;
+import lombok.*;
 
 import javax.validation.constraints.NotBlank;
 
+@Builder
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AppleAuthRequestDto {
     @NotBlank(message = "[request] identityToken 값을 입력해 주세요.")
     private String identityToken;

--- a/src/main/java/scs/planus/global/auth/dto/apple/FullName.java
+++ b/src/main/java/scs/planus/global/auth/dto/apple/FullName.java
@@ -1,8 +1,11 @@
 package scs.planus.global.auth.dto.apple;
 
-import lombok.Getter;
+import lombok.*;
 
+@Builder
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FullName {
     private String givenName;
     private String familyName;

--- a/src/main/java/scs/planus/global/auth/service/apple/AppleClaimsValidator.java
+++ b/src/main/java/scs/planus/global/auth/service/apple/AppleClaimsValidator.java
@@ -21,7 +21,7 @@ public class AppleClaimsValidator {
         this.nonce = Encryptor.encryptWithSHA256(nonce);
     }
 
-    public boolean validation(Claims claims) {
+    public boolean isValid(Claims claims) {
         return claims.getIssuer().contains(iss) &&
                 claims.getAudience().equals(clientId) &&
                 claims.get(NONCE_KEY, String.class).equals(nonce);

--- a/src/main/java/scs/planus/global/auth/service/apple/AppleClaimsValidator.java
+++ b/src/main/java/scs/planus/global/auth/service/apple/AppleClaimsValidator.java
@@ -3,10 +3,7 @@ package scs.planus.global.auth.service.apple;
 import io.jsonwebtoken.Claims;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import scs.planus.global.exception.PlanusException;
 import scs.planus.global.util.encryptor.Encryptor;
-
-import static scs.planus.global.exception.CustomExceptionStatus.INVALID_APPLE_IDENTITY_TOKEN;
 
 @Component
 public class AppleClaimsValidator {
@@ -24,13 +21,9 @@ public class AppleClaimsValidator {
         this.nonce = Encryptor.encryptWithSHA256(nonce);
     }
 
-    public void validation(Claims claims) {
-        boolean result = claims.getIssuer().contains(iss) &&
+    public boolean validation(Claims claims) {
+        return claims.getIssuer().contains(iss) &&
                 claims.getAudience().equals(clientId) &&
                 claims.get(NONCE_KEY, String.class).equals(nonce);
-
-        if (!result) {
-            throw new PlanusException(INVALID_APPLE_IDENTITY_TOKEN);
-        }
     }
 }

--- a/src/main/java/scs/planus/global/auth/service/apple/AppleJwtParser.java
+++ b/src/main/java/scs/planus/global/auth/service/apple/AppleJwtParser.java
@@ -1,6 +1,7 @@
 package scs.planus.global.auth.service.apple;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.*;
 import org.springframework.stereotype.Component;
@@ -23,8 +24,8 @@ public class AppleJwtParser {
         try {
             String encodedHeader = identityToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
             String decodedHeader = new String(Base64Utils.decodeFromUrlSafeString(encodedHeader));
-
-            return OBJECT_MAPPER.readValue(decodedHeader, Map.class);
+            TypeReference<Map<String, String>> typeReference = new TypeReference<>() {};
+            return OBJECT_MAPPER.readValue(decodedHeader, typeReference);
         } catch (JsonProcessingException | ArrayIndexOutOfBoundsException e) {
             throw new PlanusException(INVALID_APPLE_IDENTITY_TOKEN);
         } catch (RuntimeException e) {

--- a/src/main/java/scs/planus/global/auth/service/apple/AppleOAuthService.java
+++ b/src/main/java/scs/planus/global/auth/service/apple/AppleOAuthService.java
@@ -23,8 +23,7 @@ import javax.transaction.Transactional;
 import java.security.PublicKey;
 import java.util.Map;
 
-import static scs.planus.global.exception.CustomExceptionStatus.ALREADY_EXIST_SOCIAL_ACCOUNT;
-import static scs.planus.global.exception.CustomExceptionStatus.INVALID_USER_NAME;
+import static scs.planus.global.exception.CustomExceptionStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -76,7 +75,8 @@ public class AppleOAuthService {
         PublicKey publicKey = applePublicKeyGenerator.generatePublicKey(headers, applePublicKey);
 
         Claims claims = appleJwtParser.parseClaimWithPublicKey(identityToken, publicKey);
-        appleClaimsValidator.validation(claims);
+
+        validateClaims(claims);
 
         return claims.get(EMAIL_KEY, String.class);
     }
@@ -110,5 +110,11 @@ public class AppleOAuthService {
             member.init(member.getNickname());
         }
         return member;
+    }
+
+    private void validateClaims(Claims claims) {
+        if (!appleClaimsValidator.validation(claims)) {
+            throw new PlanusException(INVALID_APPLE_IDENTITY_TOKEN);
+        }
     }
 }

--- a/src/main/java/scs/planus/global/auth/service/apple/AppleOAuthService.java
+++ b/src/main/java/scs/planus/global/auth/service/apple/AppleOAuthService.java
@@ -113,7 +113,7 @@ public class AppleOAuthService {
     }
 
     private void validateClaims(Claims claims) {
-        if (!appleClaimsValidator.validation(claims)) {
+        if (!appleClaimsValidator.isValid(claims)) {
             throw new PlanusException(INVALID_APPLE_IDENTITY_TOKEN);
         }
     }

--- a/src/main/java/scs/planus/global/auth/service/apple/AppleOAuthService.java
+++ b/src/main/java/scs/planus/global/auth/service/apple/AppleOAuthService.java
@@ -1,6 +1,5 @@
 package scs.planus.global.auth.service.apple;
 
-import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,40 +13,33 @@ import scs.planus.global.auth.dto.apple.AppleAuthRequestDto;
 import scs.planus.global.auth.dto.apple.AppleClientSecretResponseDto;
 import scs.planus.global.auth.dto.apple.FullName;
 import scs.planus.global.auth.entity.Token;
-import scs.planus.global.auth.entity.apple.ApplePublicKeys;
 import scs.planus.global.auth.service.JwtProvider;
 import scs.planus.global.exception.PlanusException;
 import scs.planus.infra.redis.RedisService;
 
 import javax.transaction.Transactional;
-import java.security.PublicKey;
-import java.util.Map;
 
-import static scs.planus.global.exception.CustomExceptionStatus.*;
+import static scs.planus.global.exception.CustomExceptionStatus.ALREADY_EXIST_SOCIAL_ACCOUNT;
+import static scs.planus.global.exception.CustomExceptionStatus.INVALID_USER_NAME;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class AppleOAuthService {
-    private static final String EMAIL_KEY = "email";
-
     private final MemberRepository memberRepository;
     private final JwtProvider jwtProvider;
     private final RedisService redisService;
 
-    private final AppleJwtParser appleJwtParser;
-    private final AppleAuthClient appleAuthClient;
+    private final AppleOAuthUserProvider appleOAuthUserProvider;
     private final AppleJwtProvider appleJwtProvider;
-    private final ApplePublicKeyGenerator applePublicKeyGenerator;
-    private final AppleClaimsValidator appleClaimsValidator;
 
     @Transactional
     public OAuthLoginResponseDto login(AppleAuthRequestDto appleAuthRequestDto) {
-        String email = getAppleEmail(appleAuthRequestDto.getIdentityToken());
+        String email = appleOAuthUserProvider.getAppleEmail(appleAuthRequestDto.getIdentityToken());
 
         Member member  = memberRepository.findByEmail(email)
                 .map(this::validateMember)
-                .orElseGet(() -> saveNewMember(appleAuthRequestDto, email));
+                .orElseGet(() -> saveNewMember(appleAuthRequestDto.getFullName(), email));
 
         Token token = jwtProvider.generateToken(member.getEmail());
         redisService.saveValue(member.getEmail(), token);
@@ -67,22 +59,8 @@ public class AppleOAuthService {
                 .build();
     }
 
-    public String getAppleEmail(String identityToken) {
-        Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
-
-        ApplePublicKeys applePublicKey = appleAuthClient.getApplePublicKey();
-
-        PublicKey publicKey = applePublicKeyGenerator.generatePublicKey(headers, applePublicKey);
-
-        Claims claims = appleJwtParser.parseClaimWithPublicKey(identityToken, publicKey);
-
-        validateClaims(claims);
-
-        return claims.get(EMAIL_KEY, String.class);
-    }
-
-    public Member saveNewMember(AppleAuthRequestDto appleAuthRequestDto, String email) {
-        String nickName = getName(appleAuthRequestDto.getFullName());
+    private Member saveNewMember(FullName fullName, String email) {
+        String nickName = getName(fullName);
         return memberRepository.save(
                 Member.builder()
                         .nickname(nickName)
@@ -94,14 +72,14 @@ public class AppleOAuthService {
         );
     }
 
-    public String getName(FullName fullName) {
+    private String getName(FullName fullName) {
         if (fullName == null) {
             throw new PlanusException(INVALID_USER_NAME);
         }
         return fullName.getFamilyName() + fullName.getGivenName();
     }
 
-    public Member validateMember(Member member) {
+    private Member validateMember(Member member) {
         if (!member.getSocialType().equals(SocialType.APPLE)) {
             throw new PlanusException(ALREADY_EXIST_SOCIAL_ACCOUNT);
         }
@@ -110,11 +88,5 @@ public class AppleOAuthService {
             member.init(member.getNickname());
         }
         return member;
-    }
-
-    private void validateClaims(Claims claims) {
-        if (!appleClaimsValidator.isValid(claims)) {
-            throw new PlanusException(INVALID_APPLE_IDENTITY_TOKEN);
-        }
     }
 }

--- a/src/main/java/scs/planus/global/auth/service/apple/AppleOAuthUserProvider.java
+++ b/src/main/java/scs/planus/global/auth/service/apple/AppleOAuthUserProvider.java
@@ -1,0 +1,43 @@
+package scs.planus.global.auth.service.apple;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import scs.planus.global.auth.entity.apple.ApplePublicKeys;
+import scs.planus.global.exception.PlanusException;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+import static scs.planus.global.exception.CustomExceptionStatus.INVALID_APPLE_IDENTITY_TOKEN;
+
+@Component
+@RequiredArgsConstructor
+public class AppleOAuthUserProvider {
+    private static final String EMAIL_KEY = "email";
+
+    private final AppleJwtParser appleJwtParser;
+    private final AppleAuthClient appleAuthClient;
+    private final ApplePublicKeyGenerator applePublicKeyGenerator;
+    private final AppleClaimsValidator appleClaimsValidator;
+
+    public String getAppleEmail(String identityToken) {
+        Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
+
+        ApplePublicKeys applePublicKey = appleAuthClient.getApplePublicKey();
+
+        PublicKey publicKey = applePublicKeyGenerator.generatePublicKey(headers, applePublicKey);
+
+        Claims claims = appleJwtParser.parseClaimWithPublicKey(identityToken, publicKey);
+
+        validateClaims(claims);
+
+        return claims.get(EMAIL_KEY, String.class);
+    }
+
+    private void validateClaims(Claims claims) {
+        if (!appleClaimsValidator.isValid(claims)) {
+            throw new PlanusException(INVALID_APPLE_IDENTITY_TOKEN);
+        }
+    }
+}

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -67,7 +67,7 @@ public enum CustomExceptionStatus implements ResponseStatus {
     INVALID_FILE_EXTENSION(BAD_REQUEST, 5001, "잘못된 확장자입니다. jpeg / jpg / png / heic 파일을 선택해주세요."),
 
     // key Algorithm exception
-    NO_SUCH_ALGORITHM(HttpStatus.INTERNAL_SERVER_ERROR, 6000, "잘못되거나 존재하지 않는 파일입니다.");
+    NO_SUCH_ALGORITHM(HttpStatus.INTERNAL_SERVER_ERROR, 6000, "존재하지 않는 알고리즘 입니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
+++ b/src/main/java/scs/planus/global/exception/CustomExceptionStatus.java
@@ -55,7 +55,7 @@ public enum CustomExceptionStatus implements ResponseStatus {
     ALREADY_APPLY_JOINED_GROUP(BAD_REQUEST, 2607, "이미 가입 신청한 그룹입니다."),
     CANNOT_WITHDRAW(BAD_REQUEST, 2608, "탈퇴가 불가능합니다."),
 
-    // groupMember excepion
+    // groupMember exception
     NOT_JOINED_GROUP(BAD_REQUEST, 2700, "가입하지 않은 그룹 입니다."),
     NOT_JOINED_MEMBER_IN_GROUP(BAD_REQUEST, 2701, "그룹에 가입되어 있지 않은 회원입니다."),
 
@@ -64,7 +64,10 @@ public enum CustomExceptionStatus implements ResponseStatus {
 
     // s3 exception
     INVALID_FILE(BAD_REQUEST, 5000, "잘못되거나 존재하지 않는 파일입니다."),
-    INVALID_FILE_EXTENSION(BAD_REQUEST, 5001, "잘못된 확장자입니다. jpeg / jpg / png / heic 파일을 선택해주세요.");
+    INVALID_FILE_EXTENSION(BAD_REQUEST, 5001, "잘못된 확장자입니다. jpeg / jpg / png / heic 파일을 선택해주세요."),
+
+    // key Algorithm exception
+    NO_SUCH_ALGORITHM(HttpStatus.INTERNAL_SERVER_ERROR, 6000, "잘못되거나 존재하지 않는 파일입니다.");
 
     private final HttpStatus httpStatus;
     private final int code;

--- a/src/test/java/scs/planus/global/auth/entity/apple/ApplePublicKeysTest.java
+++ b/src/test/java/scs/planus/global/auth/entity/apple/ApplePublicKeysTest.java
@@ -1,0 +1,60 @@
+package scs.planus.global.auth.entity.apple;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import scs.planus.global.exception.PlanusException;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static scs.planus.global.exception.CustomExceptionStatus.INVALID_ALG_KID_INFO;
+
+class ApplePublicKeysTest {
+    private static final String ALG = "alg";
+    private static final String KID = "kid";
+    private static final String KTY = "RSA";
+    private static final String USE = "use";
+    private static final String N = "n";
+    private static final String E = "e";
+    private static final String UN_MATCH = "un match value";
+
+    @DisplayName("alg 과 kid 가 일치하는 applePublicKey 를 반환해야 한다.")
+    @Test
+    void getKeys() {
+        // given
+        ApplePublicKey applePublicKey = new ApplePublicKey(KTY, KID, USE, ALG, N, E);
+
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(
+                List.of(applePublicKey,
+                        new ApplePublicKey(KTY,  UN_MATCH, USE, ALG, N, E),
+                        new ApplePublicKey(KTY, KID, USE, UN_MATCH, N, E))
+        );
+
+        // when
+        ApplePublicKey matchesKey = applePublicKeys.getMatchesKey(ALG, KID);
+
+        // then
+        assertThat(matchesKey).isEqualTo(applePublicKey);
+    }
+
+    @DisplayName("alg 과 kid 가 일치하는 applePublicKey 가 없는 경우" +
+                "INVALID_ALG_KID_INFO 예외가 발생해야 한다.")
+    @Test
+    void getKeys_Fail() {
+        // given
+        ApplePublicKey applePublicKey = new ApplePublicKey(KTY, KID, USE, ALG, N, E);
+
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(
+                List.of(applePublicKey,
+                        new ApplePublicKey(KTY,  UN_MATCH, USE, ALG, N, E),
+                        new ApplePublicKey(KTY, KID, USE, UN_MATCH, N, E))
+        );
+
+        // when & then
+        assertThatThrownBy(() -> applePublicKeys.getMatchesKey(UN_MATCH, UN_MATCH))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(INVALID_ALG_KID_INFO);
+    }
+}

--- a/src/test/java/scs/planus/global/auth/service/apple/AppleAuthClientTest.java
+++ b/src/test/java/scs/planus/global/auth/service/apple/AppleAuthClientTest.java
@@ -1,0 +1,39 @@
+package scs.planus.global.auth.service.apple;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import scs.planus.global.auth.entity.apple.ApplePublicKey;
+import scs.planus.global.auth.entity.apple.ApplePublicKeys;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppleAuthClientTest {
+
+    private AppleAuthClient appleAuthClient;
+
+    public AppleAuthClientTest() {
+        this.appleAuthClient = new AppleAuthClient("https://appleid.apple.com/auth/keys");
+    }
+
+    @DisplayName("Apple Server 로 요청을 보내 PublicKey 를 응답 받아야 한다.")
+    @Test
+    void getApplePublicKey() {
+        // when
+        ApplePublicKeys applePublicKeys = appleAuthClient.getApplePublicKey();
+
+        boolean isRequestedKeysNonNull = applePublicKeys.getKeys().stream()
+                .allMatch(this::isAllNotNull);
+
+        // then
+        assertThat(applePublicKeys.getKeys()).hasSize(3);
+        assertThat(isRequestedKeysNonNull).isTrue();
+    }
+
+    private boolean isAllNotNull(ApplePublicKey applePublicKey) {
+        return Objects.nonNull(applePublicKey.getKty()) && Objects.nonNull(applePublicKey.getKid()) &&
+                Objects.nonNull(applePublicKey.getUse()) && Objects.nonNull(applePublicKey.getAlg()) &&
+                Objects.nonNull(applePublicKey.getN()) && Objects.nonNull(applePublicKey.getE());
+    }
+}

--- a/src/test/java/scs/planus/global/auth/service/apple/AppleClaimsValidatorTest.java
+++ b/src/test/java/scs/planus/global/auth/service/apple/AppleClaimsValidatorTest.java
@@ -1,0 +1,58 @@
+package scs.planus.global.auth.service.apple;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import scs.planus.global.util.encryptor.Encryptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppleClaimsValidatorTest {
+    private static final String ISS = "test_iss";
+    private static final String CLIENT_ID = "test_clientId";
+    private static final String NONCE = "test_nonce";
+    private static final String NONCE_KEY = "nonce";
+
+    private final AppleClaimsValidator appleClaimsValidator = new AppleClaimsValidator(ISS, CLIENT_ID, NONCE);
+
+    @DisplayName("iss, clientId, nonce 모두 일치하면 True 를 반환 해야 한다.")
+    @Test
+    void isValid() {
+        // given
+        Map<String, Object> claimsMap = new HashMap<>();
+        claimsMap.put(NONCE_KEY, Encryptor.encryptWithSHA256(NONCE));
+
+        Claims claims = Jwts.claims(claimsMap)
+                .setIssuer(ISS)
+                .setAudience(CLIENT_ID);
+
+        // when & then
+        assertThat(appleClaimsValidator.isValid(claims)).isTrue();
+    }
+
+    @DisplayName("iss, clientId, nonce 중 하나라도 일치하지 않으면 False 를 반환 해야 한다.")
+    @ParameterizedTest
+    @CsvSource({
+            "invalid_nonce, test_iss, test_clientId",
+            "test_nonce, invalid_iss, test_clientId",
+            "test_nonce, test_iss, invalid_aud",
+    })
+    void isValid_Fail(String nonce, String iss, String clientId) {
+        // given
+        Map<String, Object> claimsMap = new HashMap<>();
+        claimsMap.put(NONCE_KEY, Encryptor.encryptWithSHA256(nonce));
+
+        Claims claims = Jwts.claims(claimsMap)
+                .setIssuer(iss)
+                .setAudience(clientId);
+
+        // when & then
+        assertThat(appleClaimsValidator.isValid(claims)).isFalse();
+    }
+}

--- a/src/test/java/scs/planus/global/auth/service/apple/AppleJwtParserTest.java
+++ b/src/test/java/scs/planus/global/auth/service/apple/AppleJwtParserTest.java
@@ -27,7 +27,7 @@ class AppleJwtParserTest {
 
     private final AppleJwtParser appleJwtParser;
 
-    private JwtBuilder DEFAULT_JWT_BUILDER;
+    private JwtBuilder defaultJwtBuilder;
     private String identityToken;
     private KeyPair keyPair;
 
@@ -42,7 +42,7 @@ class AppleJwtParserTest {
 
         keyPair = generateKeyPair();
 
-        DEFAULT_JWT_BUILDER = Jwts.builder()
+        defaultJwtBuilder = Jwts.builder()
                 .setHeaderParam(KID_KEY, KID)
                 .claim(EMAIL_KEY, EMAIL)
                 .setIssuer("iss")
@@ -51,7 +51,7 @@ class AppleJwtParserTest {
                 .setExpiration(new Date(now.getTime() + expirationTime))
                 .signWith(keyPair.getPrivate(), SignatureAlgorithm.RS256);
 
-        identityToken = DEFAULT_JWT_BUILDER
+        identityToken = defaultJwtBuilder
                 .compact();
     }
 
@@ -96,7 +96,7 @@ class AppleJwtParserTest {
         Date now = new Date();
         long expirationTime = -1L;
 
-        String expiredToken = DEFAULT_JWT_BUILDER
+        String expiredToken = defaultJwtBuilder
                 .setExpiration(new Date(now.getTime() + expirationTime))
                 .compact();
 

--- a/src/test/java/scs/planus/global/auth/service/apple/AppleJwtParserTest.java
+++ b/src/test/java/scs/planus/global/auth/service/apple/AppleJwtParserTest.java
@@ -1,0 +1,180 @@
+package scs.planus.global.auth.service.apple;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import scs.planus.global.exception.PlanusException;
+
+import java.security.*;
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static scs.planus.global.exception.CustomExceptionStatus.*;
+
+class AppleJwtParserTest {
+    private static final String INVALID_TOKEN = "invalidToken";
+    private static final String KID = "fh6Bs8C";
+    private static final String TEST_EMAIL = "planus@planus";
+
+    private final AppleJwtParser appleJwtParser;
+
+    public AppleJwtParserTest() {
+        this.appleJwtParser = new AppleJwtParser();
+    }
+
+    @DisplayName("Apple 의 identityToken 으로 부터 headers 를 파싱할 수 있다.")
+    @Test
+    void parseHeaders_Success() throws NoSuchAlgorithmException {
+        // given
+        Date now = new Date();
+        long expirationTime = 24 * 60 * 60 * 1000;
+
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+
+        PrivateKey privateKey = keyPair.getPrivate();
+
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", KID)
+                .claim("email", TEST_EMAIL)
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime() + expirationTime))
+                .signWith(privateKey, SignatureAlgorithm.RS256)
+                .compact();
+
+        // when
+        Map<String, String> headers = appleJwtParser.parseHeaders(identityToken);
+
+        // then
+        assertThat(headers).containsKeys("alg", "kid");
+        assertThat(headers.get("alg")).isEqualTo("RS256");
+        assertThat(headers.get("kid")).isEqualTo(KID);
+    }
+
+    @DisplayName("올바르지 않은 형식의 identityToken 으로 헤더를 파싱할 경우," +
+                "INVALID_APPLE_IDENTITY_TOKEN 예외를 발생 시킨다.")
+    @Test
+    void parseHeaders_Fail() {
+        // when & then
+        assertThatThrownBy(() -> appleJwtParser.parseHeaders(INVALID_TOKEN))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(INVALID_APPLE_IDENTITY_TOKEN);
+    }
+
+    @DisplayName("Apple 의 PublicKey 로부터 identityToken 의 claim 을 파싱할 수 있다.")
+    @Test
+    void parseClaimWithPublicKey() throws NoSuchAlgorithmException {
+        // given
+        Date now = new Date();
+        long expirationTime = 24 * 60 * 60 * 1000;
+
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", KID)
+                .claim("email", TEST_EMAIL)
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime() + expirationTime))
+                .signWith(privateKey, SignatureAlgorithm.RS256)
+                .compact();
+
+        // when
+        Claims claims = appleJwtParser.parseClaimWithPublicKey(identityToken, publicKey);
+
+        // then
+        assertThat(claims.get("email", String.class)).isEqualTo(TEST_EMAIL);
+    }
+
+    @DisplayName("만료된 Apple identityToken 을 PublicKey 로 파싱할 경우," +
+                "UNAUTHORIZED_ACCESS_TOKEN 예외를 발생 시킨다.")
+    @Test
+    void parseClaimWithPublicKey_Fail_Expired() throws NoSuchAlgorithmException {
+        // given
+        Date now = new Date();
+        long expirationTime = -1L;
+
+        KeyPair keyPair = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair();
+
+        PrivateKey privateKey = keyPair.getPrivate();
+        PublicKey publicKey = keyPair.getPublic();
+
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", KID)
+                .claim("email", TEST_EMAIL)
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime() + expirationTime))
+                .signWith(privateKey, SignatureAlgorithm.RS256)
+                .compact();
+
+        // when & then
+        assertThatThrownBy(() -> appleJwtParser.parseClaimWithPublicKey(identityToken, publicKey))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(UNAUTHORIZED_ACCESS_TOKEN);
+    }
+
+    @DisplayName("올바르지 않은 형식의 identityToken 으로 헤더를 파싱할 경우," +
+                "INVALID_APPLE_IDENTITY_TOKEN 예외를 발생 시킨다.")
+    @Test
+    void parseClaimWithPublicKey_Fail_Invalid_IdentityToken() throws NoSuchAlgorithmException {
+        // given
+        PublicKey publicKey = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair()
+                .getPublic();
+
+        // when & then
+        assertThatThrownBy(() -> appleJwtParser.parseClaimWithPublicKey(INVALID_TOKEN, publicKey))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(INVALID_APPLE_IDENTITY_TOKEN);
+    }
+
+    @DisplayName("잘못된 PublicKey 로 Apple identityToken 를 파싱할 경우," +
+                "INTERNAL_SERVER_ERROR 예외를 발생 시킨다.")
+    @Test
+    void parseClaimWithPublicKey_Fail_Invalid_PublicKey() throws NoSuchAlgorithmException {
+        // given
+        Date now = new Date();
+        long expirationTime = 24 * 60 * 60 * 1000;
+
+        PrivateKey privateKey = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair()
+                .getPrivate();
+
+        PublicKey invalidPublicKey = KeyPairGenerator.getInstance("RSA")
+                .generateKeyPair()
+                .getPublic();
+
+        String identityToken = Jwts.builder()
+                .setHeaderParam("kid", KID)
+                .claim("email", TEST_EMAIL)
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("aud")
+                .setExpiration(new Date(now.getTime() + expirationTime))
+                .signWith(privateKey, SignatureAlgorithm.RS256)
+                .compact();
+
+        // when & then
+        assertThatThrownBy(() -> appleJwtParser.parseClaimWithPublicKey(identityToken, invalidPublicKey))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/test/java/scs/planus/global/auth/service/apple/AppleJwtProviderTest.java
+++ b/src/test/java/scs/planus/global/auth/service/apple/AppleJwtProviderTest.java
@@ -1,0 +1,69 @@
+package scs.planus.global.auth.service.apple;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import scs.planus.global.exception.PlanusException;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static scs.planus.global.exception.CustomExceptionStatus.INTERNAL_SERVER_ERROR;
+
+class AppleJwtProviderTest {
+    private static final String KEY_FACTORY_INSTANCE_ALGO = "EC";
+    private AppleJwtProvider appleJwtProvider;
+
+    @DisplayName("ClientSecretKey 로 부터 ClientSecret 토큰이 정상적으로 생성 되어야 한다.")
+    @Test
+    void createClientSecret() throws NoSuchAlgorithmException {
+        // given
+        appleJwtProvider = new AppleJwtProvider(
+                "clientId",
+                createClientSecretKey(),
+                10000,
+                "keyId",
+                "teamId",
+                "authUrl"
+        );
+
+        // when
+        String clientSecret = appleJwtProvider.createClientSecret();
+
+        // then
+        assertThat(clientSecret).isNotNull();
+    }
+
+    @DisplayName("유효하지 않은 ClientSecretKey 일 경우," +
+                "INTERNAL_SERVER_ERROR 예외를 발생시켜야 한다.")
+    @Test
+    void createClientSecret_f() {
+        // given
+        appleJwtProvider = new AppleJwtProvider(
+                "clientId",
+                "invalid",
+                10000,
+                "keyId",
+                "teamId",
+                "authUrl"
+        );
+
+        // when & then
+        assertThatThrownBy(() -> appleJwtProvider.createClientSecret())
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(INTERNAL_SERVER_ERROR);
+    }
+
+    private String createClientSecretKey() throws NoSuchAlgorithmException {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(KEY_FACTORY_INSTANCE_ALGO);
+        KeyPair keyPair = keyPairGenerator.generateKeyPair();
+        PrivateKey privateKey = keyPair.getPrivate();
+        byte[] privateKeyEncoded = privateKey.getEncoded();
+        return Base64.getEncoder().encodeToString(privateKeyEncoded);
+    }
+}

--- a/src/test/java/scs/planus/global/auth/service/apple/AppleJwtProviderTest.java
+++ b/src/test/java/scs/planus/global/auth/service/apple/AppleJwtProviderTest.java
@@ -42,7 +42,7 @@ class AppleJwtProviderTest {
     @DisplayName("유효하지 않은 ClientSecretKey 일 경우," +
                 "INTERNAL_SERVER_ERROR 예외를 발생시켜야 한다.")
     @Test
-    void createClientSecret_f() {
+    void createClientSecret_Fail_Invalid_ClientSecretKey() {
         // given
         appleJwtProvider = new AppleJwtProvider(
                 "clientId",

--- a/src/test/java/scs/planus/global/auth/service/apple/AppleJwtProviderTest.java
+++ b/src/test/java/scs/planus/global/auth/service/apple/AppleJwtProviderTest.java
@@ -21,7 +21,7 @@ class AppleJwtProviderTest {
 
     @DisplayName("ClientSecretKey 로 부터 ClientSecret 토큰이 정상적으로 생성 되어야 한다.")
     @Test
-    void createClientSecret() throws NoSuchAlgorithmException {
+    void createClientSecret() {
         // given
         appleJwtProvider = new AppleJwtProvider(
                 "clientId",

--- a/src/test/java/scs/planus/global/auth/service/apple/AppleJwtProviderTest.java
+++ b/src/test/java/scs/planus/global/auth/service/apple/AppleJwtProviderTest.java
@@ -13,6 +13,7 @@ import java.util.Base64;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static scs.planus.global.exception.CustomExceptionStatus.INTERNAL_SERVER_ERROR;
+import static scs.planus.global.exception.CustomExceptionStatus.NO_SUCH_ALGORITHM;
 
 class AppleJwtProviderTest {
     private static final String KEY_FACTORY_INSTANCE_ALGO = "EC";
@@ -59,11 +60,15 @@ class AppleJwtProviderTest {
                 .isEqualTo(INTERNAL_SERVER_ERROR);
     }
 
-    private String createClientSecretKey() throws NoSuchAlgorithmException {
-        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(KEY_FACTORY_INSTANCE_ALGO);
-        KeyPair keyPair = keyPairGenerator.generateKeyPair();
-        PrivateKey privateKey = keyPair.getPrivate();
-        byte[] privateKeyEncoded = privateKey.getEncoded();
-        return Base64.getEncoder().encodeToString(privateKeyEncoded);
+    private String createClientSecretKey() {
+        try {
+            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(KEY_FACTORY_INSTANCE_ALGO);
+            KeyPair keyPair = keyPairGenerator.generateKeyPair();
+            PrivateKey privateKey = keyPair.getPrivate();
+            byte[] privateKeyEncoded = privateKey.getEncoded();
+            return Base64.getEncoder().encodeToString(privateKeyEncoded);
+        } catch (NoSuchAlgorithmException e) {
+            throw new PlanusException(NO_SUCH_ALGORITHM);
+        }
     }
 }

--- a/src/test/java/scs/planus/global/auth/service/apple/AppleOAuthServiceTest.java
+++ b/src/test/java/scs/planus/global/auth/service/apple/AppleOAuthServiceTest.java
@@ -1,0 +1,280 @@
+package scs.planus.global.auth.service.apple;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import scs.planus.domain.Status;
+import scs.planus.domain.member.entity.Member;
+import scs.planus.domain.member.entity.SocialType;
+import scs.planus.domain.member.repository.MemberRepository;
+import scs.planus.global.auth.dto.OAuthLoginResponseDto;
+import scs.planus.global.auth.dto.apple.AppleAuthRequestDto;
+import scs.planus.global.auth.dto.apple.AppleClientSecretResponseDto;
+import scs.planus.global.auth.dto.apple.FullName;
+import scs.planus.global.auth.entity.Token;
+import scs.planus.global.auth.entity.apple.ApplePublicKey;
+import scs.planus.global.auth.entity.apple.ApplePublicKeys;
+import scs.planus.global.auth.service.JwtProvider;
+import scs.planus.global.exception.PlanusException;
+import scs.planus.global.util.encryptor.Encryptor;
+import scs.planus.infra.redis.RedisService;
+import scs.planus.support.ServiceTest;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.verify;
+import static scs.planus.global.exception.CustomExceptionStatus.*;
+
+@Import({AppleJwtParser.class,
+        AppleAuthClient.class,
+        AppleJwtProvider.class,
+        ApplePublicKeyGenerator.class,
+        AppleClaimsValidator.class})
+@Slf4j
+class AppleOAuthServiceTest extends ServiceTest {
+    private final MemberRepository memberRepository;
+    @MockBean
+    private JwtProvider jwtProvider;
+    @MockBean
+    private final RedisService redisService;
+    @MockBean
+    private AppleJwtProvider appleJwtProvider;
+    private final AppleJwtParser appleJwtParser;
+    @MockBean
+    private final AppleAuthClient appleAuthClient;
+    @MockBean
+    private final ApplePublicKeyGenerator applePublicKeyGenerator;
+    @MockBean
+    private final AppleClaimsValidator appleClaimsValidator;
+
+    private final AppleOAuthService appleOAuthService;
+
+    private AppleAuthRequestDto appleAuthRequestDto;
+
+    private String identityToken;
+
+    @Autowired
+    public AppleOAuthServiceTest(MemberRepository memberRepository,
+                                 JwtProvider jwtProvider,
+                                 RedisService redisService,
+                                 AppleJwtParser appleJwtParser,
+                                 AppleAuthClient appleAuthClient,
+                                 AppleJwtProvider appleJwtProvider,
+                                 ApplePublicKeyGenerator applePublicKeyGenerator,
+                                 AppleClaimsValidator appleClaimsValidator) {
+        this.memberRepository = memberRepository;
+        this.jwtProvider = jwtProvider;
+        this.redisService = redisService;
+        this.appleJwtParser = appleJwtParser;
+        this.appleAuthClient = appleAuthClient;
+        this.appleJwtProvider = appleJwtProvider;
+        this.applePublicKeyGenerator = applePublicKeyGenerator;
+        this.appleClaimsValidator = appleClaimsValidator;
+
+        appleOAuthService = new AppleOAuthService(
+                memberRepository,
+                jwtProvider,
+                redisService,
+                appleJwtParser,
+                appleAuthClient,
+                appleJwtProvider,
+                applePublicKeyGenerator,
+                appleClaimsValidator
+        );
+    }
+
+    @BeforeEach
+    void init() {
+        Date now = new Date();
+        long expirationTime = 24 * 60 * 60 * 1000;
+
+        KeyPair keyPair = generateKeyPair();
+
+        identityToken = Jwts.builder()
+                .setHeaderParam("kid", "kid")
+                .claim("email", "email")
+                .claim("nonce", Encryptor.encryptWithSHA256("nonce"))
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("clientId")
+                .setExpiration(new Date(now.getTime() + expirationTime))
+                .signWith(keyPair.getPrivate(), SignatureAlgorithm.RS256)
+                .compact();
+
+        FullName fullName = FullName.builder()
+                .familyName("플")
+                .givenName("래너스")
+                .build();
+
+        appleAuthRequestDto = AppleAuthRequestDto.builder()
+                .identityToken(identityToken)
+                .fullName(fullName)
+                .build();
+
+        String N = RandomStringUtils.randomAlphanumeric(128);
+        String E = RandomStringUtils.randomAlphanumeric(4);
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(
+                List.of(new ApplePublicKey("RSA",  "kid", "use", "RS256", N, E))
+        );
+
+        given(appleAuthClient.getApplePublicKey()).willReturn(applePublicKeys);
+        given(applePublicKeyGenerator.generatePublicKey(anyMap(), any(ApplePublicKeys.class))).willReturn(keyPair.getPublic());
+        given(appleClaimsValidator.isValid(any(Claims.class))).willReturn(true);
+    }
+
+    @DisplayName("회원가입이 정상적으로 이루어 져야 한다.")
+    @Test
+    void login_Success_Join() {
+        // given
+        Token token = Token.builder()
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .build();
+
+        given(jwtProvider.generateToken(anyString())).willReturn(token);
+        willDoNothing().given(redisService).saveValue(anyString(), any(Token.class));
+
+        // when
+        OAuthLoginResponseDto oAuthLoginResponseDto = appleOAuthService.login(appleAuthRequestDto);
+
+        // then
+        assertThat(oAuthLoginResponseDto).hasNoNullFieldsOrProperties();
+
+        verify(appleAuthClient).getApplePublicKey();
+        verify(applePublicKeyGenerator).generatePublicKey(anyMap(), any(ApplePublicKeys.class));
+        verify(appleClaimsValidator).isValid(any(Claims.class));
+        verify(jwtProvider).generateToken(anyString());
+        verify(redisService).saveValue(anyString(), any(Token.class));
+    }
+
+    @DisplayName("비활성화 계정일 경우, 재활성화 및 사용자 정보 초기화가 되어야 한다.")
+    @Test
+    void login_Success_Reactivation() {
+        // given
+        Member InactiveMember = memberRepository.save(Member.builder()
+                .nickname("비활성계정")
+                .email("email")
+                .socialType(SocialType.APPLE)
+                .status(Status.INACTIVE)
+                .build());
+
+        Token token = Token.builder()
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .build();
+
+        given(jwtProvider.generateToken(anyString())).willReturn(token);
+        willDoNothing().given(redisService).saveValue(anyString(), any(Token.class));
+
+        // when
+        OAuthLoginResponseDto oAuthLoginResponseDto = appleOAuthService.login(appleAuthRequestDto);
+
+        // then
+        assertThat(oAuthLoginResponseDto.getMemberId()).isEqualTo(InactiveMember.getId());
+        assertThat(oAuthLoginResponseDto).hasNoNullFieldsOrProperties();
+
+        verify(appleAuthClient).getApplePublicKey();
+        verify(applePublicKeyGenerator).generatePublicKey(anyMap(), any(ApplePublicKeys.class));
+        verify(appleClaimsValidator).isValid(any(Claims.class));
+        verify(jwtProvider).generateToken(anyString());
+        verify(redisService).saveValue(anyString(), any(Token.class));
+    }
+
+    @DisplayName("회원가입 시 FullName 이 null 인 경우," +
+                "INVALID_USER_NAME 예외가 발생해야 한다.")
+    @Test
+    void login_Fail_INVALID_USER_NAME() {
+        // given
+        appleAuthRequestDto = AppleAuthRequestDto.builder()
+                .identityToken(identityToken)
+                .build();
+
+        // when & then
+        assertThatThrownBy(() -> appleOAuthService.login(appleAuthRequestDto))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(INVALID_USER_NAME);
+
+        verify(appleAuthClient).getApplePublicKey();
+        verify(applePublicKeyGenerator).generatePublicKey(anyMap(), any(ApplePublicKeys.class));
+        verify(appleClaimsValidator).isValid(any(Claims.class));
+    }
+
+    @DisplayName("identity claims 의 검증 결과가 false 인 경우," +
+                "INVALID_APPLE_IDENTITY_TOKEN 예외가 발생해야 한다.")
+    @Test
+    void login_Fail_INVALID_APPLE_IDENTITY_TOKEN() {
+        // given
+        given(appleClaimsValidator.isValid(any(Claims.class))).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> appleOAuthService.login(appleAuthRequestDto))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(INVALID_APPLE_IDENTITY_TOKEN);
+
+        verify(appleAuthClient).getApplePublicKey();
+        verify(applePublicKeyGenerator).generatePublicKey(anyMap(), any(ApplePublicKeys.class));
+        verify(appleClaimsValidator).isValid(any(Claims.class));
+    }
+
+    @DisplayName("다른 계정으로 가입된 이메일인 경우," +
+                "ALREADY_EXIST_SOCIAL_ACCOUNT 예외를 발생 시킨다.")
+    @Test
+    void login_Fail_ALREADY_EXIST_SOCIAL_ACCOUNT() {
+        // given
+        memberRepository.save(Member.builder()
+                .email("email")
+                .socialType(SocialType.KAKAO)
+                .build());
+
+        // when & then
+        assertThatThrownBy(() -> appleOAuthService.login(appleAuthRequestDto))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(ALREADY_EXIST_SOCIAL_ACCOUNT);
+
+        verify(appleAuthClient).getApplePublicKey();
+        verify(applePublicKeyGenerator).generatePublicKey(anyMap(), any(ApplePublicKeys.class));
+        verify(appleClaimsValidator).isValid(any(Claims.class));
+    }
+
+    @DisplayName("생성된 clientSecret 토큰을 AppleClientSecretResponseDto 로 반환해야 한다.")
+    @Test
+    void getClientSecret() {
+        // given
+        given(appleJwtProvider.createClientSecret()).willReturn("clientSecret");
+
+        // when
+        AppleClientSecretResponseDto clientSecret = appleOAuthService.getClientSecret();
+
+        // then
+        assertThat(clientSecret).isNotNull();
+    }
+
+    private KeyPair generateKeyPair() {
+        try {
+            return KeyPairGenerator.getInstance("RSA")
+                    .generateKeyPair();
+        } catch (NoSuchAlgorithmException e) {
+            throw new PlanusException(NO_SUCH_ALGORITHM);
+        }
+    }
+}

--- a/src/test/java/scs/planus/global/auth/service/apple/AppleOAuthServiceTest.java
+++ b/src/test/java/scs/planus/global/auth/service/apple/AppleOAuthServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import scs.planus.domain.Status;
 import scs.planus.domain.member.entity.Member;
 import scs.planus.domain.member.entity.SocialType;
@@ -31,7 +30,6 @@ import static org.mockito.Mockito.verify;
 import static scs.planus.global.exception.CustomExceptionStatus.ALREADY_EXIST_SOCIAL_ACCOUNT;
 import static scs.planus.global.exception.CustomExceptionStatus.INVALID_USER_NAME;
 
-@Import(AppleJwtProvider.class)
 @Slf4j
 class AppleOAuthServiceTest extends ServiceTest {
     private static final String IDENTITY_TOKEN = "identityToken";
@@ -75,8 +73,8 @@ class AppleOAuthServiceTest extends ServiceTest {
     @BeforeEach
     void init() {
         FullName fullName = FullName.builder()
-                .familyName("플")
-                .givenName("래너스")
+                .familyName("성")
+                .givenName("이름")
                 .build();
 
         appleAuthRequestDto = AppleAuthRequestDto.builder()

--- a/src/test/java/scs/planus/global/auth/service/apple/AppleOAuthServiceTest.java
+++ b/src/test/java/scs/planus/global/auth/service/apple/AppleOAuthServiceTest.java
@@ -1,10 +1,6 @@
 package scs.planus.global.auth.service.apple;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,123 +16,73 @@ import scs.planus.global.auth.dto.apple.AppleAuthRequestDto;
 import scs.planus.global.auth.dto.apple.AppleClientSecretResponseDto;
 import scs.planus.global.auth.dto.apple.FullName;
 import scs.planus.global.auth.entity.Token;
-import scs.planus.global.auth.entity.apple.ApplePublicKey;
-import scs.planus.global.auth.entity.apple.ApplePublicKeys;
 import scs.planus.global.auth.service.JwtProvider;
 import scs.planus.global.exception.PlanusException;
-import scs.planus.global.util.encryptor.Encryptor;
 import scs.planus.infra.redis.RedisService;
 import scs.planus.support.ServiceTest;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.util.Date;
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.Mockito.verify;
-import static scs.planus.global.exception.CustomExceptionStatus.*;
+import static scs.planus.global.exception.CustomExceptionStatus.ALREADY_EXIST_SOCIAL_ACCOUNT;
+import static scs.planus.global.exception.CustomExceptionStatus.INVALID_USER_NAME;
 
-@Import({AppleJwtParser.class,
-        AppleAuthClient.class,
-        AppleJwtProvider.class,
-        ApplePublicKeyGenerator.class,
-        AppleClaimsValidator.class})
+@Import(AppleJwtProvider.class)
 @Slf4j
 class AppleOAuthServiceTest extends ServiceTest {
+    private static final String IDENTITY_TOKEN = "identityToken";
+    private static final String EMAIL = "email";
+
     private final MemberRepository memberRepository;
     @MockBean
-    private JwtProvider jwtProvider;
+    private final JwtProvider jwtProvider;
     @MockBean
     private final RedisService redisService;
     @MockBean
-    private AppleJwtProvider appleJwtProvider;
-    private final AppleJwtParser appleJwtParser;
+    private final AppleOAuthUserProvider appleOAuthUserProvider;
     @MockBean
-    private final AppleAuthClient appleAuthClient;
-    @MockBean
-    private final ApplePublicKeyGenerator applePublicKeyGenerator;
-    @MockBean
-    private final AppleClaimsValidator appleClaimsValidator;
+    private final AppleJwtProvider appleJwtProvider;
 
     private final AppleOAuthService appleOAuthService;
 
     private AppleAuthRequestDto appleAuthRequestDto;
 
-    private String identityToken;
-
     @Autowired
     public AppleOAuthServiceTest(MemberRepository memberRepository,
                                  JwtProvider jwtProvider,
                                  RedisService redisService,
-                                 AppleJwtParser appleJwtParser,
-                                 AppleAuthClient appleAuthClient,
-                                 AppleJwtProvider appleJwtProvider,
-                                 ApplePublicKeyGenerator applePublicKeyGenerator,
-                                 AppleClaimsValidator appleClaimsValidator) {
+                                 AppleOAuthUserProvider appleOAuthUserProvider,
+                                 AppleJwtProvider appleJwtProvider) {
         this.memberRepository = memberRepository;
         this.jwtProvider = jwtProvider;
         this.redisService = redisService;
-        this.appleJwtParser = appleJwtParser;
-        this.appleAuthClient = appleAuthClient;
         this.appleJwtProvider = appleJwtProvider;
-        this.applePublicKeyGenerator = applePublicKeyGenerator;
-        this.appleClaimsValidator = appleClaimsValidator;
+        this.appleOAuthUserProvider = appleOAuthUserProvider;
 
         appleOAuthService = new AppleOAuthService(
                 memberRepository,
                 jwtProvider,
                 redisService,
-                appleJwtParser,
-                appleAuthClient,
-                appleJwtProvider,
-                applePublicKeyGenerator,
-                appleClaimsValidator
+                appleOAuthUserProvider,
+                appleJwtProvider
         );
     }
 
     @BeforeEach
     void init() {
-        Date now = new Date();
-        long expirationTime = 24 * 60 * 60 * 1000;
-
-        KeyPair keyPair = generateKeyPair();
-
-        identityToken = Jwts.builder()
-                .setHeaderParam("kid", "kid")
-                .claim("email", "email")
-                .claim("nonce", Encryptor.encryptWithSHA256("nonce"))
-                .setIssuer("iss")
-                .setIssuedAt(now)
-                .setAudience("clientId")
-                .setExpiration(new Date(now.getTime() + expirationTime))
-                .signWith(keyPair.getPrivate(), SignatureAlgorithm.RS256)
-                .compact();
-
         FullName fullName = FullName.builder()
                 .familyName("플")
                 .givenName("래너스")
                 .build();
 
         appleAuthRequestDto = AppleAuthRequestDto.builder()
-                .identityToken(identityToken)
+                .identityToken(IDENTITY_TOKEN)
                 .fullName(fullName)
                 .build();
-
-        String N = RandomStringUtils.randomAlphanumeric(128);
-        String E = RandomStringUtils.randomAlphanumeric(4);
-        ApplePublicKeys applePublicKeys = new ApplePublicKeys(
-                List.of(new ApplePublicKey("RSA",  "kid", "use", "RS256", N, E))
-        );
-
-        given(appleAuthClient.getApplePublicKey()).willReturn(applePublicKeys);
-        given(applePublicKeyGenerator.generatePublicKey(anyMap(), any(ApplePublicKeys.class))).willReturn(keyPair.getPublic());
-        given(appleClaimsValidator.isValid(any(Claims.class))).willReturn(true);
     }
 
     @DisplayName("회원가입이 정상적으로 이루어 져야 한다.")
@@ -148,6 +94,7 @@ class AppleOAuthServiceTest extends ServiceTest {
                 .refreshToken("refreshToken")
                 .build();
 
+        given(appleOAuthUserProvider.getAppleEmail(anyString())).willReturn(EMAIL);
         given(jwtProvider.generateToken(anyString())).willReturn(token);
         willDoNothing().given(redisService).saveValue(anyString(), any(Token.class));
 
@@ -157,9 +104,7 @@ class AppleOAuthServiceTest extends ServiceTest {
         // then
         assertThat(oAuthLoginResponseDto).hasNoNullFieldsOrProperties();
 
-        verify(appleAuthClient).getApplePublicKey();
-        verify(applePublicKeyGenerator).generatePublicKey(anyMap(), any(ApplePublicKeys.class));
-        verify(appleClaimsValidator).isValid(any(Claims.class));
+        verify(appleOAuthUserProvider).getAppleEmail(anyString());
         verify(jwtProvider).generateToken(anyString());
         verify(redisService).saveValue(anyString(), any(Token.class));
     }
@@ -168,18 +113,21 @@ class AppleOAuthServiceTest extends ServiceTest {
     @Test
     void login_Success_Reactivation() {
         // given
-        Member InactiveMember = memberRepository.save(Member.builder()
-                .nickname("비활성계정")
-                .email("email")
-                .socialType(SocialType.APPLE)
-                .status(Status.INACTIVE)
-                .build());
+        Member InactiveMember = memberRepository.save(
+                Member.builder()
+                        .nickname("비활성계정")
+                        .email(EMAIL)
+                        .socialType(SocialType.APPLE)
+                        .status(Status.INACTIVE)
+                        .build()
+        );
 
         Token token = Token.builder()
                 .accessToken("accessToken")
                 .refreshToken("refreshToken")
                 .build();
 
+        given(appleOAuthUserProvider.getAppleEmail(anyString())).willReturn(EMAIL);
         given(jwtProvider.generateToken(anyString())).willReturn(token);
         willDoNothing().given(redisService).saveValue(anyString(), any(Token.class));
 
@@ -190,9 +138,7 @@ class AppleOAuthServiceTest extends ServiceTest {
         assertThat(oAuthLoginResponseDto.getMemberId()).isEqualTo(InactiveMember.getId());
         assertThat(oAuthLoginResponseDto).hasNoNullFieldsOrProperties();
 
-        verify(appleAuthClient).getApplePublicKey();
-        verify(applePublicKeyGenerator).generatePublicKey(anyMap(), any(ApplePublicKeys.class));
-        verify(appleClaimsValidator).isValid(any(Claims.class));
+        verify(appleOAuthUserProvider).getAppleEmail(anyString());
         verify(jwtProvider).generateToken(anyString());
         verify(redisService).saveValue(anyString(), any(Token.class));
     }
@@ -203,8 +149,10 @@ class AppleOAuthServiceTest extends ServiceTest {
     void login_Fail_INVALID_USER_NAME() {
         // given
         appleAuthRequestDto = AppleAuthRequestDto.builder()
-                .identityToken(identityToken)
+                .identityToken(IDENTITY_TOKEN)
                 .build();
+
+        given(appleOAuthUserProvider.getAppleEmail(anyString())).willReturn(EMAIL);
 
         // when & then
         assertThatThrownBy(() -> appleOAuthService.login(appleAuthRequestDto))
@@ -212,38 +160,22 @@ class AppleOAuthServiceTest extends ServiceTest {
                 .extracting("status")
                 .isEqualTo(INVALID_USER_NAME);
 
-        verify(appleAuthClient).getApplePublicKey();
-        verify(applePublicKeyGenerator).generatePublicKey(anyMap(), any(ApplePublicKeys.class));
-        verify(appleClaimsValidator).isValid(any(Claims.class));
+        verify(appleOAuthUserProvider).getAppleEmail(anyString());
     }
 
-    @DisplayName("identity claims 의 검증 결과가 false 인 경우," +
-                "INVALID_APPLE_IDENTITY_TOKEN 예외가 발생해야 한다.")
-    @Test
-    void login_Fail_INVALID_APPLE_IDENTITY_TOKEN() {
-        // given
-        given(appleClaimsValidator.isValid(any(Claims.class))).willReturn(false);
-
-        // when & then
-        assertThatThrownBy(() -> appleOAuthService.login(appleAuthRequestDto))
-                .isInstanceOf(PlanusException.class)
-                .extracting("status")
-                .isEqualTo(INVALID_APPLE_IDENTITY_TOKEN);
-
-        verify(appleAuthClient).getApplePublicKey();
-        verify(applePublicKeyGenerator).generatePublicKey(anyMap(), any(ApplePublicKeys.class));
-        verify(appleClaimsValidator).isValid(any(Claims.class));
-    }
-
-    @DisplayName("다른 계정으로 가입된 이메일인 경우," +
+    @DisplayName("다른 SNS 계정으로 가입된 이메일인 경우," +
                 "ALREADY_EXIST_SOCIAL_ACCOUNT 예외를 발생 시킨다.")
     @Test
     void login_Fail_ALREADY_EXIST_SOCIAL_ACCOUNT() {
         // given
-        memberRepository.save(Member.builder()
-                .email("email")
-                .socialType(SocialType.KAKAO)
-                .build());
+        memberRepository.save(
+                Member.builder()
+                        .email(EMAIL)
+                        .socialType(SocialType.KAKAO)
+                        .build()
+        );
+
+        given(appleOAuthUserProvider.getAppleEmail(anyString())).willReturn(EMAIL);
 
         // when & then
         assertThatThrownBy(() -> appleOAuthService.login(appleAuthRequestDto))
@@ -251,9 +183,7 @@ class AppleOAuthServiceTest extends ServiceTest {
                 .extracting("status")
                 .isEqualTo(ALREADY_EXIST_SOCIAL_ACCOUNT);
 
-        verify(appleAuthClient).getApplePublicKey();
-        verify(applePublicKeyGenerator).generatePublicKey(anyMap(), any(ApplePublicKeys.class));
-        verify(appleClaimsValidator).isValid(any(Claims.class));
+        verify(appleOAuthUserProvider).getAppleEmail(anyString());
     }
 
     @DisplayName("생성된 clientSecret 토큰을 AppleClientSecretResponseDto 로 반환해야 한다.")
@@ -263,18 +193,11 @@ class AppleOAuthServiceTest extends ServiceTest {
         given(appleJwtProvider.createClientSecret()).willReturn("clientSecret");
 
         // when
-        AppleClientSecretResponseDto clientSecret = appleOAuthService.getClientSecret();
+        AppleClientSecretResponseDto appleClientSecretResponseDto = appleOAuthService.getClientSecret();
 
         // then
-        assertThat(clientSecret).isNotNull();
-    }
+        assertThat(appleClientSecretResponseDto).hasNoNullFieldsOrProperties();
 
-    private KeyPair generateKeyPair() {
-        try {
-            return KeyPairGenerator.getInstance("RSA")
-                    .generateKeyPair();
-        } catch (NoSuchAlgorithmException e) {
-            throw new PlanusException(NO_SUCH_ALGORITHM);
-        }
+        verify(appleJwtProvider).createClientSecret();
     }
 }

--- a/src/test/java/scs/planus/global/auth/service/apple/AppleOAuthUserProviderTest.java
+++ b/src/test/java/scs/planus/global/auth/service/apple/AppleOAuthUserProviderTest.java
@@ -1,0 +1,148 @@
+package scs.planus.global.auth.service.apple;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import scs.planus.global.auth.entity.apple.ApplePublicKey;
+import scs.planus.global.auth.entity.apple.ApplePublicKeys;
+import scs.planus.global.exception.PlanusException;
+import scs.planus.global.util.encryptor.Encryptor;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static scs.planus.global.exception.CustomExceptionStatus.INVALID_APPLE_IDENTITY_TOKEN;
+import static scs.planus.global.exception.CustomExceptionStatus.NO_SUCH_ALGORITHM;
+
+class AppleOAuthUserProviderTest {
+    private static final String EMAIL = "email";
+
+    @Mock
+    private AppleJwtParser appleJwtParser;
+    @Mock
+    private AppleAuthClient appleAuthClient;
+    @Mock
+    private ApplePublicKeyGenerator applePublicKeyGenerator;
+    @Mock
+    private AppleClaimsValidator appleClaimsValidator;
+
+    private final AppleOAuthUserProvider appleOAuthUserProvider;
+
+    private String identityToken;
+
+    public AppleOAuthUserProviderTest() {
+        MockitoAnnotations.openMocks(this);
+        appleOAuthUserProvider = new AppleOAuthUserProvider(
+                appleJwtParser,
+                appleAuthClient,
+                applePublicKeyGenerator,
+                appleClaimsValidator
+        );
+    }
+
+    @BeforeEach
+    void init() {
+        Date now = new Date();
+        long expirationTime = 24 * 60 * 60 * 1000;
+
+        KeyPair keyPair = generateKeyPair();
+
+        identityToken = Jwts.builder()
+                .setHeaderParam("kid", "kid")
+                .claim("email", EMAIL)
+                .claim("nonce", Encryptor.encryptWithSHA256("nonce"))
+                .setIssuer("iss")
+                .setIssuedAt(now)
+                .setAudience("clientId")
+                .setExpiration(new Date(now.getTime() + expirationTime))
+                .signWith(keyPair.getPrivate(), SignatureAlgorithm.RS256)
+                .compact();
+
+        String N = RandomStringUtils.randomAlphanumeric(128);
+        String E = RandomStringUtils.randomAlphanumeric(4);
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(
+                List.of(new ApplePublicKey("RSA",  "kid", "use", "RS256", N, E))
+        );
+
+        Map<String, String> heads = new HashMap<>();
+        heads.put("alg", "RS256");
+        heads.put("kid", "kid");
+
+        Claims claims = Jwts.claims()
+                .setIssuer("iss")
+                .setAudience("clientId");
+
+        claims.put("nonce", Encryptor.encryptWithSHA256("nonce"));
+        claims.put("email", "email");
+
+        given(appleJwtParser.parseHeaders(anyString())).willReturn(heads);
+        given(appleAuthClient.getApplePublicKey()).willReturn(applePublicKeys);
+        given(applePublicKeyGenerator.generatePublicKey(anyMap(), any(ApplePublicKeys.class))).willReturn(keyPair.getPublic());
+        given(appleJwtParser.parseClaimWithPublicKey(anyString(), any(PublicKey.class))).willReturn(claims);
+    }
+
+    @DisplayName("identityToken 으로 부터 사용자 email 을 얻을 수 있다.")
+    @Test
+    void getAppleEmail() {
+        // given
+        given(appleClaimsValidator.isValid(any(Claims.class))).willReturn(true);
+
+        // when
+        String appleEmail = appleOAuthUserProvider.getAppleEmail(identityToken);
+
+        // then
+        assertThat(appleEmail).isEqualTo(EMAIL);
+
+        verify(appleJwtParser).parseHeaders(anyString());
+        verify(appleAuthClient).getApplePublicKey();
+        verify(applePublicKeyGenerator).generatePublicKey(anyMap(), any(ApplePublicKeys.class));
+        verify(appleJwtParser).parseClaimWithPublicKey(anyString(), any(PublicKey.class));
+        verify(appleClaimsValidator).isValid(any(Claims.class));
+    }
+
+    @DisplayName("identity claims 의 검증 결과가 false 인 경우," +
+                "INVALID_APPLE_IDENTITY_TOKEN 예외가 발생해야 한다.")
+    @Test
+    void getAppleEmail_Fail_INVALID_APPLE_IDENTITY_TOKEN() {
+        // given
+        given(appleClaimsValidator.isValid(any(Claims.class))).willReturn(false);
+
+        // when & then
+        Assertions.assertThatThrownBy(() -> appleOAuthUserProvider.getAppleEmail(identityToken))
+                .isInstanceOf(PlanusException.class)
+                .extracting("status")
+                .isEqualTo(INVALID_APPLE_IDENTITY_TOKEN);
+
+        verify(appleJwtParser).parseHeaders(anyString());
+        verify(appleAuthClient).getApplePublicKey();
+        verify(applePublicKeyGenerator).generatePublicKey(anyMap(), any(ApplePublicKeys.class));
+        verify(appleJwtParser).parseClaimWithPublicKey(anyString(), any(PublicKey.class));
+        verify(appleClaimsValidator).isValid(any(Claims.class));
+    }
+
+    private KeyPair generateKeyPair() {
+        try {
+            return KeyPairGenerator.getInstance("RSA")
+                    .generateKeyPair();
+        } catch (NoSuchAlgorithmException e) {
+            throw new PlanusException(NO_SUCH_ALGORITHM);
+        }
+    }
+}

--- a/src/test/java/scs/planus/global/auth/service/apple/ApplePublicKeyGeneratorTest.java
+++ b/src/test/java/scs/planus/global/auth/service/apple/ApplePublicKeyGeneratorTest.java
@@ -1,0 +1,50 @@
+package scs.planus.global.auth.service.apple;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import scs.planus.global.auth.entity.apple.ApplePublicKey;
+import scs.planus.global.auth.entity.apple.ApplePublicKeys;
+
+import java.security.PublicKey;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+class ApplePublicKeyGeneratorTest {
+    private static final String ALG = "alg";
+    private static final String ALG_KEY = "alg";
+    private static final String KID = "kid";
+    private static final String KID_KEY = "kid";
+    private static final String KTY = "RSA";
+    private static final String USE = "use";
+    private static final Integer LEN_N = 128;
+    private static final Integer LEN_E = 4;
+
+    private final ApplePublicKeyGenerator applePublicKeyGenerator = new ApplePublicKeyGenerator();
+
+    @DisplayName("header 와 ApplePublicKeys 로 PublicKey 를 생성할 수 있다.")
+    @Test
+    void generatePublicKey() {
+        // given
+        Map<String, String> heads = new HashMap<>();
+        heads.put(ALG_KEY, ALG);
+        heads.put(KID_KEY, KID);
+
+        String N = RandomStringUtils.randomAlphanumeric(LEN_N);
+        String E = RandomStringUtils.randomAlphanumeric(LEN_E);
+
+        ApplePublicKeys applePublicKeys = new ApplePublicKeys(
+                List.of(new ApplePublicKey(KTY, KID, USE, ALG, N, E)));
+
+        // when
+        PublicKey publicKey = applePublicKeyGenerator.generatePublicKey(heads, applePublicKeys);
+
+        // then
+        assertThat(publicKey).isNotNull();
+    }
+}

--- a/src/test/java/scs/planus/global/util/encryptor/EncryptorTest.java
+++ b/src/test/java/scs/planus/global/util/encryptor/EncryptorTest.java
@@ -1,0 +1,22 @@
+package scs.planus.global.util.encryptor;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EncryptorTest {
+    private static final String TEST_STRING = "test";
+    private static final String ENCRYPT_WITH_SHA256_RESULT = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+
+
+    @DisplayName("문자열을 SHA-256 알고리즘으로 암호화 할 수 있다.")
+    @Test
+    void encryptWithSHA256() {
+        // when
+        String encryption = Encryptor.encryptWithSHA256(TEST_STRING);
+
+        // then
+        assertThat(encryption).isEqualTo(ENCRYPT_WITH_SHA256_RESULT);
+    }
+}


### PR DESCRIPTION
### :: PR 타입
- [x] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [x]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [x]  테스트 🔍

## :: 테스트 🔍
### 🔥 OAuthControllerTest 🔥
- appleLogin API 와 getAppleClientSecret API 의 테스트 코드를 추가하였습니다.

### 🔥 EncryptorTest 🔥 
- 임의의 문자열 `test` 에 대한 실제 해쉬문자열 값으로 테스트를 진행하였습니다.

### 🔥 AppleJwtParserTest 🔥
`init()`
- 모든 테스트에서 반복되는 `given` 코드를 `@BeforEach` 로 분리하였습니다.
- 테스트를 위해 `identityToken` 의 claim 변경이 필요 없는 경우는 그대로 사용합니다.
- claim (만료 시간 등) 의 변경이 필요한 경우 `DEFAULT_JWT_BUILDER` 를 사용하여, 필요한 값만 변경하면 `jwt` 를 생성할 수 있도록 하였습니다.

`parseHeaders`
- Apple 의 사용자 `identityToken` 으로 부터 `Header` 정보를 정상적으로 추출하는지 검증합니다.

`parseClaimWithPublicKey`
- `PublicKey` 로 `identityToken` 의 Claims 를 정상적으로 추출하는지 검증합니다.


### 🔥 AppleAuthClientTest 🔥 
- Apple 공개키 주소로 직접 요청을 보내 테스트를 진행합니다.
- 총 `3`쌍의 PublicKey 가 응답으로 주어지는데, 각 PublicKey 다 `6`개의 필드를 가지는지 검증합니다.

### 🔥 AppleClaimsValidatorTest 🔥
- `Claims` 에 대해 `Iss`, `ClientId`, `Nonce` 3 개의 값이 모두 일치하는지 테스트 하는 코드입니다.
- 예외가 발생할 수 있는 3가지 조합에 대해 `@ParameterizedTest` `@CsvSource` 로 모든 경우의 수를 테스트 하였습니다.

### 🔥 ApplePublicKeysTest 🔥
- `ApplePublicKeys` 엔티티 내장 메소드인 `getMatchesKey()` 에 대한 테스트 코드를 작성하였습니다.
- `List<ApplePublicKey>` 에서 `alg` 과 `kid` 가 일치하는 `ApplePublicKey` 가 정상적으로 추출되는지 검증합니다.
- 하나도 없을 시 예외가 잘 발생하는지 검증합니다.

### 🔥 ApplePublicKeyGeneratorTest 🔥
- `ApplePublicKeys` 에서 `haeder` 정보와 일치하는 `ApplePublicKey` 를 추출 하여 `RSA` 기반의 `PublicKey` 가 정상적으로 생성되는지 검증합니다.

### 🔥 AppleJwtProviderTest 🔥
- 주어진 정보로 `clientSecret` 토큰을 정상적으로 생성하는지 검증합니다.
- Apple 의 ClientSecret 토큰은 서명할 `PrivateKey` 로 `EC` 알고리즘의 `Base64`로 인코딩 된  문자열 `clientSecretKey` 을 필요로 합니다. 따라서, 이를 위한 테스트 클래스 내에 `createClientSecretKey()` 을 구현하였습니다.

<br/>

## :: 리팩토링 🚧
### 🔥 AppleClaimsValidator 🔥 
- 역할 분리와 테스트 코드 작성의 용이성을 위해, `Claims` 검증과 동시에 예외 처리까지 하던 `validation()` 메소드명을 `isValid()`로 수정하고 검증 결과를 `boolean`으로 반환하도록 수정하였습니다.
- 예외 처리는 서비스단(`AppleOAuthService`)에서 처리하도록 하였습니다.

<br/>

## :: 기능 추가 🔨
### 🔥 AppleAuthRequestDto & FullName 🔥 
- OAuthControllerTest 시 ObjectMapper 가 객체에 바인딩할 때 기본 생성자를 필요로 하여 `@NoArgsConstructor` 를 추가하였습니다.
- `@NoArgsConstructor`만 있을 떄 `@Builder` 를 사용하기 위해서 `@AllArgsConstructor` 를 필요로 하기때문에 추가하였습니다.

### 🔥 CustomExceptionStatus 🔥 
- 암호와 알고리즘에 대한 예외 `NO_SUCH_ALGORITHM` 를 추가하였습니다.

### 🔥 AppleOAuthUserProvider 🔥
- 기존에 `AppleOAuthService` 클래스에 있던, 토큰으로 부터 사용자 정보를 얻는 `getAppleEmail(String identityToken)` 메소드는, Apple OAuth 관련 처리를 하는 `AppleOAuthService`에게 과하게 주어진 책임이라고 판단하여, `AppleOAuthUserProvider` 클래스를 새로 생성하여 `getAppleEmail(String identityToken)` 에 대한 역할을 분리시켰습니다.
- 책임에 따라 역할을 적절하게 분리시킴으로써, 테스트 코드 구현의 편리함과, 코드의 가시성을 높혔습니다.