### PR TITLE
[Refactor] exception log 모듈 getParameter() 메소드 로직 변경

### DIFF
--- a/src/main/java/scs/planus/global/util/gson/EntityExclusionStrategy.java
+++ b/src/main/java/scs/planus/global/util/gson/EntityExclusionStrategy.java
@@ -1,0 +1,18 @@
+package scs.planus.global.util.gson;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+
+import javax.persistence.Entity;
+
+public class EntityExclusionStrategy implements ExclusionStrategy {
+    @Override
+    public boolean shouldSkipField(FieldAttributes field) {
+        return field.getDeclaredClass().isAnnotationPresent(Entity.class);
+    }
+
+    @Override
+    public boolean shouldSkipClass(Class<?> clazz) {
+        return clazz.isAnnotationPresent(Entity.class);
+    }
+}


### PR DESCRIPTION
### :: PR 타입
- [ ] 기능 추가 🔨
- [ ]  버그 수정 🐞
- [x]  리팩토링 🚧
- [ ]  문서 📄
- [ ]  코드 스타일 😎
- [ ]  의존성, 환경 변수, 빌드 관련 코드 업데이트 ⚙️
- [ ]  기타 사소한 수정 🎸
- [ ]  테스트 🔍

### :: 구현
* 엔티티 클래스: @Entity가 붙은 클래스
### 목적
- Gson.toJson() 이용해 파라미터 정보들을 모두 `JSON` 으로 직렬화 함.
- 파라미터 중에 엔티티 클래스가 있을 경우
  - 엔티티 클래스를 직렬화 할 때, 연관관계가 맺어져 있는 다른 엔티티 클래스를 참조하면서 무한 참조가 일어날 수 있음.
  - 연관관계가 맺어져있는 엔티티 클래스가 `fetch.LAZY`면 오류가 남.(오류 메시지에선 Eager 전략을 쓰라고 함.)
  - **_아하 그럼, `@Entity` 어노테이션이 붙은 클래스는 직렬화에서 제외시키면 되겠다!_**

### 문제 상황
[이전 코드]
![image](https://github.com/Planus-SCS/Planus-Backend/assets/54929830/6190b8f5-71d5-46be-9285-f8c3d5c1847e)

- 이렇게 하면 직렬화할 클래스가 엔티티 클래스일 경우엔 제외시키고, 엔티티 클래스가 아닌 경우엔 직렬화를 바로 진행함. 
- 문제는 엔티티가 아닌 클래스가 필드로 엔티티 클래스를 가지고 있을 때임. ex) PrincipalDetails
![image](https://github.com/Planus-SCS/Planus-Backend/assets/54929830/658000c5-3b2b-4f71-8354-f4bff8641062)
- 이때는 원래의 문제가 재발하게 됨 ㅠㅠ

### 해결 방법 - ExclusionStrategy!!!!
![image](https://github.com/Planus-SCS/Planus-Backend/assets/54929830/590f8358-e46e-4058-947b-b524a87bf29b)
- `ExclusionStrategy` 라는 Gson에 직렬화 제외 전략을 설정하는 인터페이스가 있었음!!!!

- 먼저 `ExclusionStrategy`의 구현체를 선언 해야함.
![image](https://github.com/Planus-SCS/Planus-Backend/assets/54929830/8ff2b6bb-a8a9-486a-ac41-e607e65970ad)
- 1. `shouldSkipField(FieldAttributes field)`: 필드 중에 엔티티 클래스가 있으면 제외 시킴.
- 2. `shouldSkipClass(Class<?> clazz)`: 해달 클래스가 엔티티일 경우도 물론 제외 시킴!

- 이렇게 구현체를 선언한 다음, 아래와 같이 Gson 객체 생성할 때 끼워주기만 하면 됨! ㅎ
![image](https://github.com/Planus-SCS/Planus-Backend/assets/54929830/71c00613-269f-49fb-ba17-691771a6bf5f)


### :: 특이사항
- 
